### PR TITLE
feat: retrieve expo extra params ow-expo-channel to allow channel overwrite

### DIFF
--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -14,7 +14,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"github.com/google/uuid"
 	"hash"
 	"strings"
 )
@@ -56,10 +55,6 @@ func ConvertSHA256HashToUUID(value string) string {
 		value[16:20],
 		value[20:32],
 	)
-}
-
-func GenerateUUID() string {
-	return uuid.New().String()
 }
 
 func GetBase64URLEncoding(encodedString string) string {

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -14,6 +14,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"github.com/google/uuid"
 	"hash"
 	"strings"
 )
@@ -55,6 +56,10 @@ func ConvertSHA256HashToUUID(value string) string {
 		value[16:20],
 		value[20:32],
 	)
+}
+
+func GenerateUUID() string {
+	return uuid.New().String()
 }
 
 func GetBase64URLEncoding(encodedString string) string {

--- a/internal/handlers/assets_handler.go
+++ b/internal/handlers/assets_handler.go
@@ -13,7 +13,11 @@ import (
 
 func AssetsHandler(w http.ResponseWriter, r *http.Request) {
 	requestID := uuid.New().String()
-	channelName := helpers.ResolveExpoChannel(r.Header, requestID)
+	channelName := helpers.ResolveExpoChannel(r.Header)
+	expoChannelOverride := r.URL.Query().Get("ow-expo-channel")
+	if expoChannelOverride != "" {
+		channelName = expoChannelOverride
+	}
 	preventCDNRedirection := r.Header.Get("prevent-cdn-redirection") == "true"
 	branchMap, err := services.FetchExpoChannelMapping(channelName)
 	if err != nil {

--- a/internal/handlers/manifest_handler.go
+++ b/internal/handlers/manifest_handler.go
@@ -108,6 +108,10 @@ func putUpdateInResponse(w http.ResponseWriter, r *http.Request, lastUpdate type
 		http.Error(w, "Error composing manifest", http.StatusInternalServerError)
 		return
 	}
+	channelOverride := helpers.GetChannelOverride(r.Header)
+	if channelOverride != "" {
+		update.AppendChannelOverrideToAsset(&manifest, channelOverride)
+	}
 	metrics.TrackUpdateDownload(platform, lastUpdate.RuntimeVersion, lastUpdate.Branch, metadata.ID, "update")
 	putResponse(w, r, manifest, "manifest", lastUpdate.RuntimeVersion, protocolVersion, requestID)
 }
@@ -149,7 +153,7 @@ func putNoUpdateAvailableInResponse(w http.ResponseWriter, r *http.Request, runt
 func ManifestHandler(w http.ResponseWriter, r *http.Request) {
 	requestID := uuid.New().String()
 
-	channelName := helpers.ResolveExpoChannel(r.Header, requestID)
+	channelName := helpers.ResolveExpoChannel(r.Header)
 	if channelName == "" {
 		log.Printf("[RequestID: %s] No channel name provided", requestID)
 		http.Error(w, "No channel name provided", http.StatusBadRequest)

--- a/internal/handlers/manifest_handler.go
+++ b/internal/handlers/manifest_handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"expo-open-ota/internal/crypto"
+	"expo-open-ota/internal/helpers"
 	"expo-open-ota/internal/keyStore"
 	"expo-open-ota/internal/metrics"
 	"expo-open-ota/internal/services"
@@ -148,7 +149,7 @@ func putNoUpdateAvailableInResponse(w http.ResponseWriter, r *http.Request, runt
 func ManifestHandler(w http.ResponseWriter, r *http.Request) {
 	requestID := uuid.New().String()
 
-	channelName := r.Header.Get("expo-channel-name")
+	channelName := helpers.ResolveExpoChannel(r.Header, requestID)
 	if channelName == "" {
 		log.Printf("[RequestID: %s] No channel name provided", requestID)
 		http.Error(w, "No channel name provided", http.StatusBadRequest)

--- a/internal/helpers/headers.go
+++ b/internal/helpers/headers.go
@@ -1,0 +1,39 @@
+package helpers
+
+import (
+	"net/http"
+	"strings"
+)
+
+func ParseExpoExtraParams(header string) map[string]string {
+	params := make(map[string]string)
+	pairs := strings.Split(header, ",")
+	for _, pair := range pairs {
+		pair = strings.TrimSpace(pair)
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.Trim(parts[1], `"`)
+		params[key] = value
+	}
+	return params
+}
+
+func ResolveExpoChannel(headers http.Header, requestID string) string {
+	channelName := headers.Get("expo-channel-name")
+	if channelName == "" {
+		return ""
+	}
+
+	extra := headers.Get("expo-extra-params")
+	if extra != "" {
+		params := ParseExpoExtraParams(extra)
+		if override, ok := params["ow-expo-channel"]; ok && override != "" {
+			channelName = override
+		}
+	}
+
+	return channelName
+}

--- a/internal/helpers/headers.go
+++ b/internal/helpers/headers.go
@@ -21,19 +21,28 @@ func ParseExpoExtraParams(header string) map[string]string {
 	return params
 }
 
-func ResolveExpoChannel(headers http.Header, requestID string) string {
-	channelName := headers.Get("expo-channel-name")
-	if channelName == "" {
-		return ""
-	}
-
+func GetChannelOverride(headers http.Header) string {
+	channelName := ""
 	extra := headers.Get("expo-extra-params")
 	if extra != "" {
 		params := ParseExpoExtraParams(extra)
 		if override, ok := params["ow-expo-channel"]; ok && override != "" {
-			channelName = override
+			if override != headers.Get("expo-channel-name") {
+				channelName = override
+			}
 		}
 	}
+	return channelName
+}
 
+func ResolveExpoChannel(headers http.Header) string {
+	channelName := headers.Get("expo-channel-name")
+	if channelName == "" {
+		return ""
+	}
+	channelOverride := GetChannelOverride(headers)
+	if channelOverride != "" {
+		channelName = channelOverride
+	}
 	return channelName
 }

--- a/internal/update/updates.go
+++ b/internal/update/updates.go
@@ -267,7 +267,6 @@ func BuildFinalManifestAssetUrlURL(baseURL, assetFilePath, runtimeVersion, platf
 	query.Set("runtimeVersion", runtimeVersion)
 	query.Set("platform", platform)
 	parsedURL.RawQuery = query.Encode()
-
 	return parsedURL.String(), nil
 }
 
@@ -334,6 +333,26 @@ func shapeManifestAsset(update types.Update, asset *types.Asset, isLaunchAsset b
 	}
 	_ = cache.Set(cacheKey, string(cacheValue), nil)
 	return manifestAsset, nil
+}
+
+func appendChannelOverrideToUrl(urlStr, channelOverride string) string {
+	parsedUrl, err := url.Parse(urlStr)
+	if err != nil {
+		return urlStr
+	}
+	query := parsedUrl.Query()
+	query.Set("ow-expo-channel", channelOverride)
+	parsedUrl.RawQuery = query.Encode()
+	return parsedUrl.String()
+}
+
+func AppendChannelOverrideToAsset(manifest *types.UpdateManifest, channelOverride string) {
+	// Generate UUID Randomly
+	manifest.Id = crypto.ConvertSHA256HashToUUID(crypto.GenerateUUID())
+	manifest.LaunchAsset.Url = appendChannelOverrideToUrl(manifest.LaunchAsset.Url, channelOverride)
+	for i := range manifest.Assets {
+		manifest.Assets[i].Url = appendChannelOverrideToUrl(manifest.Assets[i].Url, channelOverride)
+	}
 }
 
 func ComposeUpdateManifest(

--- a/internal/update/updates.go
+++ b/internal/update/updates.go
@@ -347,8 +347,6 @@ func appendChannelOverrideToUrl(urlStr, channelOverride string) string {
 }
 
 func AppendChannelOverrideToAsset(manifest *types.UpdateManifest, channelOverride string) {
-	// Generate UUID Randomly
-	manifest.Id = crypto.ConvertSHA256HashToUUID(crypto.GenerateUUID())
 	manifest.LaunchAsset.Url = appendChannelOverrideToUrl(manifest.LaunchAsset.Url, channelOverride)
 	for i := range manifest.Assets {
 		manifest.Assets[i].Url = appendChannelOverrideToUrl(manifest.Assets[i].Url, channelOverride)


### PR DESCRIPTION
This PR introduces support for overriding the update channel at runtime using the ow-expo-channel key inside the expo-extra-params header.

While Updates.setUpdateURLAndRequestHeadersOverride in expo-updates persists across sessions, it only takes effect after restarting the app.
On the other hand, Updates.setExtraParamAsync allows modifying headers for the current session.

By enabling support for ow-expo-channel, we allow clients to switch update channels dynamically during runtime, making it possible to fetch and apply updates without requiring a full reload.