### PR TITLE
fix(eoas-publish): make rm command OS-independent

### DIFF
--- a/apps/eoas/src/commands/publish.ts
+++ b/apps/eoas/src/commands/publish.ts
@@ -186,7 +186,7 @@ export default class Publish extends Command {
     runtimeSpinner.succeed('✅ Runtime versions resolved');
     const cleaningSpinner = ora(`🗑️ Cleaning up ${outputDir} directory...`).start();
     try {
-      await spawnAsync('rm', ['-rf', outputDir], { cwd: projectDir });
+      await fs.remove(path.join(projectDir, outputDir));
       cleaningSpinner.succeed('✅ Cleanup completed');
     } catch (e) {
       cleaningSpinner.fail('❌ Failed to clean up the output directory');
@@ -195,7 +195,6 @@ export default class Publish extends Command {
     }
     const exportSpinner = ora('📦 Exporting project files...').start();
     try {
-      await spawnAsync('rm', ['-rf', outputDir], { cwd: projectDir });
       const { stdout } = await spawnAsync('npx', ['expo', 'export', '--output-dir', outputDir], {
         cwd: projectDir,
         env: {


### PR DESCRIPTION
This PR fixes an issue on Windows where running the `rm` command in `commands/publish.ts` caused the error:

    Error: spawn rm ENOENT

The command is now OS-independent, ensuring proper file removal on both Unix-like systems and Windows.