### PR TITLE
fix(eoas): preserve Expo schemes in published manifests

### DIFF
--- a/apps/eoas/package.json
+++ b/apps/eoas/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc --project tsconfig.json",
+    "test": "node --require ts-node/register --test src/**/*.test.ts",
     "watch": "tsc --project tsconfig.json --watch",
     "lint": "eslint ."
   },

--- a/apps/eoas/src/commands/publish.ts
+++ b/apps/eoas/src/commands/publish.ts
@@ -12,6 +12,7 @@ import {
   RequestedPlatform,
   getPrivateExpoConfigAsync,
   getPublicExpoConfigAsync,
+  preserveSchemesInPublicExpoConfig,
   resolveServerUrl,
 } from '../lib/expoConfig';
 import { fetchWithRetries } from '../lib/fetch';
@@ -220,13 +221,17 @@ export default class Publish extends Command {
     const exportSpinner = ora('📦 Exporting project files...').start();
     try {
       const specifiedPlatform = platform === RequestedPlatform.All ? [] : ['--platform', platform];
-      const { stdout } = await spawnAsync(packageRunner, ['expo', 'export', '--output-dir', outputDir, ...specifiedPlatform], {
-        cwd: projectDir,
-        env: {
-          ...process.env,
-          EXPO_NO_DOTENV: '1',
-        },
-      });
+      const { stdout } = await spawnAsync(
+        packageRunner,
+        ['expo', 'export', '--output-dir', outputDir, ...specifiedPlatform],
+        {
+          cwd: projectDir,
+          env: {
+            ...process.env,
+            EXPO_NO_DOTENV: '1',
+          },
+        }
+      );
       exportSpinner.succeed('🚀 Project exported successfully');
       Log.withInfo(stdout);
     } catch (e) {
@@ -243,8 +248,9 @@ export default class Publish extends Command {
       );
       process.exit(1);
     }
+    const normalizedPublicConfig = preserveSchemesInPublicExpoConfig(publicConfig, config);
     // eslint-disable-next-line
-    fs.writeJsonSync(path.join(projectDir, outputDir, 'expoConfig.json'), publicConfig, {
+    fs.writeJsonSync(path.join(projectDir, outputDir, 'expoConfig.json'), normalizedPublicConfig, {
       spaces: 2,
     });
     Log.withInfo(`expoConfig.json file created in ${outputDir} directory`);

--- a/apps/eoas/src/lib/expoConfig.test.ts
+++ b/apps/eoas/src/lib/expoConfig.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { preserveSchemesInPublicExpoConfig } from './expoConfig';
+
+void test('preserves missing top-level and platform schemes from the private config', () => {
+  const normalized = preserveSchemesInPublicExpoConfig(
+    {
+      name: 'demo',
+      slug: 'demo',
+      version: '1.0.0',
+      ios: {
+        bundleIdentifier: 'com.example.demo',
+      },
+      android: {
+        package: 'com.example.demo',
+      },
+    },
+    {
+      name: 'demo',
+      slug: 'demo',
+      version: '1.0.0',
+      scheme: 'demo',
+      ios: {
+        bundleIdentifier: 'com.example.demo',
+        scheme: 'demo-ios',
+      },
+      android: {
+        package: 'com.example.demo',
+        scheme: 'demo-android',
+      },
+    } as any
+  );
+
+  assert.equal(normalized.scheme, 'demo');
+  assert.equal(normalized.ios?.scheme, 'demo-ios');
+  assert.equal(normalized.android?.scheme, 'demo-android');
+});
+
+void test('backfills platform schemes from the normalized top-level scheme when needed', () => {
+  const normalized = preserveSchemesInPublicExpoConfig(
+    {
+      name: 'demo',
+      slug: 'demo',
+      version: '1.0.0',
+      scheme: 'demo',
+    },
+    {
+      name: 'demo',
+      slug: 'demo',
+      version: '1.0.0',
+      scheme: 'demo',
+    } as any
+  );
+
+  assert.equal(normalized.scheme, 'demo');
+  assert.equal(normalized.ios?.scheme, 'demo');
+  assert.equal(normalized.android?.scheme, 'demo');
+});
+
+void test('keeps public scheme values when they are already present', () => {
+  const normalized = preserveSchemesInPublicExpoConfig(
+    {
+      name: 'demo',
+      slug: 'demo',
+      version: '1.0.0',
+      scheme: 'public-scheme',
+      ios: {
+        bundleIdentifier: 'com.example.demo',
+        scheme: 'public-ios',
+      },
+      android: {
+        package: 'com.example.demo',
+        scheme: 'public-android',
+      },
+    },
+    {
+      name: 'demo',
+      slug: 'demo',
+      version: '1.0.0',
+      scheme: 'private-scheme',
+      ios: {
+        bundleIdentifier: 'com.example.demo',
+        scheme: 'private-ios',
+      },
+      android: {
+        package: 'com.example.demo',
+        scheme: 'private-android',
+      },
+    } as any
+  );
+
+  assert.equal(normalized.scheme, 'public-scheme');
+  assert.equal(normalized.ios?.scheme, 'public-ios');
+  assert.equal(normalized.android?.scheme, 'public-android');
+});

--- a/apps/eoas/src/lib/expoConfig.ts
+++ b/apps/eoas/src/lib/expoConfig.ts
@@ -17,12 +17,16 @@ export enum RequestedPlatform {
   All = 'all',
 }
 
+type SchemeValue = string | string[] | null | undefined;
+type IOSConfigWithScheme = NonNullable<ExpoConfig['ios']> & { scheme?: SchemeValue };
+type AndroidConfigWithScheme = NonNullable<ExpoConfig['android']> & { scheme?: SchemeValue };
+
 export type PublicExpoConfig = Omit<
   ExpoConfig,
   '_internal' | 'hooks' | 'ios' | 'android' | 'updates'
 > & {
-  ios?: Omit<ExpoConfig['ios'], 'config'>;
-  android?: Omit<ExpoConfig['android'], 'config'>;
+  ios?: Omit<IOSConfigWithScheme, 'config'>;
+  android?: Omit<AndroidConfigWithScheme, 'config'>;
   updates?: Omit<ExpoConfig['updates'], 'codeSigningCertificate' | 'codeSigningMetadata'>;
 };
 
@@ -143,6 +147,60 @@ export async function getPublicExpoConfigAsync(
   ensureExpoConfigExists(projectDir);
 
   return await getExpoConfigInternalAsync(projectDir, { ...opts, isPublicConfig: true });
+}
+
+function hasScheme(value: SchemeValue): value is string | string[] {
+  if (typeof value === 'string') {
+    return value.length > 0;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some(item => typeof item === 'string' && item.length > 0);
+  }
+
+  return false;
+}
+
+export function preserveSchemesInPublicExpoConfig(
+  publicConfig: PublicExpoConfig,
+  privateConfig: ExpoConfig
+): PublicExpoConfig {
+  const privateIosConfig = privateConfig.ios as IOSConfigWithScheme | undefined;
+  const privateAndroidConfig = privateConfig.android as AndroidConfigWithScheme | undefined;
+  const normalizedConfig: PublicExpoConfig = {
+    ...publicConfig,
+    ...(publicConfig.ios ? { ios: { ...publicConfig.ios } } : {}),
+    ...(publicConfig.android ? { android: { ...publicConfig.android } } : {}),
+  };
+
+  const topLevelScheme =
+    publicConfig.scheme ??
+    privateConfig.scheme ??
+    privateIosConfig?.scheme ??
+    privateAndroidConfig?.scheme;
+
+  if (!hasScheme(normalizedConfig.scheme) && hasScheme(topLevelScheme)) {
+    normalizedConfig.scheme = topLevelScheme;
+  }
+
+  const iosScheme = publicConfig.ios?.scheme ?? privateIosConfig?.scheme ?? normalizedConfig.scheme;
+  if (!hasScheme(normalizedConfig.ios?.scheme) && hasScheme(iosScheme)) {
+    normalizedConfig.ios = {
+      ...(normalizedConfig.ios ?? {}),
+      scheme: iosScheme,
+    };
+  }
+
+  const androidScheme =
+    publicConfig.android?.scheme ?? privateAndroidConfig?.scheme ?? normalizedConfig.scheme;
+  if (!hasScheme(normalizedConfig.android?.scheme) && hasScheme(androidScheme)) {
+    normalizedConfig.android = {
+      ...(normalizedConfig.android ?? {}),
+      scheme: androidScheme,
+    };
+  }
+
+  return normalizedConfig;
 }
 
 export function getExpoConfigUpdateUrl(config: ExpoConfig): string | undefined {
@@ -276,7 +334,7 @@ export async function resolveServerUrl(config: ExpoConfig): Promise<string> {
   try {
     const parsedUrl = new URL(updateUrl);
     baseUrl = parsedUrl.origin;
-  } catch (e) {
+  } catch {
     throw new Error('Invalid update URL.');
   }
   return baseUrl;


### PR DESCRIPTION
## Summary
- preserve missing `scheme`, `ios.scheme`, and `android.scheme` when `eoas publish` writes `expoConfig.json`
- normalize the public Expo config with scheme values from the private config before uploading the manifest payload
- add a focused unit test covering missing-scheme and already-present-scheme cases

## Why
`expo-open-ota` serves `expoConfig.json` verbatim inside `extra.expoClient`. On some projects/SDK combinations, the public config written during publish can omit scheme fields even though the private Expo config contains them. That leads to standalone apps crashing during Expo Router bootstrap when `expo-linking` calls `Linking.createURL('/')` and finds no custom scheme in the runtime manifest.

## Verification
- `npm test`
- `npm run build`
- `npx eslint src/commands/publish.ts src/lib/expoConfig.ts src/lib/expoConfig.test.ts`
