### PR TITLE
fix(assets): fallback to branch query when channel header is missing

### DIFF
--- a/internal/handlers/assets_handler.go
+++ b/internal/handlers/assets_handler.go
@@ -13,21 +13,32 @@ import (
 func AssetsHandler(w http.ResponseWriter, r *http.Request) {
 	requestID := uuid.New().String()
 	channelName := r.Header.Get("expo-channel-name")
+	branchName := ""
 	preventCDNRedirection := r.Header.Get("prevent-cdn-redirection") == "true"
-	branchMap, err := services.FetchExpoChannelMapping(channelName)
-	if err != nil {
-		log.Printf("[RequestID: %s] Error fetching channel mapping: %v", requestID, err)
-		http.Error(w, "Error fetching channel mapping", http.StatusInternalServerError)
-		return
-	}
-	if branchMap == nil {
-		log.Printf("[RequestID: %s] No branch mapping found for channel: %s", requestID, channelName)
-		http.Error(w, "No branch mapping found", http.StatusNotFound)
-		return
+	if channelName != "" {
+		branchMap, err := services.FetchExpoChannelMapping(channelName)
+		if err != nil {
+			log.Printf("[RequestID: %s] Error fetching channel mapping: %v", requestID, err)
+			http.Error(w, "Error fetching channel mapping", http.StatusInternalServerError)
+			return
+		}
+		if branchMap == nil {
+			log.Printf("[RequestID: %s] No branch mapping found for channel: %s", requestID, channelName)
+			http.Error(w, "No branch mapping found", http.StatusNotFound)
+			return
+		}
+		branchName = branchMap.BranchName
+	} else {
+		branchName = r.URL.Query().Get("branch")
+		if branchName == "" {
+			log.Printf("[RequestID: %s] Missing both expo-channel-name header and branch query parameter", requestID)
+			http.Error(w, "No channel or branch provided", http.StatusBadRequest)
+			return
+		}
 	}
 
 	req := assets.AssetsRequest{
-		Branch:         branchMap.BranchName,
+		Branch:         branchName,
 		AssetName:      r.URL.Query().Get("asset"),
 		RuntimeVersion: r.URL.Query().Get("runtimeVersion"),
 		Platform:       r.URL.Query().Get("platform"),

--- a/test/assets_test.go
+++ b/test/assets_test.go
@@ -365,3 +365,30 @@ func TestPreventCDNRedirectionHeader(t *testing.T) {
 
 	assert.Equal(t, 200, w.Code, "Expected status code 200")
 }
+
+func TestAssetsHandlerUsesBranchQueryWhenChannelHeaderMissing(t *testing.T) {
+	teardown := setup(t)
+	defer teardown()
+
+	url, _ := update.BuildFinalManifestAssetUrlURL("http://localhost:3000", "bundles/android-82adadb1fb6e489d04ad95fd79670deb.js", "1", "android", "branch-1")
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", url, nil)
+
+	handlers.AssetsHandler(w, r)
+
+	assert.Equal(t, 200, w.Code, "Expected status code 200 when branch query parameter is provided")
+	assert.Equal(t, "application/javascript", w.Header().Get("Content-Type"), "Expected 'application/javascript' content type")
+}
+
+func TestAssetsHandlerMissingChannelAndBranch(t *testing.T) {
+	teardown := setup(t)
+	defer teardown()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/assets?asset=bundles/android-82adadb1fb6e489d04ad95fd79670deb.js&runtimeVersion=1&platform=android", nil)
+
+	handlers.AssetsHandler(w, r)
+
+	assert.Equal(t, 400, w.Code, "Expected status code 400 when both channel header and branch query are missing")
+	assert.Equal(t, "No channel or branch provided\n", w.Body.String())
+}


### PR DESCRIPTION
## Summary
This PR fixes asset serving when `expo-channel-name` is missing on `/assets` requests but `branch` is present in query parameters.

Previously, `AssetsHandler` always attempted channel mapping lookup from the header and could return a server error if the header was absent, even when the request already contained branch information.

Fix implemented:
- Keep existing behavior when `expo-channel-name` is present.
- Fallback to `branch` query parameter when `expo-channel-name` is missing.
- Return `400` with a clear error when both channel and branch are missing.

Closes #43.

## Root Cause
`internal/handlers/assets_handler.go` required `expo-channel-name` for branch resolution in all cases.

In production, some `/assets` requests arrived without `expo-channel-name` while still containing `branch=...` in the URL. The server ignored `branch` and attempted to parse channel mapping for an empty channel, causing failures.

## Changes
### Handler
- Updated `AssetsHandler` in `internal/handlers/assets_handler.go`:
  - Introduced branch resolution fallback from query string.
  - Added explicit `400` response when both identifiers are missing.

### Tests
Added regression tests in `test/assets_test.go`:
- `TestAssetsHandlerUsesBranchQueryWhenChannelHeaderMissing`
- `TestAssetsHandlerMissingChannelAndBranch`

## Validation
Executed focused tests locally:
```bash
go test ./test -run 'TestAssetsHandlerUsesBranchQueryWhenChannelHeaderMissing|TestAssetsHandlerMissingChannelAndBranch|TestAutomaticUrlRedirectionIfCDNIsSet|TestPreventCDNRedirectionHeader|TestToRetrieveBundleAssetWithGzipCompression' -v
```
All passed.

## Backward Compatibility
- No behavior change for clients that already send `expo-channel-name`.
- Improves compatibility for clients/proxies that only provide branch on asset URLs.
- Error semantics are improved for malformed requests.
