### PR TITLE
feat: multi-app support — single instance serving multiple Expo apps

### DIFF
--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -11,7 +11,7 @@ const queryClient = new QueryClient();
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter basename="/dashboard">
+      <BrowserRouter basename={(window as any).env?.VITE_DASHBOARD_BASENAME || "/dashboard"}>
         <App />
       </BrowserRouter>
     </QueryClientProvider>

--- a/config/apps.go
+++ b/config/apps.go
@@ -1,0 +1,94 @@
+package config
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"sync"
+)
+
+type AppConfig struct {
+	Slug            string `json:"slug"`
+	ExpoAppId       string `json:"expoAppId"`
+	ExpoAccessToken string `json:"expoAccessToken"`
+	S3KeyPrefix     string `json:"s3KeyPrefix,omitempty"`
+}
+
+func (a *AppConfig) GetEffectiveS3KeyPrefix() string {
+	if a.S3KeyPrefix != "" {
+		prefix := a.S3KeyPrefix
+		if prefix[len(prefix)-1] != '/' {
+			prefix += "/"
+		}
+		return prefix
+	}
+	return a.Slug + "/"
+}
+
+var (
+	appsConfig    []AppConfig
+	multiAppMode  bool
+	appsOnce      sync.Once
+)
+
+func LoadAppsConfig() {
+	appsOnce.Do(func() {
+		raw := os.Getenv("APPS_CONFIG")
+		if raw == "" {
+			multiAppMode = false
+			return
+		}
+		if err := json.Unmarshal([]byte(raw), &appsConfig); err != nil {
+			log.Fatalf("Invalid APPS_CONFIG JSON: %v", err)
+		}
+		if len(appsConfig) == 0 {
+			log.Fatalf("APPS_CONFIG is empty")
+		}
+		slugs := make(map[string]bool)
+		for _, app := range appsConfig {
+			if app.Slug == "" || app.ExpoAppId == "" || app.ExpoAccessToken == "" {
+				log.Fatalf("APPS_CONFIG: slug, expoAppId, and expoAccessToken are required for each app")
+			}
+			if slugs[app.Slug] {
+				log.Fatalf("APPS_CONFIG: duplicate slug: %s", app.Slug)
+			}
+			slugs[app.Slug] = true
+		}
+		multiAppMode = true
+	})
+}
+
+func IsMultiAppMode() bool {
+	return multiAppMode
+}
+
+func GetAppConfig(slug string) *AppConfig {
+	for i := range appsConfig {
+		if appsConfig[i].Slug == slug {
+			return &appsConfig[i]
+		}
+	}
+	return nil
+}
+
+func GetAllApps() []AppConfig {
+	return appsConfig
+}
+
+func GetDefaultAppConfig() *AppConfig {
+	if multiAppMode {
+		return nil
+	}
+	return &AppConfig{
+		Slug:            "",
+		ExpoAppId:       GetEnv("EXPO_APP_ID"),
+		ExpoAccessToken: GetEnv("EXPO_ACCESS_TOKEN"),
+		S3KeyPrefix:     GetEnv("S3_KEY_PREFIX"),
+	}
+}
+
+func ResetAppsConfig() {
+	appsConfig = nil
+	multiAppMode = false
+	appsOnce = sync.Once{}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -71,6 +71,9 @@ func LoadConfig() {
 	if err != nil {
 		log.Printf("No .env file found, continuing with runtime environment variables.")
 	}
+
+	LoadAppsConfig()
+
 	storageMode := GetEnv("STORAGE_MODE")
 	if !validateStorageMode(storageMode) {
 		log.Fatalf("Invalid STORAGE_MODE: %s", storageMode)
@@ -83,14 +86,20 @@ func LoadConfig() {
 	if !validateBaseUrl(baseUrl) {
 		log.Fatalf("Invalid BASE_URL: %s", baseUrl)
 	}
-	expoToken := GetEnv("EXPO_ACCESS_TOKEN")
-	if expoToken == "" {
-		log.Fatalf("EXPO_ACCESS_TOKEN not set")
+
+	if IsMultiAppMode() {
+		log.Printf("Multi-app mode enabled with %d apps", len(GetAllApps()))
+	} else {
+		expoToken := GetEnv("EXPO_ACCESS_TOKEN")
+		if expoToken == "" {
+			log.Fatalf("EXPO_ACCESS_TOKEN not set")
+		}
+		expoAppId := GetEnv("EXPO_APP_ID")
+		if expoAppId == "" {
+			log.Fatalf("EXPO_APP_ID not set")
+		}
 	}
-	expoAppId := GetEnv("EXPO_APP_ID")
-	if expoAppId == "" {
-		log.Fatalf("EXPO_APP_ID not set")
-	}
+
 	jwtSecret := GetEnv("JWT_SECRET")
 	if jwtSecret == "" {
 		log.Fatalf("JWT_SECRET not set")

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -187,10 +187,13 @@ environment:
     required: true
   - name: "EXPO_ACCESS_TOKEN"
     value: ""
-    required: true
+    required: false  # Not required when APPS_CONFIG is set (multi-app mode)
   - name: "EXPO_APP_ID"
     value: ""
-    required: true
+    required: false  # Not required when APPS_CONFIG is set (multi-app mode)
+  - name: "APPS_CONFIG"
+    value: ""
+    required: false  # JSON array of app configs for multi-app mode. Example: [{"slug":"my-app","expoAppId":"...","expoAccessToken":"...","s3KeyPrefix":"my-app"}]
   - name: "JWT_SECRET"
     value: ""
     required: true

--- a/internal/appcontext/appcontext.go
+++ b/internal/appcontext/appcontext.go
@@ -1,0 +1,19 @@
+package appcontext
+
+import (
+	"context"
+	"expo-open-ota/config"
+)
+
+type contextKey string
+
+const appConfigKey contextKey = "appConfig"
+
+func WithAppConfig(ctx context.Context, cfg *config.AppConfig) context.Context {
+	return context.WithValue(ctx, appConfigKey, cfg)
+}
+
+func GetAppConfig(ctx context.Context) *config.AppConfig {
+	cfg, _ := ctx.Value(appConfigKey).(*config.AppConfig)
+	return cfg
+}

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -1,6 +1,7 @@
 package assets
 
 import (
+	"expo-open-ota/config"
 	"expo-open-ota/internal/bucket"
 	"expo-open-ota/internal/cdn"
 	"expo-open-ota/internal/types"
@@ -26,7 +27,7 @@ type AssetsResponse struct {
 	URL         string
 }
 
-func getAssetMetadata(req AssetsRequest, returnAsset bool) (AssetsResponse, *types.BucketFile, string, error) {
+func getAssetMetadata(app *config.AppConfig, req AssetsRequest, returnAsset bool) (AssetsResponse, *types.BucketFile, string, error) {
 	requestID := req.RequestID
 
 	if req.AssetName == "" {
@@ -44,7 +45,7 @@ func getAssetMetadata(req AssetsRequest, returnAsset bool) (AssetsResponse, *typ
 		return AssetsResponse{StatusCode: http.StatusBadRequest, Body: []byte("No runtime version provided")}, nil, "", nil
 	}
 
-	lastUpdate, err := update.GetLatestUpdateBundlePathForRuntimeVersion(req.Branch, req.RuntimeVersion, req.Platform)
+	lastUpdate, err := update.GetLatestUpdateBundlePathForRuntimeVersion(app, req.Branch, req.RuntimeVersion, req.Platform)
 	if err != nil || lastUpdate == nil {
 		log.Printf("[RequestID: %s] No update found for runtimeVersion: %s", requestID, req.RuntimeVersion)
 		return AssetsResponse{StatusCode: http.StatusNotFound, Body: []byte("No update found")}, nil, "", nil
@@ -62,7 +63,7 @@ func getAssetMetadata(req AssetsRequest, returnAsset bool) (AssetsResponse, *typ
 		}, nil, lastUpdate.UpdateId, nil
 	}
 
-	metadata, err := update.GetMetadata(*lastUpdate)
+	metadata, err := update.GetMetadata(app, *lastUpdate)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error getting metadata: %v", requestID, err)
 		return AssetsResponse{StatusCode: http.StatusInternalServerError, Body: []byte("Error getting metadata")}, nil, "", nil
@@ -88,7 +89,7 @@ func getAssetMetadata(req AssetsRequest, returnAsset bool) (AssetsResponse, *typ
 		}
 	}
 
-	resolvedBucket := bucket.GetBucket()
+	resolvedBucket := bucket.GetBucketForApp(app)
 	asset, err := resolvedBucket.GetFile(*lastUpdate, req.AssetName)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error getting asset: %v", requestID, err)
@@ -116,8 +117,8 @@ func getAssetMetadata(req AssetsRequest, returnAsset bool) (AssetsResponse, *typ
 	}, asset, lastUpdate.UpdateId, nil
 }
 
-func HandleAssetsWithFile(req AssetsRequest) (AssetsResponse, error) {
-	resp, asset, _, err := getAssetMetadata(req, true)
+func HandleAssetsWithFile(app *config.AppConfig, req AssetsRequest) (AssetsResponse, error) {
+	resp, asset, _, err := getAssetMetadata(app, req, true)
 	if err != nil {
 		return resp, err
 	}
@@ -150,8 +151,8 @@ func HandleAssetsWithFile(req AssetsRequest) (AssetsResponse, error) {
 	return resp, nil
 }
 
-func HandleAssetsWithURL(req AssetsRequest, resolvedCDN cdn.CDN) (AssetsResponse, error) {
-	resp, _, updateId, err := getAssetMetadata(req, false)
+func HandleAssetsWithURL(app *config.AppConfig, req AssetsRequest, resolvedCDN cdn.CDN) (AssetsResponse, error) {
+	resp, _, updateId, err := getAssetMetadata(app, req, false)
 	if err != nil {
 		return resp, err
 	}

--- a/internal/branch/branch.go
+++ b/internal/branch/branch.go
@@ -1,17 +1,18 @@
 package branch
 
 import (
+	"expo-open-ota/config"
 	"expo-open-ota/internal/helpers"
 	"expo-open-ota/internal/services"
 )
 
-func UpsertBranch(branch string) error {
-	branches, err := services.FetchExpoBranches()
+func UpsertBranch(app *config.AppConfig, branch string) error {
+	branches, err := services.FetchExpoBranches(app)
 	if err != nil {
 		return err
 	}
 	if !helpers.StringInSlice(branch, branches) {
-		return services.CreateBranch(branch)
+		return services.CreateBranch(app, branch)
 	}
 	return nil
 }

--- a/internal/bucket/bucket.go
+++ b/internal/bucket/bucket.go
@@ -56,6 +56,8 @@ func ResolveBucketType() BucketType {
 var (
 	bucketInstance Bucket
 	once           sync.Once
+	bucketRegistry = make(map[string]Bucket)
+	registryMu     sync.RWMutex
 )
 
 func GetBucket() Bucket {
@@ -91,6 +93,51 @@ func GetBucket() Bucket {
 	return bucketInstance
 }
 
+func GetBucketForApp(app *config.AppConfig) Bucket {
+	if app == nil || app.Slug == "" {
+		return GetBucket()
+	}
+	prefix := app.GetEffectiveS3KeyPrefix()
+	return getBucketForPrefix(prefix)
+}
+
+func getBucketForPrefix(prefix string) Bucket {
+	registryMu.RLock()
+	if b, ok := bucketRegistry[prefix]; ok {
+		registryMu.RUnlock()
+		return b
+	}
+	registryMu.RUnlock()
+
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if b, ok := bucketRegistry[prefix]; ok {
+		return b
+	}
+
+	bucketType := ResolveBucketType()
+	var b Bucket
+	switch bucketType {
+	case S3BucketType:
+		b = &S3Bucket{
+			BucketName: config.GetEnv("S3_BUCKET_NAME"),
+			KeyPrefix:  prefix,
+		}
+	case GCSBucketType:
+		b = &GCSBucket{
+			BucketName: config.GetEnv("GCS_BUCKET_NAME"),
+		}
+	case LocalBucketType:
+		b = &LocalBucket{
+			BasePath: config.GetEnv("LOCAL_BUCKET_BASE_PATH"),
+		}
+	default:
+		panic(fmt.Sprintf("Unknown bucket type: %s", bucketType))
+	}
+	bucketRegistry[prefix] = b
+	return b
+}
+
 func ConvertReadCloserToBytes(rc io.ReadCloser) ([]byte, error) {
 	defer rc.Close()
 	var buf bytes.Buffer
@@ -111,13 +158,13 @@ type FileUploadRequest struct {
 	FilePath         string `json:"filePath"`
 }
 
-func RequestUploadUrlsForFileUpdates(branch string, runtimeVersion string, updateId string, fileNames []string) ([]FileUploadRequest, error) {
+func RequestUploadUrlsForFileUpdates(app *config.AppConfig, branch string, runtimeVersion string, updateId string, fileNames []string) ([]FileUploadRequest, error) {
 	uniqueFileNames := make(map[string]struct{})
 	for _, fileName := range fileNames {
 		uniqueFileNames[fileName] = struct{}{}
 	}
 
-	bucket := GetBucket()
+	bucket := GetBucketForApp(app)
 
 	var requests []FileUploadRequest
 	var mu sync.Mutex

--- a/internal/bucket/localBucket.go
+++ b/internal/bucket/localBucket.go
@@ -44,7 +44,7 @@ func (b *LocalBucket) RequestUploadUrlForFileUpdate(branch string, runtimeVersio
 		return "", err
 	}
 	token, err := services.GenerateJWTToken(config.GetEnv("JWT_SECRET"), jwt.MapClaims{
-		"sub":      services.FetchSelfExpoUsername(),
+		"sub":      services.FetchSelfExpoUsername(nil),
 		"exp":      time.Now().Add(time.Minute * 10).Unix(),
 		"filePath": filepath.Join(dirPath, fileName),
 		"action":   "uploadLocalFile",
@@ -217,7 +217,7 @@ func ValidateUploadTokenAndResolveFilePath(token string) (string, error) {
 	action := claims["action"].(string)
 	filePath := claims["filePath"].(string)
 	sub := claims["sub"].(string)
-	if sub != services.FetchSelfExpoUsername() {
+	if sub != services.FetchSelfExpoUsername(nil) {
 		return "", errors.New("invalid token sub")
 	}
 	if action != "uploadLocalFile" {

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -10,22 +10,22 @@ func IsDashboardEnabled() bool {
 	return config.GetEnv("USE_DASHBOARD") == "true"
 }
 
-func ComputeGetRuntimeVersionsCacheKey(branch string) string {
-	return fmt.Sprintf("dashboard:%s:request:getRuntimeVersions:%s", version.Version, branch)
+func ComputeGetRuntimeVersionsCacheKey(slug string, branch string) string {
+	return fmt.Sprintf("dashboard:%s:%s:request:getRuntimeVersions:%s", version.Version, slug, branch)
 }
 
-func ComputeGetBranchesCacheKey() string {
-	return fmt.Sprintf("dashboard:%s:request:getBranches", version.Version)
+func ComputeGetBranchesCacheKey(slug string) string {
+	return fmt.Sprintf("dashboard:%s:%s:request:getBranches", version.Version, slug)
 }
 
-func ComputeGetChannelsCacheKey() string {
-	return fmt.Sprintf("dashboard:%s:request:getChannels", version.Version)
+func ComputeGetChannelsCacheKey(slug string) string {
+	return fmt.Sprintf("dashboard:%s:%s:request:getChannels", version.Version, slug)
 }
 
-func ComputeGetUpdatesCacheKey(branch string, runtimeVersion string) string {
-	return fmt.Sprintf("dashboard:%s:request:getUpdates:%s:%s", version.Version, branch, runtimeVersion)
+func ComputeGetUpdatesCacheKey(slug string, branch string, runtimeVersion string) string {
+	return fmt.Sprintf("dashboard:%s:%s:request:getUpdates:%s:%s", version.Version, slug, branch, runtimeVersion)
 }
 
-func ComputeGetUpdateDetailsCacheKey(branch string, runtimeVersion string, updateID string) string {
-	return fmt.Sprintf("dashboard:%s:request:getUpdateDetails:%s:%s:%s", version.Version, branch, runtimeVersion, updateID)
+func ComputeGetUpdateDetailsCacheKey(slug string, branch string, runtimeVersion string, updateID string) string {
+	return fmt.Sprintf("dashboard:%s:%s:request:getUpdateDetails:%s:%s:%s", version.Version, slug, branch, runtimeVersion, updateID)
 }

--- a/internal/handlers/assets_handler.go
+++ b/internal/handlers/assets_handler.go
@@ -12,9 +12,11 @@ import (
 
 func AssetsHandler(w http.ResponseWriter, r *http.Request) {
 	requestID := uuid.New().String()
+	app := resolveApp(r)
+
 	channelName := r.Header.Get("expo-channel-name")
 	preventCDNRedirection := r.Header.Get("prevent-cdn-redirection") == "true"
-	branchMap, err := services.FetchExpoChannelMapping(channelName)
+	branchMap, err := services.FetchExpoChannelMapping(app, channelName)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error fetching channel mapping: %v", requestID, err)
 		http.Error(w, "Error fetching channel mapping", http.StatusInternalServerError)
@@ -36,7 +38,7 @@ func AssetsHandler(w http.ResponseWriter, r *http.Request) {
 
 	cdn := cdn2.GetCDN()
 	if cdn == nil || preventCDNRedirection {
-		resp, err := assets.HandleAssetsWithFile(req)
+		resp, err := assets.HandleAssetsWithFile(app, req)
 		if err != nil {
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
@@ -52,7 +54,7 @@ func AssetsHandler(w http.ResponseWriter, r *http.Request) {
 		compression.ServeCompressedAsset(w, r, resp.Body, resp.ContentType, req.RequestID)
 		return
 	}
-	resp, err := assets.HandleAssetsWithURL(req, cdn)
+	resp, err := assets.HandleAssetsWithURL(app, req, cdn)
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/internal/handlers/dashboard_handler.go
+++ b/internal/handlers/dashboard_handler.go
@@ -76,6 +76,8 @@ type SettingsEnv struct {
 	AWSSM_CLOUDFRONT_PRIVATE_KEY_SECRET_ID string `json:"AWSSM_CLOUDFRONT_PRIVATE_KEY_SECRET_ID"`
 	PRIVATE_LOCAL_CLOUDFRONT_KEY_PATH      string `json:"PRIVATE_LOCAL_CLOUDFRONT_KEY_PATH"`
 	PROMETHEUS_ENABLED                     string `json:"PROMETHEUS_ENABLED"`
+	MULTI_APP_MODE                         bool   `json:"MULTI_APP_MODE"`
+	APP_SLUG                               string `json:"APP_SLUG,omitempty"`
 }
 
 func maskSecret(value string) string {
@@ -85,15 +87,28 @@ func maskSecret(value string) string {
 	return "***" + value[:5]
 }
 
-func GetSettingsHandler(w http.ResponseWriter, r *http.Request) {
+func getAppSlug(app *config.AppConfig) string {
+	if app != nil {
+		return app.Slug
+	}
+	return ""
+}
 
-	// Retrieve all in config.GetEnv & return as JSON
+func GetSettingsHandler(w http.ResponseWriter, r *http.Request) {
+	app := resolveApp(r)
+	expoAppId := config.GetEnv("EXPO_APP_ID")
+	expoAccessToken := config.GetEnv("EXPO_ACCESS_TOKEN")
+	if app != nil && app.ExpoAppId != "" {
+		expoAppId = app.ExpoAppId
+		expoAccessToken = app.ExpoAccessToken
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(SettingsEnv{
 		BASE_URL:                               config.GetEnv("BASE_URL"),
-		EXPO_APP_ID:                            config.GetEnv("EXPO_APP_ID"),
-		EXPO_ACCESS_TOKEN:                      maskSecret(config.GetEnv("EXPO_ACCESS_TOKEN")),
+		EXPO_APP_ID:                            expoAppId,
+		EXPO_ACCESS_TOKEN:                      maskSecret(expoAccessToken),
 		CACHE_MODE:                             config.GetEnv("CACHE_MODE"),
 		REDIS_HOST:                             config.GetEnv("REDIS_HOST"),
 		REDIS_PORT:                             config.GetEnv("REDIS_PORT"),
@@ -115,11 +130,16 @@ func GetSettingsHandler(w http.ResponseWriter, r *http.Request) {
 		AWSSM_CLOUDFRONT_PRIVATE_KEY_SECRET_ID: config.GetEnv("AWSSM_CLOUDFRONT_PRIVATE_KEY_SECRET_ID"),
 		PRIVATE_LOCAL_CLOUDFRONT_KEY_PATH:      config.GetEnv("PRIVATE_LOCAL_CLOUDFRONT_KEY_PATH"),
 		PROMETHEUS_ENABLED:                     config.GetEnv("PROMETHEUS_ENABLED"),
+		MULTI_APP_MODE:                         config.IsMultiAppMode(),
+		APP_SLUG:                               getAppSlug(app),
 	})
 }
 
 func GetChannelsHandler(w http.ResponseWriter, r *http.Request) {
-	cacheKey := dashboard.ComputeGetChannelsCacheKey()
+	app := resolveApp(r)
+	slug := getAppSlug(app)
+
+	cacheKey := dashboard.ComputeGetChannelsCacheKey(slug)
 	cache := cache2.GetCache()
 	if cacheValue := cache.Get(cacheKey); cacheValue != "" {
 		w.Header().Set("Content-Type", "application/json")
@@ -129,12 +149,12 @@ func GetChannelsHandler(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(channels)
 		return
 	}
-	allChannels, err := services.FetchExpoChannels()
+	allChannels, err := services.FetchExpoChannels(app)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	branchesMapping, err := services.FetchExpoBranchesMapping()
+	branchesMapping, err := services.FetchExpoBranchesMapping(app)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
@@ -168,13 +188,15 @@ func GetChannelsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetBranchesHandler(w http.ResponseWriter, r *http.Request) {
-	resolvedBucket := bucket.GetBucket()
+	app := resolveApp(r)
+
+	resolvedBucket := bucket.GetBucketForApp(app)
 	branches, err := resolvedBucket.GetBranches()
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	branchesMapping, err := services.FetchExpoBranchesMapping()
+	branchesMapping, err := services.FetchExpoBranchesMapping(app)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
@@ -202,9 +224,12 @@ func GetBranchesHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetRuntimeVersionsHandler(w http.ResponseWriter, r *http.Request) {
+	app := resolveApp(r)
+	slug := getAppSlug(app)
+
 	vars := mux.Vars(r)
 	branchName := vars["BRANCH"]
-	cacheKey := dashboard.ComputeGetRuntimeVersionsCacheKey(branchName)
+	cacheKey := dashboard.ComputeGetRuntimeVersionsCacheKey(slug, branchName)
 	cache := cache2.GetCache()
 	if cacheValue := cache.Get(cacheKey); cacheValue != "" {
 		w.Header().Set("Content-Type", "application/json")
@@ -214,7 +239,7 @@ func GetRuntimeVersionsHandler(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(runtimeVersions)
 		return
 	}
-	resolvedBucket := bucket.GetBucket()
+	resolvedBucket := bucket.GetBucketForApp(app)
 	runtimeVersions, err := resolvedBucket.GetRuntimeVersions(branchName)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
@@ -237,11 +262,14 @@ func GetRuntimeVersionsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetUpdateDetails(w http.ResponseWriter, r *http.Request) {
+	app := resolveApp(r)
+	slug := getAppSlug(app)
+
 	vars := mux.Vars(r)
 	branchName := vars["BRANCH"]
 	runtimeVersion := vars["RUNTIME_VERSION"]
 	updateId := vars["UPDATE_ID"]
-	cacheKey := dashboard.ComputeGetUpdateDetailsCacheKey(branchName, runtimeVersion, updateId)
+	cacheKey := dashboard.ComputeGetUpdateDetailsCacheKey(slug, branchName, runtimeVersion, updateId)
 	cache := cache2.GetCache()
 	if cacheValue := cache.Get(cacheKey); cacheValue != "" {
 		w.Header().Set("Content-Type", "application/json")
@@ -256,14 +284,14 @@ func GetUpdateDetails(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	metadata, err := update2.GetMetadata(*update)
+	metadata, err := update2.GetMetadata(app, *update)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	numberUpdate, _ := strconv.ParseInt(update.UpdateId, 10, 64)
-	storedMetadata, _ := update2.RetrieveUpdateStoredMetadata(*update)
-	expoConfig, err := update2.GetExpoConfig(*update)
+	storedMetadata, _ := update2.RetrieveUpdateStoredMetadata(app, *update)
+	expoConfig, err := update2.GetExpoConfig(app, *update)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
@@ -280,7 +308,7 @@ func GetUpdateDetails(w http.ResponseWriter, r *http.Request) {
 		CommitHash: storedMetadata.CommitHash,
 		Platform:   storedMetadata.Platform,
 		Message:    storedMetadata.Message,
-		Type:       update2.GetUpdateType(*update),
+		Type:       update2.GetUpdateType(app, *update),
 		ExpoConfig: string(expoConfig),
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -293,10 +321,13 @@ func GetUpdateDetails(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetUpdatesHandler(w http.ResponseWriter, r *http.Request) {
+	app := resolveApp(r)
+	slug := getAppSlug(app)
+
 	vars := mux.Vars(r)
 	branchName := vars["BRANCH"]
 	runtimeVersion := vars["RUNTIME_VERSION"]
-	cacheKey := dashboard.ComputeGetUpdatesCacheKey(branchName, runtimeVersion)
+	cacheKey := dashboard.ComputeGetUpdatesCacheKey(slug, branchName, runtimeVersion)
 	cache := cache2.GetCache()
 	if cacheValue := cache.Get(cacheKey); cacheValue != "" {
 		w.Header().Set("Content-Type", "application/json")
@@ -306,7 +337,7 @@ func GetUpdatesHandler(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(updatesResponse)
 		return
 	}
-	resolvedBucket := bucket.GetBucket()
+	resolvedBucket := bucket.GetBucketForApp(app)
 	updates, err := resolvedBucket.GetUpdates(branchName, runtimeVersion)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -315,13 +346,13 @@ func GetUpdatesHandler(w http.ResponseWriter, r *http.Request) {
 
 	var updatesResponse []UpdateItem
 	for _, update := range updates {
-		isValid := update2.IsUpdateValid(update)
+		isValid := update2.IsUpdateValid(app, update)
 		if !isValid {
 			continue
 		}
 		numberUpdate, _ := strconv.ParseInt(update.UpdateId, 10, 64)
-		storedMetadata, _ := update2.RetrieveUpdateStoredMetadata(update)
-		updateType := update2.GetUpdateType(update)
+		storedMetadata, _ := update2.RetrieveUpdateStoredMetadata(app, update)
+		updateType := update2.GetUpdateType(app, update)
 		if updateType == types.Rollback {
 			updatesResponse = append(updatesResponse, UpdateItem{
 				UpdateUUID: "Rollback to embedded",
@@ -334,7 +365,7 @@ func GetUpdatesHandler(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		metadata, err := update2.GetMetadata(update)
+		metadata, err := update2.GetMetadata(app, update)
 		if err != nil {
 			continue
 		}
@@ -366,6 +397,9 @@ func GetUpdatesHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func UpdateChannelBranchMappingHandler(w http.ResponseWriter, r *http.Request) {
+	app := resolveApp(r)
+	slug := getAppSlug(app)
+
 	vars := mux.Vars(r)
 	branchId := vars["BRANCH"]
 	var requestBody struct {
@@ -385,7 +419,7 @@ func UpdateChannelBranchMappingHandler(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("Release channel is empty"))
 		return
 	}
-	err = services.UpdateChannelBranchMapping(releaseChannel, branchId)
+	err = services.UpdateChannelBranchMapping(app, releaseChannel, branchId)
 	if err != nil {
 		fmt.Println("Error updating channel branch mapping:", err)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -397,11 +431,11 @@ func UpdateChannelBranchMappingHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(marshaledResponse)
 
-	branchesCacheKey := dashboard.ComputeGetBranchesCacheKey()
-	channelsCacheKey := dashboard.ComputeGetChannelsCacheKey()
+	branchesCacheKey := dashboard.ComputeGetBranchesCacheKey(slug)
+	channelsCacheKey := dashboard.ComputeGetChannelsCacheKey(slug)
 	cache := cache2.GetCache()
 	cache.Delete(branchesCacheKey)
 	cache.Delete(channelsCacheKey)
-	channelMappingCacheKey := services.ComputeChannelMappingCacheKey(releaseChannel)
+	channelMappingCacheKey := services.ComputeChannelMappingCacheKey(app, releaseChannel)
 	cache.Delete(channelMappingCacheKey)
 }

--- a/internal/handlers/manifest_handler.go
+++ b/internal/handlers/manifest_handler.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
+	"expo-open-ota/config"
+	"expo-open-ota/internal/appcontext"
 	"expo-open-ota/internal/crypto"
 	"expo-open-ota/internal/keyStore"
 	"expo-open-ota/internal/metrics"
@@ -17,6 +19,14 @@ import (
 
 	"github.com/google/uuid"
 )
+
+func resolveApp(r *http.Request) *config.AppConfig {
+	app := appcontext.GetAppConfig(r.Context())
+	if app == nil {
+		return config.GetDefaultAppConfig()
+	}
+	return app
+}
 
 func createMultipartResponse(headers map[string][]string, jsonContent interface{}) (*multipart.Writer, *bytes.Buffer, error) {
 	var buf bytes.Buffer
@@ -90,9 +100,9 @@ func putResponse(w http.ResponseWriter, r *http.Request, content interface{}, fi
 	writeResponse(w, writer, buf, protocolVersion, runtimeVersion, requestID)
 }
 
-func putUpdateInResponse(w http.ResponseWriter, r *http.Request, lastUpdate types.Update, platform string, protocolVersion int64, requestID string) {
+func putUpdateInResponse(w http.ResponseWriter, r *http.Request, app *config.AppConfig, lastUpdate types.Update, platform string, protocolVersion int64, requestID string) {
 	currentUpdateId := r.Header.Get("expo-current-update-id")
-	metadata, err := update.GetMetadata(lastUpdate)
+	metadata, err := update.GetMetadata(app, lastUpdate)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error getting metadata: %v", requestID, err)
 		http.Error(w, "Error getting metadata", http.StatusInternalServerError)
@@ -103,7 +113,7 @@ func putUpdateInResponse(w http.ResponseWriter, r *http.Request, lastUpdate type
 		putNoUpdateAvailableInResponse(w, r, lastUpdate.RuntimeVersion, protocolVersion, requestID)
 		return
 	}
-	manifest, err := update.ComposeUpdateManifest(&metadata, lastUpdate, platform)
+	manifest, err := update.ComposeUpdateManifest(app, &metadata, lastUpdate, platform)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error composing manifest: %v", requestID, err)
 		http.Error(w, "Error composing manifest", http.StatusInternalServerError)
@@ -116,7 +126,7 @@ func putUpdateInResponse(w http.ResponseWriter, r *http.Request, lastUpdate type
 	putResponse(w, r, manifest, "manifest", lastUpdate.RuntimeVersion, protocolVersion, requestID)
 }
 
-func putRollbackInResponse(w http.ResponseWriter, r *http.Request, lastUpdate types.Update, platform string, protocolVersion int64, requestID string) {
+func putRollbackInResponse(w http.ResponseWriter, r *http.Request, app *config.AppConfig, lastUpdate types.Update, platform string, protocolVersion int64, requestID string) {
 	if protocolVersion == 0 {
 		http.Error(w, "Rollback not supported in protocol version 0", http.StatusBadRequest)
 		return
@@ -131,7 +141,7 @@ func putRollbackInResponse(w http.ResponseWriter, r *http.Request, lastUpdate ty
 		putNoUpdateAvailableInResponse(w, r, lastUpdate.RuntimeVersion, protocolVersion, requestID)
 		return
 	}
-	directive, err := update.CreateRollbackDirective(lastUpdate)
+	directive, err := update.CreateRollbackDirective(app, lastUpdate)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error creating rollback directive: %v", requestID, err)
 		http.Error(w, "Error creating rollback directive", http.StatusInternalServerError)
@@ -152,6 +162,7 @@ func putNoUpdateAvailableInResponse(w http.ResponseWriter, r *http.Request, runt
 
 func ManifestHandler(w http.ResponseWriter, r *http.Request) {
 	requestID := uuid.New().String()
+	app := resolveApp(r)
 
 	channelName := r.Header.Get("expo-channel-name")
 	if channelName == "" {
@@ -159,7 +170,7 @@ func ManifestHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "No channel name provided", http.StatusBadRequest)
 		return
 	}
-	branchMap, err := services.FetchExpoChannelMapping(channelName)
+	branchMap, err := services.FetchExpoChannelMapping(app, channelName)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error fetching channel mapping: %v", requestID, err)
 		http.Error(w, fmt.Sprintf("Error fetching channel mapping: %v", err), http.StatusInternalServerError)
@@ -211,7 +222,7 @@ func ManifestHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "No runtime version provided", http.StatusBadRequest)
 		return
 	}
-	lastUpdate, err := update.GetLatestUpdateBundlePathForRuntimeVersion(branch, runtimeVersion, platform)
+	lastUpdate, err := update.GetLatestUpdateBundlePathForRuntimeVersion(app, branch, runtimeVersion, platform)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error getting latest update: %v", requestID, err)
 		http.Error(w, "Error getting latest update", http.StatusInternalServerError)
@@ -223,10 +234,10 @@ func ManifestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updateType := update.GetUpdateType(*lastUpdate)
+	updateType := update.GetUpdateType(app, *lastUpdate)
 	if updateType == types.NormalUpdate {
-		putUpdateInResponse(w, r, *lastUpdate, platform, protocolVersion, requestID)
+		putUpdateInResponse(w, r, app, *lastUpdate, platform, protocolVersion, requestID)
 	} else {
-		putRollbackInResponse(w, r, *lastUpdate, platform, protocolVersion, requestID)
+		putRollbackInResponse(w, r, app, *lastUpdate, platform, protocolVersion, requestID)
 	}
 }

--- a/internal/handlers/republish_handler.go
+++ b/internal/handlers/republish_handler.go
@@ -15,6 +15,8 @@ import (
 
 func RepublishHandler(w http.ResponseWriter, r *http.Request) {
 	requestID := uuid.New().String()
+	app := resolveApp(r)
+
 	vars := mux.Vars(r)
 	branchName := vars["BRANCH"]
 	platform := r.URL.Query().Get("platform")
@@ -53,7 +55,7 @@ func RepublishHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "No updateId provided", http.StatusBadRequest)
 		return
 	}
-	err = branch.UpsertBranch(branchName)
+	err = branch.UpsertBranch(app, branchName)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error upserting branch: %v", requestID, err)
 		http.Error(w, "Error upserting branch", http.StatusInternalServerError)
@@ -70,13 +72,13 @@ func RepublishHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "No update found", http.StatusNotFound)
 		return
 	}
-	updateType := update2.GetUpdateType(*update)
+	updateType := update2.GetUpdateType(app, *update)
 	if updateType != types2.NormalUpdate {
 		log.Printf("[RequestID: %s] Update type is not normal update", requestID)
 		http.Error(w, "Update type is not normal update", http.StatusBadRequest)
 		return
 	}
-	storedMetadata, err := update2.RetrieveUpdateStoredMetadata(*update)
+	storedMetadata, err := update2.RetrieveUpdateStoredMetadata(app, *update)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error retrieving update commit hash and platform: %v", requestID, err)
 		http.Error(w, "Error retrieving update commit hash and platform", http.StatusInternalServerError)
@@ -87,7 +89,7 @@ func RepublishHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "No stored metadata found for update", http.StatusNotFound)
 		return
 	}
-	isValid := update2.IsUpdateValid(*update)
+	isValid := update2.IsUpdateValid(app, *update)
 	if !isValid {
 		log.Printf("[RequestID: %s] Update is not valid", requestID)
 		http.Error(w, "Update is not valid", http.StatusBadRequest)
@@ -98,7 +100,7 @@ func RepublishHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Update platform mismatch", http.StatusBadRequest)
 		return
 	}
-	newUpdate, err := update2.RepublishUpdate(update, platform, commitHash)
+	newUpdate, err := update2.RepublishUpdate(app, update, platform, commitHash)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error republishing update: %v", requestID, err)
 		http.Error(w, "Error republishing update", http.StatusInternalServerError)

--- a/internal/handlers/rollback_handler.go
+++ b/internal/handlers/rollback_handler.go
@@ -14,6 +14,8 @@ import (
 
 func RollbackHandler(w http.ResponseWriter, r *http.Request) {
 	requestID := uuid.New().String()
+	app := resolveApp(r)
+
 	vars := mux.Vars(r)
 	branchName := vars["BRANCH"]
 	platform := r.URL.Query().Get("platform")
@@ -45,14 +47,14 @@ func RollbackHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "No runtime version provided", http.StatusBadRequest)
 		return
 	}
-	errUpsert := branch.UpsertBranch(branchName)
+	errUpsert := branch.UpsertBranch(app, branchName)
 	if errUpsert != nil {
 		log.Printf("[RequestID: %s] Error upserting branch: %v", requestID, errUpsert)
 		http.Error(w, "Error upserting branch", http.StatusInternalServerError)
 		return
 	}
 	commitHash := r.URL.Query().Get("commitHash")
-	rollback, err := update.CreateRollback(platform, commitHash, runtimeVersion, branchName)
+	rollback, err := update.CreateRollback(app, platform, commitHash, runtimeVersion, branchName)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error creating rollback: %v", requestID, err)
 		http.Error(w, "Error creating rollback", http.StatusInternalServerError)

--- a/internal/handlers/upload_handler.go
+++ b/internal/handlers/upload_handler.go
@@ -26,6 +26,8 @@ type FileNamesRequest struct {
 
 func MarkUpdateAsUploadedHandler(w http.ResponseWriter, r *http.Request) {
 	requestID := uuid.New().String()
+	app := resolveApp(r)
+
 	vars := mux.Vars(r)
 	branchName := vars["BRANCH"]
 	platform := r.URL.Query().Get("platform")
@@ -40,7 +42,7 @@ func MarkUpdateAsUploadedHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	expoAuth := helpers.GetExpoAuth(r)
-	expoAccount, err := services.ValidateExpoAuth(expoAuth)
+	expoAccount, err := services.ValidateExpoAuth(app, expoAuth)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error validating expo auth: %v", requestID, err)
 		http.Error(w, "Error validating expo auth", http.StatusUnauthorized)
@@ -63,7 +65,7 @@ func MarkUpdateAsUploadedHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "No update id provided", http.StatusBadRequest)
 		return
 	}
-	err = branch.UpsertBranch(branchName)
+	err = branch.UpsertBranch(app, branchName)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error upserting branch: %v", requestID, err)
 		http.Error(w, "Error upserting branch", http.StatusInternalServerError)
@@ -75,10 +77,9 @@ func MarkUpdateAsUploadedHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Error getting update", http.StatusInternalServerError)
 		return
 	}
-	resolvedBucket := bucket.GetBucket()
-	errorVerify := update.VerifyUploadedUpdate(*currentUpdate)
+	resolvedBucket := bucket.GetBucketForApp(app)
+	errorVerify := update.VerifyUploadedUpdate(app, *currentUpdate)
 	if errorVerify != nil {
-		// Delete folder and throw error
 		log.Printf("[RequestID: %s] Invalid update, deleting folder...", requestID)
 		err := resolvedBucket.DeleteUpdateFolder(branchName, runtimeVersion, updateId)
 		if err != nil {
@@ -90,10 +91,9 @@ func MarkUpdateAsUploadedHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("Invalid update %s", errorVerify), http.StatusBadRequest)
 		return
 	}
-	// Now we have to retrieve the latest update and compare hash changes
-	latestUpdate, err := update.GetLatestUpdateBundlePathForRuntimeVersion(branchName, runtimeVersion, platform)
-	if err != nil || latestUpdate == nil || update.GetUpdateType(*latestUpdate) == types.Rollback {
-		err = update.MarkUpdateAsChecked(*currentUpdate)
+	latestUpdate, err := update.GetLatestUpdateBundlePathForRuntimeVersion(app, branchName, runtimeVersion, platform)
+	if err != nil || latestUpdate == nil || update.GetUpdateType(app, *latestUpdate) == types.Rollback {
+		err = update.MarkUpdateAsChecked(app, *currentUpdate)
 		if err != nil {
 			log.Printf("[RequestID: %s] Error marking update as checked: %v", requestID, err)
 			http.Error(w, "Error marking update as checked", http.StatusInternalServerError)
@@ -104,14 +104,14 @@ func MarkUpdateAsUploadedHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	areUpdatesIdentical, err := update.AreUpdatesIdentical(*currentUpdate, *latestUpdate)
+	areUpdatesIdentical, err := update.AreUpdatesIdentical(app, *currentUpdate, *latestUpdate)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error comparing updates: %v", requestID, err)
 		http.Error(w, "Error comparing updates", http.StatusInternalServerError)
 		return
 	}
 	if !areUpdatesIdentical {
-		err = update.MarkUpdateAsChecked(*currentUpdate)
+		err = update.MarkUpdateAsChecked(app, *currentUpdate)
 		if err != nil {
 			log.Printf("[RequestID: %s] Error marking update as checked: %v", requestID, err)
 			http.Error(w, "Error marking update as checked", http.StatusInternalServerError)
@@ -129,7 +129,6 @@ func MarkUpdateAsUploadedHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNotAcceptable)
-	// Send error like json error { error: "No changes detected in the update from the previous one" }
 	log.Printf("[RequestID: %s] Updates are identical, folder deleted", requestID)
 	w.Header().Set("Content-Type", "application/json")
 	response := map[string]string{
@@ -146,8 +145,10 @@ func RequestUploadLocalFileHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	requestID := uuid.New().String()
+	app := resolveApp(r)
+
 	expoAuth := helpers.GetExpoAuth(r)
-	expoAccount, err := services.ValidateExpoAuth(expoAuth)
+	expoAccount, err := services.ValidateExpoAuth(app, expoAuth)
 	if err != nil || expoAccount == nil {
 		log.Printf("[RequestID: %s] Error validating expo auth: %v", requestID, err)
 		http.Error(w, "Error validating expo auth", http.StatusUnauthorized)
@@ -197,6 +198,8 @@ func RequestUploadLocalFileHandler(w http.ResponseWriter, r *http.Request) {
 
 func RequestUploadUrlHandler(w http.ResponseWriter, r *http.Request) {
 	requestID := uuid.New().String()
+	app := resolveApp(r)
+
 	vars := mux.Vars(r)
 	branchName := vars["BRANCH"]
 	if branchName == "" {
@@ -206,7 +209,7 @@ func RequestUploadUrlHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	expoAuth := helpers.GetExpoAuth(r)
-	expoAccount, err := services.ValidateExpoAuth(expoAuth)
+	expoAccount, err := services.ValidateExpoAuth(app, expoAuth)
 	if err != nil || expoAccount == nil {
 		log.Printf("[RequestID: %s] Error validating expo auth: %v", requestID, err)
 		http.Error(w, "Error validating expo auth", http.StatusUnauthorized)
@@ -240,7 +243,7 @@ func RequestUploadUrlHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = branch.UpsertBranch(branchName)
+	err = branch.UpsertBranch(app, branchName)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error upserting branch: %v", requestID, err)
 		http.Error(w, "Error upserting branch", http.StatusInternalServerError)
@@ -248,7 +251,7 @@ func RequestUploadUrlHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	updateId := update.GenerateUpdateTimestamp()
-	updateRequests, err := bucket.RequestUploadUrlsForFileUpdates(branchName, runtimeVersion, update.ConvertUpdateTimestampToString(updateId), request.FileNames)
+	updateRequests, err := bucket.RequestUploadUrlsForFileUpdates(app, branchName, runtimeVersion, update.ConvertUpdateTimestampToString(updateId), request.FileNames)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error requesting upload urls: %v", requestID, err)
 		http.Error(w, "Error requesting upload urls", http.StatusInternalServerError)
@@ -268,7 +271,7 @@ func RequestUploadUrlHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	metadataReader := bytes.NewReader(marshalledMetadata)
-	resolvedBucket := bucket.GetBucket()
+	resolvedBucket := bucket.GetBucketForApp(app)
 	err = resolvedBucket.UploadFileIntoUpdate(types.Update{
 		Branch:         branchName,
 		RuntimeVersion: runtimeVersion,

--- a/internal/middleware/auth_middleware.go
+++ b/internal/middleware/auth_middleware.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"expo-open-ota/config"
+	"expo-open-ota/internal/appcontext"
 	"expo-open-ota/internal/auth"
 	"expo-open-ota/internal/helpers"
 	"expo-open-ota/internal/services"
@@ -14,7 +16,11 @@ func AuthMiddleware(next http.Handler) http.Handler {
 		if useExpoAuth == "true" {
 			expoAuth := helpers.GetExpoAuth(r)
 			fmt.Println(expoAuth)
-			_, err := services.ValidateExpoAuth(expoAuth)
+			app := appcontext.GetAppConfig(r.Context())
+			if app == nil {
+				app = config.GetDefaultAppConfig()
+			}
+			_, err := services.ValidateExpoAuth(app, expoAuth)
 			if err != nil {
 				fmt.Println("lel", err)
 				http.Error(w, "Invalid Expo auth", http.StatusUnauthorized)

--- a/internal/migration/runner.go
+++ b/internal/migration/runner.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"expo-open-ota/config"
 	"expo-open-ota/internal/bucket"
 	"expo-open-ota/internal/cache"
 	"fmt"
@@ -61,19 +62,41 @@ func RollbackLastMigration(b bucket.Bucket) error {
 
 func RunMigrationsWithLock() {
 	log.Println("🔧 Checking if migrations should run...")
-	b := bucket.GetBucket()
 	c := cache.GetCache()
-	ok, err := c.TryLock("migration-lock", 120)
-	if err != nil {
-		log.Fatalf("❌ Failed to acquire migration lock: %v", err)
+
+	if config.IsMultiAppMode() {
+		for _, app := range config.GetAllApps() {
+			appCopy := app
+			b := bucket.GetBucketForApp(&appCopy)
+			lockKey := fmt.Sprintf("migration-lock:%s", app.Slug)
+			ok, err := c.TryLock(lockKey, 120)
+			if err != nil {
+				log.Fatalf("❌ Failed to acquire migration lock for app %s: %v", app.Slug, err)
+			}
+			if !ok {
+				log.Printf("⏩ Migration already in progress for app %s – skipping.", app.Slug)
+				continue
+			}
+			log.Printf("✅ Migration lock acquired for app %s – starting migrations...", app.Slug)
+			if err := RunMigrations(b); err != nil {
+				log.Fatalf("🚨 Migration failed for app %s: %v", app.Slug, err)
+			}
+			log.Printf("🎉 Migrations completed for app %s.", app.Slug)
+		}
+	} else {
+		b := bucket.GetBucket()
+		ok, err := c.TryLock("migration-lock", 120)
+		if err != nil {
+			log.Fatalf("❌ Failed to acquire migration lock: %v", err)
+		}
+		if !ok {
+			log.Println("⏩ Migration already in progress or completed on another instance – skipping.")
+			return
+		}
+		log.Println("✅ Migration lock acquired – starting migrations...")
+		if err := RunMigrations(b); err != nil {
+			log.Fatalf("🚨 Migration failed: %v", err)
+		}
+		log.Println("🎉 Migrations completed successfully.")
 	}
-	if !ok {
-		log.Println("⏩ Migration already in progress or completed on another instance – skipping.")
-		return
-	}
-	log.Println("✅ Migration lock acquired – starting migrations...")
-	if err := RunMigrations(b); err != nil {
-		log.Fatalf("🚨 Migration failed: %v", err)
-	}
-	log.Println("🎉 Migrations completed successfully.")
 }

--- a/internal/migrations/20250417_persist_uuid/20250417_persist_uuid.go
+++ b/internal/migrations/20250417_persist_uuid/20250417_persist_uuid.go
@@ -36,7 +36,7 @@ func init() {
 					}
 					for _, update := range updates {
 						fmt.Println("Processing update:", update.UpdateId)
-						storedMetadata, err := update2.RetrieveUpdateStoredMetadata(update)
+						storedMetadata, err := update2.RetrieveUpdateStoredMetadata(nil, update)
 						if storedMetadata == nil {
 							fmt.Println("Update UUID already exists, skipping:", update.UpdateId)
 							continue

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,7 +1,9 @@
 package infrastructure
 
 import (
+	"encoding/json"
 	"expo-open-ota/config"
+	"expo-open-ota/internal/appcontext"
 	"expo-open-ota/internal/dashboard"
 	"expo-open-ota/internal/handlers"
 	"expo-open-ota/internal/metrics"
@@ -33,15 +35,8 @@ func getDashboardPath() string {
 	return filepath.Join(exeDir, "apps", "dashboard", "dist")
 }
 
-func NewRouter() *mux.Router {
-	r := mux.NewRouter()
-	r.Use(middleware.LoggingMiddleware)
 
-	r.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
-		metrics.PrometheusHandler().ServeHTTP(w, r)
-	}).Methods(http.MethodGet)
-
-	r.HandleFunc("/hc", HealthCheck).Methods(http.MethodGet)
+func registerRoutes(r *mux.Router) {
 	r.HandleFunc("/manifest", handlers.ManifestHandler).Methods(http.MethodGet)
 	r.HandleFunc("/assets", handlers.AssetsHandler).Methods(http.MethodGet)
 	r.HandleFunc("/requestUploadUrl/{BRANCH}", handlers.RequestUploadUrlHandler).Methods(http.MethodPost)
@@ -54,46 +49,6 @@ func NewRouter() *mux.Router {
 	corsSubrouter.HandleFunc("/login", handlers.LoginHandler).Methods(http.MethodPost)
 	corsSubrouter.HandleFunc("/refreshToken", handlers.RefreshTokenHandler).Methods(http.MethodPost)
 
-	dashboardPath := getDashboardPath()
-
-	if dashboard.IsDashboardEnabled() {
-		r.PathPrefix("/dashboard").Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Get env.js
-			if r.URL.Path == "/dashboard/env.js" {
-				w.Header().Set("Content-Type", "application/javascript")
-				baseURL := config.GetEnv("BASE_URL")
-				if baseURL == "" {
-					baseURL = "http://localhost:3000"
-				}
-				w.Write([]byte(fmt.Sprintf("window.env = { VITE_OTA_API_URL: '%s' };", baseURL)))
-				return
-			}
-			if r.URL.Path == "/dashboard" {
-				target := "/dashboard/"
-				if r.URL.RawQuery != "" {
-					target += "?" + r.URL.RawQuery
-				}
-				http.Redirect(w, r, target, http.StatusMovedPermanently)
-				return
-			}
-			staticExtensions := []string{".css", ".js", ".svg", ".png", ".json", ".ico"}
-			for _, ext := range staticExtensions {
-				if len(r.URL.Path) > len(ext) && r.URL.Path[len(r.URL.Path)-len(ext):] == ext {
-					filePath := filepath.Join(dashboardPath, r.URL.Path[len("/dashboard/"):])
-					if !strings.HasPrefix(filePath, dashboardPath) {
-						http.Error(w, "Forbidden", http.StatusForbidden)
-						return
-					}
-					http.ServeFile(w, r, filePath)
-					return
-				}
-			}
-			filePath := filepath.Join(dashboardPath, "index.html")
-			fmt.Println("Serving file", filePath)
-			http.ServeFile(w, r, filePath)
-		}))
-	}
-
 	authSubrouter := r.PathPrefix("/api").Subrouter()
 	authSubrouter.Use(middleware.AuthMiddleware)
 	authSubrouter.HandleFunc("/settings", handlers.GetSettingsHandler).Methods(http.MethodGet)
@@ -103,5 +58,179 @@ func NewRouter() *mux.Router {
 	authSubrouter.HandleFunc("/branch/{BRANCH}/runtimeVersion/{RUNTIME_VERSION}/updates", handlers.GetUpdatesHandler).Methods(http.MethodGet)
 	authSubrouter.HandleFunc("/branch/{BRANCH}/runtimeVersion/{RUNTIME_VERSION}/updates/{UPDATE_ID}", handlers.GetUpdateDetails).Methods(http.MethodGet)
 	authSubrouter.HandleFunc("/branch/{BRANCH}/updateChannelBranchMapping", handlers.UpdateChannelBranchMappingHandler).Methods(http.MethodPost)
+}
+
+func NewRouter() http.Handler {
+	r := mux.NewRouter()
+	r.Use(middleware.LoggingMiddleware)
+
+	r.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		metrics.PrometheusHandler().ServeHTTP(w, r)
+	}).Methods(http.MethodGet)
+
+	r.HandleFunc("/hc", HealthCheck).Methods(http.MethodGet)
+
+	dashboardPath := getDashboardPath()
+
+
+	// Register dashboard routes BEFORE /{APP_SLUG} to avoid conflict
+	if dashboard.IsDashboardEnabled() {
+		serveDashboard := func(appSlug string) http.HandlerFunc {
+			return func(w http.ResponseWriter, r *http.Request) {
+				basePath := "/dashboard"
+				if appSlug != "" {
+					basePath = "/" + appSlug + "/dashboard"
+				} else if config.IsMultiAppMode() {
+					vars := mux.Vars(r)
+					if slug := vars["APP_SLUG"]; slug != "" {
+						appSlug = slug
+						basePath = "/" + slug + "/dashboard"
+					}
+				}
+
+				if strings.HasSuffix(r.URL.Path, "/env.js") {
+					w.Header().Set("Content-Type", "application/javascript")
+					baseURL := config.GetEnv("BASE_URL")
+					if baseURL == "" {
+						baseURL = "http://localhost:3000"
+					}
+					apiURL := baseURL
+					if appSlug != "" {
+						apiURL = baseURL + "/" + appSlug
+					}
+					dashboardBasename := "/dashboard"
+						if appSlug != "" {
+							dashboardBasename = "/" + appSlug + "/dashboard"
+						}
+						w.Write([]byte(fmt.Sprintf("window.env = { VITE_OTA_API_URL: '%s', VITE_DASHBOARD_BASENAME: '%s' };", apiURL, dashboardBasename)))
+					return
+				}
+				if r.URL.Path == basePath {
+					target := basePath + "/"
+					if r.URL.RawQuery != "" {
+						target += "?" + r.URL.RawQuery
+					}
+					http.Redirect(w, r, target, http.StatusMovedPermanently)
+					return
+				}
+				staticExtensions := []string{".css", ".js", ".svg", ".png", ".json", ".ico"}
+				for _, ext := range staticExtensions {
+					if len(r.URL.Path) > len(ext) && r.URL.Path[len(r.URL.Path)-len(ext):] == ext {
+						relPath := strings.TrimPrefix(r.URL.Path, basePath+"/")
+						// Also try stripping /dashboard/ for absolute paths from HTML
+						if strings.HasPrefix(r.URL.Path, "/dashboard/") && basePath != "/dashboard" {
+							relPath = strings.TrimPrefix(r.URL.Path, "/dashboard/")
+						}
+						filePath := filepath.Join(dashboardPath, relPath)
+						if !strings.HasPrefix(filePath, dashboardPath) {
+							http.Error(w, "Forbidden", http.StatusForbidden)
+							return
+						}
+						http.ServeFile(w, r, filePath)
+						return
+					}
+				}
+				filePath := filepath.Join(dashboardPath, "index.html")
+				http.ServeFile(w, r, filePath)
+			}
+		}
+
+		if config.IsMultiAppMode() {
+			// Serve dashboard under /{appSlug}/dashboard for each app
+			for _, app := range config.GetAllApps() {
+				r.PathPrefix("/" + app.Slug + "/dashboard").HandlerFunc(serveDashboard(app.Slug))
+			}
+			// /dashboard/ static files are handled by middleware above
+		} else {
+			r.PathPrefix("/dashboard").HandlerFunc(serveDashboard(""))
+		}
+	}
+
+	if config.IsMultiAppMode() {
+		// Multi-app mode: register routes for each configured app explicitly
+		for _, app := range config.GetAllApps() {
+			appRouter := r.PathPrefix("/" + app.Slug).Subrouter()
+			appCopy := app
+			appRouter.Use(func(next http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					ctx := appcontext.WithAppConfig(r.Context(), &appCopy)
+					next.ServeHTTP(w, r.WithContext(ctx))
+				})
+			})
+			registerRoutes(appRouter)
+		}
+
+		// List available apps at root
+		r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			apps := config.GetAllApps()
+			slugs := make([]string, len(apps))
+			for i, app := range apps {
+				slugs[i] = app.Slug
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"mode":"multi-app","apps":%s}`, mustJSON(slugs))
+		}).Methods(http.MethodGet)
+	} else {
+		// Single-app mode: routes at root (backward compatible)
+		registerRoutes(r)
+	}
+
+	// Wrap router with dashboard static file handler for multi-app mode
+	if dashboard.IsDashboardEnabled() && config.IsMultiAppMode() {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if strings.HasPrefix(req.URL.Path, "/dashboard/") || req.URL.Path == "/dashboard" {
+				// env.js is dynamically generated
+				if strings.HasSuffix(req.URL.Path, "/env.js") {
+					apps := config.GetAllApps()
+					slug := ""
+					if len(apps) > 0 {
+						slug = apps[0].Slug
+					}
+					w.Header().Set("Content-Type", "application/javascript")
+					baseURL := config.GetEnv("BASE_URL")
+					apiURL := baseURL
+					if slug != "" {
+						apiURL = baseURL + "/" + slug
+					}
+					dashboardBasename := "/dashboard"
+						if slug != "" {
+							dashboardBasename = "/" + slug + "/dashboard"
+						}
+						w.Write([]byte(fmt.Sprintf("window.env = { VITE_OTA_API_URL: '%s', VITE_DASHBOARD_BASENAME: '%s' };", apiURL, dashboardBasename)))
+					return
+				}
+				// Static files
+				staticExtensions := []string{".css", ".js", ".svg", ".png", ".json", ".ico"}
+				for _, ext := range staticExtensions {
+					if strings.HasSuffix(req.URL.Path, ext) {
+						relPath := strings.TrimPrefix(req.URL.Path, "/dashboard/")
+						filePath := filepath.Join(dashboardPath, relPath)
+						if strings.HasPrefix(filePath, dashboardPath) {
+							http.ServeFile(w, req, filePath)
+							return
+						}
+					}
+				}
+				// Redirect /dashboard to first app dashboard
+				if req.URL.Path == "/dashboard" || req.URL.Path == "/dashboard/" {
+					apps := config.GetAllApps()
+					if len(apps) > 0 {
+						http.Redirect(w, req, "/"+apps[0].Slug+"/dashboard/", http.StatusFound)
+						return
+					}
+				}
+			}
+			r.ServeHTTP(w, req)
+		})
+	}
+
 	return r
+}
+
+func mustJSON(v interface{}) string {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return "[]"
+	}
+	return string(data)
 }

--- a/internal/services/expo.go
+++ b/internal/services/expo.go
@@ -46,7 +46,14 @@ type BranchMapping struct {
 	} `json:"data"`
 }
 
-func ValidateExpoAuth(expoAuth types.ExpoAuth) (*ExpoUserAccount, error) {
+func resolveAppConfig(app *config.AppConfig) (string, string) {
+	if app != nil && app.ExpoAppId != "" {
+		return app.ExpoAppId, app.ExpoAccessToken
+	}
+	return config.GetEnv("EXPO_APP_ID"), config.GetEnv("EXPO_ACCESS_TOKEN")
+}
+
+func ValidateExpoAuth(app *config.AppConfig, expoAuth types.ExpoAuth) (*ExpoUserAccount, error) {
 	if expoAuth.Token == nil && expoAuth.SessionSecret == nil {
 		return nil, errors.New("no valid Expo auth provided")
 	}
@@ -57,7 +64,7 @@ func ValidateExpoAuth(expoAuth types.ExpoAuth) (*ExpoUserAccount, error) {
 	if expoAccount == nil {
 		return nil, errors.New("no expo account found")
 	}
-	selfExpoUsername := FetchSelfExpoUsername()
+	selfExpoUsername := FetchSelfExpoUsername(app)
 	if selfExpoUsername != expoAccount.Username {
 		return nil, errors.New("expo account does not match self expo username")
 	}
@@ -111,7 +118,6 @@ func makeGraphQLRequest(ctx context.Context, query string, variables map[string]
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		// Read error message in response body
 		responseBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return errors.New("GraphQL request failed with status: " + resp.Status + " and unable to read response body")
@@ -122,7 +128,7 @@ func makeGraphQLRequest(ctx context.Context, query string, variables map[string]
 	return json.NewDecoder(resp.Body).Decode(result)
 }
 
-func FetchExpoChannels() ([]ExpoChannel, error) {
+func FetchExpoChannels(app *config.AppConfig) ([]ExpoChannel, error) {
 	query := `
 		query FetchAppChannel($appId: String!) {
 			app {
@@ -136,8 +142,7 @@ func FetchExpoChannels() ([]ExpoChannel, error) {
 			}
 		}
 	`
-	appId := GetExpoAppId()
-	expoToken := GetExpoAccessToken()
+	appId, expoToken := resolveAppConfig(app)
 	variables := map[string]interface{}{
 		"appId": appId,
 	}
@@ -163,7 +168,7 @@ func FetchExpoChannels() ([]ExpoChannel, error) {
 	return resp.Data.App.ById.UpdateChannels, nil
 }
 
-func UpdateChannelBranchMapping(channelName, branchId string) error {
+func UpdateChannelBranchMapping(app *config.AppConfig, channelName, branchId string) error {
 	fmt.Println("Updating channel branch mapping for channel:", channelName, "to branch:", branchId)
 	query := `
 		mutation UpdateChannelBranchMapping($channelId: ID!, $branchMapping: String!) {
@@ -197,7 +202,7 @@ func UpdateChannelBranchMapping(channelName, branchId string) error {
 		"branchMapping": string(branchMappingBytes),
 	}
 
-	token := GetExpoAccessToken()
+	_, token := resolveAppConfig(app)
 	headers := map[string]string{}
 	if config.IsTestMode() {
 		headers["operationName"] = "UpdateChannelBranchMapping"
@@ -209,7 +214,7 @@ func UpdateChannelBranchMapping(channelName, branchId string) error {
 	}, &resp, headers)
 }
 
-func FetchExpoBranches() ([]string, error) {
+func FetchExpoBranches(app *config.AppConfig) ([]string, error) {
 	query := `
 		query FetchAppChannel($appId: String!) {
 			app {
@@ -223,8 +228,7 @@ func FetchExpoBranches() ([]string, error) {
 			}
 		}
 	`
-	appId := GetExpoAppId()
-	expoToken := GetExpoAccessToken()
+	appId, expoToken := resolveAppConfig(app)
 	variables := map[string]interface{}{
 		"appId": appId,
 	}
@@ -287,8 +291,8 @@ func FetchExpoUserAccountInformations(expoAuth types.ExpoAuth) (*ExpoUserAccount
 	return &resp.Data.Me, nil
 }
 
-func FetchSelfExpoUsername() string {
-	token := GetExpoAccessToken()
+func FetchSelfExpoUsername(app *config.AppConfig) string {
+	_, token := resolveAppConfig(app)
 	expoAccount, err := FetchExpoUserAccountInformations(types.ExpoAuth{
 		Token: &token,
 	})
@@ -298,13 +302,17 @@ func FetchSelfExpoUsername() string {
 	return expoAccount.Username
 }
 
-func ComputeChannelMappingCacheKey(channelName string) string {
-	return fmt.Sprintf("channelMapping:%s:%s", version.Version, channelName)
+func ComputeChannelMappingCacheKey(app *config.AppConfig, channelName string) string {
+	appSlug := ""
+	if app != nil {
+		appSlug = app.Slug
+	}
+	return fmt.Sprintf("channelMapping:%s:%s:%s", version.Version, appSlug, channelName)
 }
 
-func FetchExpoChannelMapping(channelName string) (*ExpoChannelMapping, error) {
+func FetchExpoChannelMapping(app *config.AppConfig, channelName string) (*ExpoChannelMapping, error) {
 	cache := cache2.GetCache()
-	cacheKey := ComputeChannelMappingCacheKey(channelName)
+	cacheKey := ComputeChannelMappingCacheKey(app, channelName)
 	if cachedValue := cache.Get(cacheKey); cachedValue != "" {
 		var mapping ExpoChannelMapping
 		if err := json.Unmarshal([]byte(cachedValue), &mapping); err != nil {
@@ -333,8 +341,7 @@ func FetchExpoChannelMapping(channelName string) (*ExpoChannelMapping, error) {
 		}
 	`
 
-	appId := GetExpoAppId()
-	expoToken := GetExpoAccessToken()
+	appId, expoToken := resolveAppConfig(app)
 	variables := map[string]interface{}{
 		"appId":       appId,
 		"channelName": channelName,
@@ -405,7 +412,7 @@ func FetchExpoChannelMapping(channelName string) (*ExpoChannelMapping, error) {
 	return result, nil
 }
 
-func FetchExpoBranchesMapping() ([]ExpoBranchMapping, error) {
+func FetchExpoBranchesMapping(app *config.AppConfig) ([]ExpoBranchMapping, error) {
 	query := `
 		query FetchAppChannel($appId: String!) {
 			app {
@@ -425,8 +432,7 @@ func FetchExpoBranchesMapping() ([]ExpoBranchMapping, error) {
 		}
 	`
 
-	appId := GetExpoAppId()
-	expoToken := GetExpoAccessToken()
+	appId, expoToken := resolveAppConfig(app)
 	variables := map[string]interface{}{"appId": appId}
 
 	headers := map[string]string{}
@@ -499,7 +505,7 @@ func FetchExpoBranchesMapping() ([]ExpoBranchMapping, error) {
 	return branchMappings, nil
 }
 
-func CreateBranch(branch string) error {
+func CreateBranch(app *config.AppConfig, branch string) error {
 	query := `
 		mutation CreateUpdateBranchForAppMutation($appId: ID!, $name: String!) {
 		  updateBranch {
@@ -509,12 +515,11 @@ func CreateBranch(branch string) error {
 		  }
 		}
 	`
-	appId := GetExpoAppId()
+	appId, token := resolveAppConfig(app)
 	variables := map[string]interface{}{
 		"appId": appId,
 		"name":  branch,
 	}
-	token := GetExpoAccessToken()
 	headers := map[string]string{}
 	if config.IsTestMode() {
 		headers["operationName"] = "CreateBranch"

--- a/internal/update/prewarm.go
+++ b/internal/update/prewarm.go
@@ -1,6 +1,7 @@
 package update
 
 import (
+	"expo-open-ota/config"
 	"log"
 )
 
@@ -8,14 +9,14 @@ import (
 // branch/runtimeVersion/platform combination. It is intended to be called
 // as a goroutine after MarkUpdateAsChecked so the first client request
 // hits warm caches instead of rebuilding everything from scratch.
-func PreWarmManifestCache(branch, runtimeVersion, platform string) {
+func PreWarmManifestCache(app *config.AppConfig, branch, runtimeVersion, platform string) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Printf("[PreWarm] panic recovered for branch=%s rv=%s platform=%s: %v", branch, runtimeVersion, platform, r)
 		}
 	}()
 
-	latestUpdate, err := GetLatestUpdateBundlePathForRuntimeVersion(branch, runtimeVersion, platform)
+	latestUpdate, err := GetLatestUpdateBundlePathForRuntimeVersion(app, branch, runtimeVersion, platform)
 	if err != nil {
 		log.Printf("[PreWarm] error getting latest update for branch=%s rv=%s platform=%s: %v", branch, runtimeVersion, platform, err)
 		return
@@ -24,13 +25,13 @@ func PreWarmManifestCache(branch, runtimeVersion, platform string) {
 		return
 	}
 
-	metadata, err := GetMetadata(*latestUpdate)
+	metadata, err := GetMetadata(app, *latestUpdate)
 	if err != nil {
 		log.Printf("[PreWarm] error getting metadata for update=%s: %v", latestUpdate.UpdateId, err)
 		return
 	}
 
-	_, err = ComposeUpdateManifest(&metadata, *latestUpdate, platform)
+	_, err = ComposeUpdateManifest(app, &metadata, *latestUpdate, platform)
 	if err != nil {
 		log.Printf("[PreWarm] error composing manifest for update=%s platform=%s: %v", latestUpdate.UpdateId, platform, err)
 		return

--- a/internal/update/updates.go
+++ b/internal/update/updates.go
@@ -26,10 +26,10 @@ func sortUpdates(updates []types.Update) []types.Update {
 	return updates
 }
 
-func filterPlatformUpdates(updates []types.Update, platform string) []types.Update {
+func filterPlatformUpdates(app *config.AppConfig, updates []types.Update, platform string) []types.Update {
 	filteredUpdates := make([]types.Update, 0)
 	for _, update := range updates {
-		storedMetadata, err := RetrieveUpdateStoredMetadata(update)
+		storedMetadata, err := RetrieveUpdateStoredMetadata(app, update)
 		if err == nil && storedMetadata != nil && storedMetadata.Platform == platform {
 			filteredUpdates = append(filteredUpdates, update)
 		}
@@ -37,18 +37,18 @@ func filterPlatformUpdates(updates []types.Update, platform string) []types.Upda
 	return filteredUpdates
 }
 
-func GetAllUpdatesForRuntimeVersion(branch string, runtimeVersion string, platform string) ([]types.Update, error) {
-	resolvedBucket := bucket.GetBucket()
+func GetAllUpdatesForRuntimeVersion(app *config.AppConfig, branch string, runtimeVersion string, platform string) ([]types.Update, error) {
+	resolvedBucket := bucket.GetBucketForApp(app)
 	updates, errGetUpdates := resolvedBucket.GetUpdates(branch, runtimeVersion)
 	if errGetUpdates != nil {
 		return nil, errGetUpdates
 	}
-	updates = sortUpdates(filterPlatformUpdates(updates, platform))
+	updates = sortUpdates(filterPlatformUpdates(app, updates, platform))
 	return updates, nil
 }
 
-func StoreUpdateUUIDInMetadata(update types.Update) error {
-	resolvedBucket := bucket.GetBucket()
+func StoreUpdateUUIDInMetadata(app *config.AppConfig, update types.Update) error {
+	resolvedBucket := bucket.GetBucketForApp(app)
 	file, err := resolvedBucket.GetFile(update, "update-metadata.json")
 	if err != nil {
 		return err
@@ -59,7 +59,7 @@ func StoreUpdateUUIDInMetadata(update types.Update) error {
 	if err != nil {
 		return err
 	}
-	metadata, err := GetMetadata(update)
+	metadata, err := GetMetadata(app, update)
 	if err != nil {
 		return err
 	}
@@ -76,34 +76,41 @@ func StoreUpdateUUIDInMetadata(update types.Update) error {
 	return nil
 }
 
-func MarkUpdateAsChecked(update types.Update) error {
+func appSlug(app *config.AppConfig) string {
+	if app != nil {
+		return app.Slug
+	}
+	return ""
+}
+
+func MarkUpdateAsChecked(app *config.AppConfig, update types.Update) error {
 	cache := cache2.GetCache()
-	branchesCacheKey := dashboard.ComputeGetBranchesCacheKey()
-	runTimeVersionsCacheKey := dashboard.ComputeGetRuntimeVersionsCacheKey(update.Branch)
-	updatesCacheKey := dashboard.ComputeGetUpdatesCacheKey(update.Branch, update.RuntimeVersion)
-	storedMetadata, err := RetrieveUpdateStoredMetadata(update)
+	slug := appSlug(app)
+	branchesCacheKey := dashboard.ComputeGetBranchesCacheKey(slug)
+	runTimeVersionsCacheKey := dashboard.ComputeGetRuntimeVersionsCacheKey(slug, update.Branch)
+	updatesCacheKey := dashboard.ComputeGetUpdatesCacheKey(slug, update.Branch, update.RuntimeVersion)
+	storedMetadata, err := RetrieveUpdateStoredMetadata(app, update)
 	if err != nil || storedMetadata == nil {
 		return err
 	}
-	cacheKeys := []string{ComputeLastUpdateCacheKey(update.Branch, update.RuntimeVersion, storedMetadata.Platform), branchesCacheKey, runTimeVersionsCacheKey, updatesCacheKey}
+	cacheKeys := []string{ComputeLastUpdateCacheKey(slug, update.Branch, update.RuntimeVersion, storedMetadata.Platform), branchesCacheKey, runTimeVersionsCacheKey, updatesCacheKey}
 	for _, cacheKey := range cacheKeys {
 		cache.Delete(cacheKey)
 	}
-	resolvedBucket := bucket.GetBucket()
-	err = StoreUpdateUUIDInMetadata(update)
+	resolvedBucket := bucket.GetBucketForApp(app)
+	err = StoreUpdateUUIDInMetadata(app, update)
 	if err != nil {
 		return err
 	}
 	reader := strings.NewReader(".check")
 	_ = resolvedBucket.UploadFileIntoUpdate(update, ".check", reader)
-	go PreWarmManifestCache(update.Branch, update.RuntimeVersion, "ios")
-	go PreWarmManifestCache(update.Branch, update.RuntimeVersion, "android")
+	go PreWarmManifestCache(app, update.Branch, update.RuntimeVersion, "ios")
+	go PreWarmManifestCache(app, update.Branch, update.RuntimeVersion, "android")
 	return nil
 }
 
-func IsUpdateValid(Update types.Update) bool {
-	resolvedBucket := bucket.GetBucket()
-	// Search for .check file in the update
+func IsUpdateValid(app *config.AppConfig, Update types.Update) bool {
+	resolvedBucket := bucket.GetBucketForApp(app)
 	file, _ := resolvedBucket.GetFile(Update, ".check")
 	if file != nil {
 		file.Reader.Close()
@@ -112,24 +119,24 @@ func IsUpdateValid(Update types.Update) bool {
 	return false
 }
 
-func ComputeLastUpdateCacheKey(branch string, runtimeVersion string, platform string) string {
-	return fmt.Sprintf("lastUpdate:%s:%s:%s:%s", version.Version, branch, runtimeVersion, platform)
+func ComputeLastUpdateCacheKey(slug string, branch string, runtimeVersion string, platform string) string {
+	return fmt.Sprintf("lastUpdate:%s:%s:%s:%s:%s", version.Version, slug, branch, runtimeVersion, platform)
 }
 
-func ComputeMetadataCacheKey(branch string, runtimeVersion string, updateId string) string {
-	return fmt.Sprintf("metadata:%s:%s:%s:%s", version.Version, branch, runtimeVersion, updateId)
+func ComputeMetadataCacheKey(slug string, branch string, runtimeVersion string, updateId string) string {
+	return fmt.Sprintf("metadata:%s:%s:%s:%s:%s", version.Version, slug, branch, runtimeVersion, updateId)
 }
 
-func ComputeUpdataManifestCacheKey(branch string, runtimeVersion string, updateId string, platform string) string {
-	return fmt.Sprintf("manifest:%s:%s:%s:%s:%s", version.Version, branch, runtimeVersion, updateId, platform)
+func ComputeUpdataManifestCacheKey(slug string, branch string, runtimeVersion string, updateId string, platform string) string {
+	return fmt.Sprintf("manifest:%s:%s:%s:%s:%s:%s", version.Version, slug, branch, runtimeVersion, updateId, platform)
 }
 
-func ComputeManifestAssetCacheKey(update types.Update, assetPath string) string {
-	return fmt.Sprintf("asset:%s:%s:%s:%s:%s", version.Version, update.Branch, update.RuntimeVersion, update.UpdateId, assetPath)
+func ComputeManifestAssetCacheKey(slug string, update types.Update, assetPath string) string {
+	return fmt.Sprintf("asset:%s:%s:%s:%s:%s:%s", version.Version, slug, update.Branch, update.RuntimeVersion, update.UpdateId, assetPath)
 }
 
-func VerifyUploadedUpdate(update types.Update) error {
-	metadata, errMetadata := GetMetadata(update)
+func VerifyUploadedUpdate(app *config.AppConfig, update types.Update) error {
+	metadata, errMetadata := GetMetadata(app, update)
 	if errMetadata != nil {
 		return errMetadata
 	}
@@ -150,7 +157,7 @@ func VerifyUploadedUpdate(update types.Update) error {
 		}
 	}
 
-	resolvedBucket := bucket.GetBucket()
+	resolvedBucket := bucket.GetBucketForApp(app)
 	for _, file := range files {
 		f, err := resolvedBucket.GetFile(update, file)
 		if err != nil {
@@ -176,21 +183,22 @@ func GetUpdate(branch string, runtimeVersion string, updateId string) (*types.Up
 	}, nil
 }
 
-func AreUpdatesIdentical(update1, update2 types.Update) (bool, error) {
-	metadata1, errMetadata1 := GetMetadata(update1)
+func AreUpdatesIdentical(app *config.AppConfig, update1, update2 types.Update) (bool, error) {
+	metadata1, errMetadata1 := GetMetadata(app, update1)
 	if errMetadata1 != nil {
 		return false, errMetadata1
 	}
-	metadata2, errMetadata2 := GetMetadata(update2)
+	metadata2, errMetadata2 := GetMetadata(app, update2)
 	if errMetadata2 != nil {
 		return false, errMetadata2
 	}
 	return metadata1.Fingerprint == metadata2.Fingerprint, nil
 }
 
-func GetLatestUpdateBundlePathForRuntimeVersion(branch string, runtimeVersion string, platform string) (*types.Update, error) {
+func GetLatestUpdateBundlePathForRuntimeVersion(app *config.AppConfig, branch string, runtimeVersion string, platform string) (*types.Update, error) {
 	cache := cache2.GetCache()
-	cacheKey := ComputeLastUpdateCacheKey(branch, runtimeVersion, platform)
+	slug := appSlug(app)
+	cacheKey := ComputeLastUpdateCacheKey(slug, branch, runtimeVersion, platform)
 	if cachedValue := cache.Get(cacheKey); cachedValue != "" {
 		var update types.Update
 		err := json.Unmarshal([]byte(cachedValue), &update)
@@ -199,13 +207,13 @@ func GetLatestUpdateBundlePathForRuntimeVersion(branch string, runtimeVersion st
 		}
 		return &update, nil
 	}
-	updates, err := GetAllUpdatesForRuntimeVersion(branch, runtimeVersion, platform)
+	updates, err := GetAllUpdatesForRuntimeVersion(app, branch, runtimeVersion, platform)
 	if err != nil {
 		return nil, err
 	}
 	filteredUpdates := make([]types.Update, 0)
 	for _, update := range updates {
-		if IsUpdateValid(update) {
+		if IsUpdateValid(app, update) {
 			filteredUpdates = append(filteredUpdates, update)
 		}
 	}
@@ -221,8 +229,8 @@ func GetLatestUpdateBundlePathForRuntimeVersion(branch string, runtimeVersion st
 	return nil, nil
 }
 
-func GetUpdateType(update types.Update) types.UpdateType {
-	resolvedBucket := bucket.GetBucket()
+func GetUpdateType(app *config.AppConfig, update types.Update) types.UpdateType {
+	resolvedBucket := bucket.GetBucketForApp(app)
 	file, _ := resolvedBucket.GetFile(update, "rollback")
 	if file != nil {
 		file.Reader.Close()
@@ -231,14 +239,13 @@ func GetUpdateType(update types.Update) types.UpdateType {
 	return types.NormalUpdate
 }
 
-func GetExpoConfig(update types.Update) (json.RawMessage, error) {
-	resolvedBucket := bucket.GetBucket()
+func GetExpoConfig(app *config.AppConfig, update types.Update) (json.RawMessage, error) {
+	resolvedBucket := bucket.GetBucketForApp(app)
 	resp, err := resolvedBucket.GetFile(update, "expoConfig.json")
 	if err != nil {
 		return nil, err
 	}
 	if resp == nil {
-		// Return empty JSON if the file is not found
 		return json.RawMessage("{}"), nil
 	}
 	defer resp.Reader.Close()
@@ -250,8 +257,9 @@ func GetExpoConfig(update types.Update) (json.RawMessage, error) {
 	return expoConfig, nil
 }
 
-func GetMetadata(update types.Update) (types.UpdateMetadata, error) {
-	metadataCacheKey := ComputeMetadataCacheKey(update.Branch, update.RuntimeVersion, update.UpdateId)
+func GetMetadata(app *config.AppConfig, update types.Update) (types.UpdateMetadata, error) {
+	slug := appSlug(app)
+	metadataCacheKey := ComputeMetadataCacheKey(slug, update.Branch, update.RuntimeVersion, update.UpdateId)
 	cache := cache2.GetCache()
 	if cachedValue := cache.Get(metadataCacheKey); cachedValue != "" {
 		var metadata types.UpdateMetadata
@@ -261,7 +269,7 @@ func GetMetadata(update types.Update) (types.UpdateMetadata, error) {
 		}
 		return metadata, nil
 	}
-	resolvedBucket := bucket.GetBucket()
+	resolvedBucket := bucket.GetBucketForApp(app)
 	file, errFile := resolvedBucket.GetFile(update, "metadata.json")
 	if errFile != nil || file == nil {
 		return types.UpdateMetadata{}, errFile
@@ -313,17 +321,21 @@ func BuildFinalManifestAssetUrlURL(baseURL, assetFilePath, runtimeVersion, platf
 	query.Set("runtimeVersion", runtimeVersion)
 	query.Set("platform", platform)
 	query.Set("branch", branch)
-	// Also set random query parameter to prevent caching issues
 	parsedURL.RawQuery = query.Encode()
 	return parsedURL.String(), nil
 }
 
-func GetAssetEndpoint() string {
-	return config.GetEnv("BASE_URL") + "/assets"
+func GetAssetEndpoint(app *config.AppConfig) string {
+	baseURL := config.GetEnv("BASE_URL")
+	if app != nil && app.Slug != "" {
+		return baseURL + "/" + app.Slug + "/assets"
+	}
+	return baseURL + "/assets"
 }
 
-func shapeManifestAsset(update types.Update, asset *types.Asset, isLaunchAsset bool, platform string) (types.ManifestAsset, error) {
-	cacheKey := ComputeManifestAssetCacheKey(update, asset.Path)
+func shapeManifestAsset(app *config.AppConfig, update types.Update, asset *types.Asset, isLaunchAsset bool, platform string) (types.ManifestAsset, error) {
+	slug := appSlug(app)
+	cacheKey := ComputeManifestAssetCacheKey(slug, update, asset.Path)
 	cache := cache2.GetCache()
 	if cachedValue := cache.Get(cacheKey); cachedValue != "" {
 		var manifestAsset types.ManifestAsset
@@ -333,7 +345,7 @@ func shapeManifestAsset(update types.Update, asset *types.Asset, isLaunchAsset b
 		}
 		return manifestAsset, nil
 	}
-	resolvedBucket := bucket.GetBucket()
+	resolvedBucket := bucket.GetBucketForApp(app)
 	assetFilePath := asset.Path
 	assetFile, errAssetFile := resolvedBucket.GetFile(update, asset.Path)
 	if errAssetFile != nil {
@@ -367,7 +379,7 @@ func shapeManifestAsset(update types.Update, asset *types.Asset, isLaunchAsset b
 	if isLaunchAsset {
 		contentType = mime.TypeByExtension(asset.Ext)
 	}
-	finalUrl, errUrl := BuildFinalManifestAssetUrlURL(GetAssetEndpoint(), assetFilePath, update.RuntimeVersion, platform, update.Branch)
+	finalUrl, errUrl := BuildFinalManifestAssetUrlURL(GetAssetEndpoint(app), assetFilePath, update.RuntimeVersion, platform, update.Branch)
 	if errUrl != nil {
 		return types.ManifestAsset{}, errUrl
 	}
@@ -409,12 +421,14 @@ func computeManifestMetadata(update types.Update) json.RawMessage {
 }
 
 func ComposeUpdateManifest(
+	app *config.AppConfig,
 	metadata *types.UpdateMetadata,
 	update types.Update,
 	platform string,
 ) (types.UpdateManifest, error) {
 	cache := cache2.GetCache()
-	cacheKey := ComputeUpdataManifestCacheKey(update.Branch, update.RuntimeVersion, update.UpdateId, platform)
+	slug := appSlug(app)
+	cacheKey := ComputeUpdataManifestCacheKey(slug, update.Branch, update.RuntimeVersion, update.UpdateId, platform)
 	if cachedValue := cache.Get(cacheKey); cachedValue != "" {
 		var manifest types.UpdateManifest
 		err := json.Unmarshal([]byte(cachedValue), &manifest)
@@ -423,11 +437,11 @@ func ComposeUpdateManifest(
 		}
 		return manifest, nil
 	}
-	expoConfig, errConfig := GetExpoConfig(update)
+	expoConfig, errConfig := GetExpoConfig(app, update)
 	if errConfig != nil {
 		return types.UpdateManifest{}, errConfig
 	}
-	storedMetadata, _ := RetrieveUpdateStoredMetadata(update)
+	storedMetadata, _ := RetrieveUpdateStoredMetadata(app, update)
 	if storedMetadata == nil || storedMetadata.UpdateUUID == "" {
 		storedMetadata = &types.UpdateStoredMetadata{
 			Platform:   platform,
@@ -456,7 +470,7 @@ func ComposeUpdateManifest(
 		wg.Add(1)
 		go func(index int, asset types.Asset) {
 			defer wg.Done()
-			shapedAsset, errShape := shapeManifestAsset(update, &asset, false, platform)
+			shapedAsset, errShape := shapeManifestAsset(app, update, &asset, false, platform)
 			if errShape != nil {
 				errs <- errShape
 				return
@@ -472,7 +486,7 @@ func ComposeUpdateManifest(
 		return types.UpdateManifest{}, <-errs
 	}
 
-	launchAsset, errShape := shapeManifestAsset(update, &types.Asset{
+	launchAsset, errShape := shapeManifestAsset(app, update, &types.Asset{
 		Path: platformSpecificMetadata.Bundle,
 		Ext:  "",
 	}, true, platform)
@@ -501,8 +515,8 @@ func ComposeUpdateManifest(
 	return manifest, nil
 }
 
-func CreateRollbackDirective(update types.Update) (types.RollbackDirective, error) {
-	resolvedBucket := bucket.GetBucket()
+func CreateRollbackDirective(app *config.AppConfig, update types.Update) (types.RollbackDirective, error) {
+	resolvedBucket := bucket.GetBucketForApp(app)
 	object, err := resolvedBucket.GetFile(update, "rollback")
 	if err != nil {
 		return types.RollbackDirective{}, err
@@ -523,8 +537,8 @@ func CreateNoUpdateAvailableDirective() types.NoUpdateAvailableDirective {
 	}
 }
 
-func RetrieveUpdateStoredMetadata(update types.Update) (*types.UpdateStoredMetadata, error) {
-	resolvedBucket := bucket.GetBucket()
+func RetrieveUpdateStoredMetadata(app *config.AppConfig, update types.Update) (*types.UpdateStoredMetadata, error) {
+	resolvedBucket := bucket.GetBucketForApp(app)
 	file, err := resolvedBucket.GetFile(update, "update-metadata.json")
 	if err != nil {
 		return nil, err
@@ -563,7 +577,7 @@ func ConvertUpdateTimestampToString(updateId int64) string {
 	return fmt.Sprintf("%d", updateId)
 }
 
-func CreateRollback(platform, commitHash, runtimeVersion, branchName string) (*types.Update, error) {
+func CreateRollback(app *config.AppConfig, platform, commitHash, runtimeVersion, branchName string) (*types.Update, error) {
 	updateId := GenerateUpdateTimestamp()
 	update := types.Update{
 		UpdateId:       ConvertUpdateTimestampToString(updateId),
@@ -571,7 +585,7 @@ func CreateRollback(platform, commitHash, runtimeVersion, branchName string) (*t
 		RuntimeVersion: runtimeVersion,
 		CreatedAt:      time.Duration(updateId) * time.Millisecond,
 	}
-	resolvedBucket := bucket.GetBucket()
+	resolvedBucket := bucket.GetBucketForApp(app)
 	reader, err := createUpdateMetadata(platform, commitHash)
 	if err != nil {
 		return nil, err
@@ -585,11 +599,11 @@ func CreateRollback(platform, commitHash, runtimeVersion, branchName string) (*t
 	if err != nil {
 		return nil, err
 	}
-	err = StoreUpdateUUIDInMetadata(update)
+	err = StoreUpdateUUIDInMetadata(app, update)
 	if err != nil {
 		return nil, err
 	}
-	err = MarkUpdateAsChecked(update)
+	err = MarkUpdateAsChecked(app, update)
 	if err != nil {
 		return nil, err
 	}
@@ -597,8 +611,8 @@ func CreateRollback(platform, commitHash, runtimeVersion, branchName string) (*t
 	return &update, nil
 }
 
-func RepublishUpdate(previousUpdate *types.Update, platform, commitHash string) (*types.Update, error) {
-	resolvedBucket := bucket.GetBucket()
+func RepublishUpdate(app *config.AppConfig, previousUpdate *types.Update, platform, commitHash string) (*types.Update, error) {
+	resolvedBucket := bucket.GetBucketForApp(app)
 	updateId := GenerateUpdateTimestamp()
 	newUpdate, err := resolvedBucket.CreateUpdateFrom(previousUpdate, ConvertUpdateTimestampToString(updateId))
 	if err != nil {
@@ -612,11 +626,11 @@ func RepublishUpdate(previousUpdate *types.Update, platform, commitHash string) 
 	if err != nil {
 		return nil, err
 	}
-	err = StoreUpdateUUIDInMetadata(*newUpdate)
+	err = StoreUpdateUUIDInMetadata(app, *newUpdate)
 	if err != nil {
 		return nil, err
 	}
-	err = MarkUpdateAsChecked(*newUpdate)
+	err = MarkUpdateAsChecked(app, *newUpdate)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Building on the `S3_KEY_PREFIX` feature from [#31](https://github.com/axelmarciano/expo-open-ota/pull/31), this PR adds **multi-app support** — allowing a single expo-open-ota instance to serve multiple Expo apps with isolated storage and per-app Expo API credentials.

Previously, `S3_KEY_PREFIX` enabled multiple instances to share one S3 bucket. This PR takes it further: **one instance, one bucket, multiple apps**.

## How it works

### Configuration

New `APPS_CONFIG` environment variable (JSON array):
```json
[
  {
    "slug": "app-one",
    "expoAppId": "...",
    "expoAccessToken": "...",
    "s3KeyPrefix": "app-one"
  },
  {
    "slug": "app-two",
    "expoAppId": "...",
    "expoAccessToken": "...",
    "s3KeyPrefix": "custom-prefix"
  }
]
```

- `s3KeyPrefix` is optional — defaults to `slug`
- Each app gets its own Expo API credentials
- Reuses the `S3_KEY_PREFIX` mechanism from [#31](https://github.com/axelmarciano/expo-open-ota/pull/31) under the hood

### URL routing

Each app is served under its slug prefix:
```
/{slug}/manifest          — OTA manifest endpoint
/{slug}/assets            — Asset serving
/{slug}/dashboard         — Web dashboard
/{slug}/requestUploadUrl  — Upload API
/{slug}/rollback          — Rollback API
/{slug}/republish         — Republish API
```

### Per-app isolation

- **S3 storage**: Each app's updates stored under `{s3KeyPrefix}/{branch}/{runtimeVersion}/{timestamp}/`
- **Expo API**: Per-app `expoAppId` and `expoAccessToken`
- **Cache**: App-scoped cache keys prevent cross-app collisions
- **Migrations**: Run independently per app

### Dashboard

- Dynamic `basename` via `env.js` for multi-app URL structure
- `/dashboard` redirects to first configured app's dashboard

## Backward compatible

When `APPS_CONFIG` is not set, everything works exactly as before — single-app mode with `EXPO_APP_ID` and `EXPO_ACCESS_TOKEN` environment variables. Zero breaking changes.

## Helm chart changes

- `APPS_CONFIG` added as optional environment variable
- `EXPO_APP_ID` and `EXPO_ACCESS_TOKEN` changed to optional (not required in multi-app mode)

## Files changed

| Area | Files | Changes |
|------|-------|---------|
| Config | `config/apps.go` (new), `config/config.go` | Multi-app config loading, optional single-app validation |
| Context | `internal/appcontext/appcontext.go` (new) | Request-scoped app config via context |
| Bucket | `internal/bucket/bucket.go` | Per-app bucket registry with prefix |
| Services | `internal/services/expo.go` | All Expo API functions accept `*AppConfig` |
| Handlers | All handler files | Extract app config from context |
| Update/Assets | `internal/update/`, `internal/assets/` | App-scoped operations and cache keys |
| Router | `internal/router/router.go` | Explicit per-slug routing, dashboard static file serving |
| Dashboard | `apps/dashboard/src/main.tsx` | Dynamic basename from env.js |
| Helm | `helm/values.yaml` | APPS_CONFIG env var |