### PR TITLE
fix: eoas cli republish without specifying --platform

### DIFF
--- a/apps/eoas/src/commands/republish.ts
+++ b/apps/eoas/src/commands/republish.ts
@@ -127,7 +127,9 @@ export default class Publish extends Command {
         commitHash: string;
       }[]
     ).filter(u => {
-      return u.updateUUID !== 'Rollback to embedded' && u.platform === platform;
+      return (
+        u.updateUUID !== 'Rollback to embedded' && (platform === 'all' || u.platform === platform)
+      );
     });
     const selectedUpdated = await promptAsync({
       type: 'select',
@@ -141,7 +143,7 @@ export default class Publish extends Command {
     });
     Log.log(`Re-publishing update: ${selectedUpdated.update.updateUUID}`);
     const republishUrl = new URL(`${baseUrl}/republish/${branch}`);
-    republishUrl.searchParams.set('platform', platform);
+    republishUrl.searchParams.set('platform', selectedUpdated.update.platform);
     republishUrl.searchParams.set('runtimeVersion', selectedRuntimeVersion.runtimeVersion);
     republishUrl.searchParams.set('updateId', selectedUpdated.update.updateId);
     republishUrl.searchParams.set('commitHash', selectedUpdated.update.commitHash);

--- a/apps/eoas/src/commands/republish.ts
+++ b/apps/eoas/src/commands/republish.ts
@@ -131,6 +131,12 @@ export default class Publish extends Command {
         u.updateUUID !== 'Rollback to embedded' && (platform === 'all' || u.platform === platform)
       );
     });
+    if (updates.length === 0) {
+      Log.error(
+        `No republishable updates found for runtime version ${selectedRuntimeVersion.runtimeVersion} on platform ${platform}.`
+      );
+      process.exit(1);
+    }
     const selectedUpdated = await promptAsync({
       type: 'select',
       name: 'update',

--- a/apps/eoas/src/commands/republish.ts
+++ b/apps/eoas/src/commands/republish.ts
@@ -21,7 +21,7 @@ export default class Publish extends Command {
     }),
     platform: Flags.string({
       type: 'option',
-      options: ['ios', 'android'],
+      options: ['ios', 'android', 'all'],
       default: 'all',
       required: true,
     }),


### PR DESCRIPTION
## Problem

The `eoas` CLI `republish` command currently only works when specifying a platform.
```bash
npx eoas republish --branch <branch-name> [--platform <platform>]
```
This indicates that `--platform` is optional, but that currently doesn't work.

```typescript
const updates = (
  (await updatesResponse.json()) as {
    ...
  }[]
).filter(u => {
  return u.updateUUID !== 'Rollback to embedded' && u.platform === platform;
});
```

When no platform is specified it defaults to `all`. But when filtering updates with `all`, all selectable updates will be filtered out. Which results in the command exiting.

---

When posting the republish to the server the user-specified platform is send along. 
```typescript
republishUrl.searchParams.set('platform', platform);
```
This will be `all` when `--platform` is unspecified. Causing the request to fail.
```go
if platform == "" || (platform != "ios" && platform != "android") {
      log.Printf("[RequestID: %s] Invalid platform: %s", requestID, platform)
      http.Error(w, "Invalid platform", http.StatusBadRequest)
      return
}
```

## Fix

Allow all when filtering selectable updates.

```typescript
const updates = (
  (await updatesResponse.json()) as {
    ...
  }[]
).filter(u => {
  u.updateUUID !== 'Rollback to embedded' && (platform === 'all' || u.platform === platform)
});
```

---

Use the platform of the selected update in the response.
```typescript
republishUrl.searchParams.set('platform', selectedUpdated.update.platform);
```