### PR TITLE
feat: add support for generic s3 cdn domain

### DIFF
--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -165,6 +165,7 @@ export class ApiClient {
       AWS_REGION: string;
       AWS_BASE_ENDPOINT: string;
       AWS_ACCESS_KEY_ID: string;
+      S3_CDN_PREFIX: string;
       CLOUDFRONT_DOMAIN: string;
       CLOUDFRONT_KEY_PAIR_ID: string;
       CLOUDFRONT_PRIVATE_KEY_B64: string;

--- a/apps/docs/docs/deployment/helm.mdx
+++ b/apps/docs/docs/deployment/helm.mdx
@@ -37,6 +37,8 @@ The environment variables used by the application depend on the following key se
   - If `true`, requires `CLOUDFRONT_DOMAIN`, `CLOUDFRONT_KEY_PAIR_ID`, and a CloudFront private key (`CLOUDFRONT_PRIVATE_KEY_B64`, `PRIVATE_CLOUDFRONT_KEY_PATH`, or `AWSSM_CLOUDFRONT_PRIVATE_KEY_SECRET_ID`, depending on `keysStorageType`).
 - **`useAWSAccessKeys`**:
   - If `true`, requires `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to be set.
+- **`useGenericCDN`**:
+  - If `true1, requires `S3_CDN_PREFIX` to be set.
 
 ### Deployment
 

--- a/apps/docs/docs/deployment/helm.mdx
+++ b/apps/docs/docs/deployment/helm.mdx
@@ -38,7 +38,7 @@ The environment variables used by the application depend on the following key se
 - **`useAWSAccessKeys`**:
   - If `true`, requires `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to be set.
 - **`useGenericCDN`**:
-  - If `true1, requires `S3_CDN_PREFIX` to be set.
+  - If `true`, requires `S3_CDN_PREFIX` to be set.
 
 ### Deployment
 

--- a/apps/docs/docs/reference/environment.mdx
+++ b/apps/docs/docs/reference/environment.mdx
@@ -43,7 +43,6 @@ You can set these variables in a `.env` file for local development or in your de
 | `STORAGE_MODE` | ✅ | `local`, `s3` or `gcs` | `local` | [Ref](/docs/server-configuration/storage) |
 | `S3_BUCKET_NAME` | ✅ if STORAGE_MODE = `s3` | S3 bucket name | `my-bucket` | [Ref](/docs/server-configuration/storage?storage=s3) |
 | `S3_KEY_PREFIX` | ❌ | Key prefix for namespacing inside a shared bucket (multi-app) | `myapp/` | [Ref](/docs/server-configuration/storage?storage=s3) |
-| `S3_CDN_PREFIX` | ❌ | CDN domain prefix for S3 assets | `https://cdn.example.com` | [Ref](/docs/server-configuration/storage?storage=s3) |
 | `GCS_BUCKET_NAME` | ✅ if STORAGE_MODE = `gcs` | GCS bucket name | `my-bucket` | [Ref](/docs/server-configuration/storage?storage=gcs) |
 | `GOOGLE_APPLICATION_CREDENTIALS_B64` | ✅ if STORAGE_MODE = `gcs` (for signed URLs) | Base64-encoded service account JSON | `Base64 string` | [Ref](/docs/server-configuration/storage?storage=gcs) |
 | `LOCAL_BUCKET_BASE_PATH` | ✅ if STORAGE_MODE = `local` | Path to store assets | `/path/to/assets` | [Ref](/docs/server-configuration/storage?storage=local) |
@@ -87,6 +86,11 @@ You can set these variables in a `.env` file for local development or in your de
 | `CLOUDFRONT_PRIVATE_KEY_B64` | ✅ if using `environment` & CLOUDFRONT_DOMAIN is set | Base64 CloudFront private key | `Base64 string` | [Ref](/docs/server-configuration/cdn/cloudfront) |
 | `AWSSM_CLOUDFRONT_PRIVATE_KEY_SECRET_ID` | ✅ if using `aws-secrets-manager` & CLOUDFRONT_DOMAIN is set | CloudFront private key in AWS Secrets Manager | `my-cloudfront-private-key` | [Ref](/docs/server-configuration/cdn/cloudfront) |
 | `PRIVATE_LOCAL_CLOUDFRONT_KEY_PATH` | ✅ if using `local` & CLOUDFRONT_DOMAIN is set | Path to CloudFront private key | `/path/to/cloudfront-private-key.pem` | [Ref](/docs/server-configuration/cdn/cloudfront) |
+
+#### **Generic CDN Settings**
+| Name | Required | Description | Example | Reference |
+| --- | --- | --- | --- | --- |
+| `S3_CDN_PREFIX` | ❌ | CDN domain prefix for S3 assets | `https://cdn.example.com` | [Ref](/docs/server-configuration/cdn/generic) |
 
 #### **Prometheus Configuration**
 | Name | Required | Description | Example | Reference |

--- a/apps/docs/docs/reference/environment.mdx
+++ b/apps/docs/docs/reference/environment.mdx
@@ -43,6 +43,7 @@ You can set these variables in a `.env` file for local development or in your de
 | `STORAGE_MODE` | ✅ | `local`, `s3` or `gcs` | `local` | [Ref](/docs/server-configuration/storage) |
 | `S3_BUCKET_NAME` | ✅ if STORAGE_MODE = `s3` | S3 bucket name | `my-bucket` | [Ref](/docs/server-configuration/storage?storage=s3) |
 | `S3_KEY_PREFIX` | ❌ | Key prefix for namespacing inside a shared bucket (multi-app) | `myapp/` | [Ref](/docs/server-configuration/storage?storage=s3) |
+| `S3_CDN_PREFIX` | ❌ | CDN domain prefix for S3 assets | `https://cdn.example.com` | [Ref](/docs/server-configuration/storage?storage=s3) |
 | `GCS_BUCKET_NAME` | ✅ if STORAGE_MODE = `gcs` | GCS bucket name | `my-bucket` | [Ref](/docs/server-configuration/storage?storage=gcs) |
 | `GOOGLE_APPLICATION_CREDENTIALS_B64` | ✅ if STORAGE_MODE = `gcs` (for signed URLs) | Base64-encoded service account JSON | `Base64 string` | [Ref](/docs/server-configuration/storage?storage=gcs) |
 | `LOCAL_BUCKET_BASE_PATH` | ✅ if STORAGE_MODE = `local` | Path to store assets | `/path/to/assets` | [Ref](/docs/server-configuration/storage?storage=local) |

--- a/apps/docs/docs/server-configuration/cdn/generic.mdx
+++ b/apps/docs/docs/server-configuration/cdn/generic.mdx
@@ -12,7 +12,7 @@ The environment variables required for each CDN are listed below. You can set th
 
 :::warning
 
-The generic CDN feature currently only supports public endpoints (i.e. the resources served by CDN url must be accessible without any signature or token).
+The generic CDN feature currently only supports public endpoints (i.e. the resources served by CDN URL must be accessible without any signature or token).
 
 :::
 

--- a/apps/docs/docs/server-configuration/cdn/generic.mdx
+++ b/apps/docs/docs/server-configuration/cdn/generic.mdx
@@ -1,0 +1,31 @@
+---
+sidebar_position: 2
+---
+
+# Generic
+
+The generic CDN feature requires your storage mode to be set to `s3`. You can follow the [storage guide](/docs/server-configuration/storage) to set up your storage solution.
+
+:::note
+The environment variables required for each cdn are listed below, you can set them in a `.env` file in the root of the project or keep them in a safe place to prepare for deployment.
+:::
+
+:::warning
+
+The generic CDN feature currently only supports public endpoints (i.e. the resources served by CDN url must be accessible without any signature or token).
+
+:::
+
+## Configure environment variables
+
+Specify your CDN accelerated domain in `S3_CDN_PREFIX` variable.
+
+```bash title=".env"
+S3_CDN_PREFIX=https://cdn.example.com
+```
+
+If your CDN domain requires bucket name to be set, please specify it in the prefix manually.
+
+```bash title=".env"
+S3_CDN_PREFIX=https://cdn.example.com/my-bucket
+```

--- a/apps/docs/docs/server-configuration/cdn/generic.mdx
+++ b/apps/docs/docs/server-configuration/cdn/generic.mdx
@@ -7,7 +7,7 @@ sidebar_position: 2
 The generic CDN feature requires your storage mode to be set to `s3`. You can follow the [storage guide](/docs/server-configuration/storage) to set up your storage solution.
 
 :::note
-The environment variables required for each cdn are listed below, you can set them in a `.env` file in the root of the project or keep them in a safe place to prepare for deployment.
+The environment variables required for each CDN are listed below. You can set them in a `.env` file in the root of the project or keep them in a safe place to prepare for deployment.
 :::
 
 :::warning

--- a/apps/docs/docs/server-configuration/storage.mdx
+++ b/apps/docs/docs/server-configuration/storage.mdx
@@ -46,15 +46,6 @@ import TabItem from '@theme/TabItem';
     S3_BUCKET_NAME=your-bucket-name
     ```
 
-    **For S3-compatible object storage that supports custom CDN domains (e.g., Qiniu):**
-    ```bash title=".env"
-    STORAGE_MODE=s3
-    AWS_REGION=auto
-    AWS_BASE_ENDPOINT=https://account-id.r2.cloudflarestorage.com
-    S3_BUCKET_NAME=your-bucket-name
-    S3_CDN_PREFIX=https://cdn.example.com
-    ```
-
     If your are not using AWS IAM roles, you also need to set the following environment variables:
     ```bash title=".env"
     AWS_ACCESS_KEY_ID=your-access-key-id

--- a/apps/docs/docs/server-configuration/storage.mdx
+++ b/apps/docs/docs/server-configuration/storage.mdx
@@ -46,6 +46,15 @@ import TabItem from '@theme/TabItem';
     S3_BUCKET_NAME=your-bucket-name
     ```
 
+    **For S3-compatible object storage that supports custom CDN domains (e.g., Qiniu):**
+    ```bash title=".env"
+    STORAGE_MODE=s3
+    AWS_REGION=auto
+    AWS_BASE_ENDPOINT=https://account-id.r2.cloudflarestorage.com
+    S3_BUCKET_NAME=your-bucket-name
+    S3_CDN_PREFIX=https://cdn.example.com
+    ```
+
     If your are not using AWS IAM roles, you also need to set the following environment variables:
     ```bash title=".env"
     AWS_ACCESS_KEY_ID=your-access-key-id

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -28,6 +28,7 @@ storageMode: "s3"
 keysStorageType: "aws-secrets-manager"
 useCloudfrontRedirect: "false"
 useAWSAccessKeys: "false"
+useGenericCDN: "false"
 cacheMode: "redis"
 useDashboard: "false"
 useRedisTLS: "false"
@@ -114,6 +115,11 @@ environment:
   - name: "S3_KEY_PREFIX"
     value: ""
     required: false
+  - name: "S3_CDN_PREFIX"
+    value: ""
+    required:
+      - key: "useGenericCDN"
+        is: "true"
   - name: "LOCAL_BUCKET_BASE_PATH"
     value: ""
     required:

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -50,18 +50,6 @@ func getAssetMetadata(req AssetsRequest, returnAsset bool) (AssetsResponse, *typ
 		return AssetsResponse{StatusCode: http.StatusNotFound, Body: []byte("No update found")}, nil, "", nil
 	}
 
-	if !returnAsset {
-		headers := map[string]string{
-			"expo-protocol-version": "1",
-			"expo-sfv-version":      "0",
-			"Cache-Control":         "public, max-age=31536000",
-		}
-		return AssetsResponse{
-			StatusCode: http.StatusOK,
-			Headers:    headers,
-		}, nil, lastUpdate.UpdateId, nil
-	}
-
 	metadata, err := update.GetMetadata(*lastUpdate)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error getting metadata: %v", requestID, err)
@@ -86,6 +74,22 @@ func getAssetMetadata(req AssetsRequest, returnAsset bool) (AssetsResponse, *typ
 		if asset.Path == req.AssetName {
 			assetMetadata = asset
 		}
+	}
+
+	if !returnAsset {
+		if !isLaunchAsset && assetMetadata == (types.Asset{}) {
+			log.Printf("[RequestID: %s] Asset not found in metadata: %s", requestID, req.AssetName)
+			return AssetsResponse{StatusCode: http.StatusNotFound, Body: []byte("Asset not found")}, nil, "", nil
+		}
+		headers := map[string]string{
+			"expo-protocol-version": "1",
+			"expo-sfv-version":      "0",
+			"Cache-Control":         "public, max-age=31536000",
+		}
+		return AssetsResponse{
+			StatusCode: http.StatusOK,
+			Headers:    headers,
+		}, nil, lastUpdate.UpdateId, nil
 	}
 
 	resolvedBucket := bucket.GetBucket()

--- a/internal/cdn/cdn.go
+++ b/internal/cdn/cdn.go
@@ -22,6 +22,11 @@ func GetCDN() CDN {
 			gcsCDN := GCSDirectCDN{}
 			if (&gcsCDN).isCDNAvailable() {
 				cdnInstance = &gcsCDN
+			} else {
+				genericCDN := GenericCDN{}
+				if (&genericCDN).isCDNAvailable() {
+					cdnInstance = &genericCDN
+				}
 			}
 		}
 	})

--- a/internal/cdn/cdn_test.go
+++ b/internal/cdn/cdn_test.go
@@ -18,3 +18,17 @@ func TestGetCDNReturnsGCSDirectWhenGCSConfigured(t *testing2.T) {
 		t.Fatalf("expected *GCSDirectCDN, got %T", c)
 	}
 }
+
+func TestGetCDNReturnsGenericWhenGenericConfigured(t *testing2.T) {
+	os.Setenv("STORAGE_MODE", "s3")
+	os.Setenv("S3_BUCKET_NAME", "test-bucket")
+	os.Setenv("S3_CDN_PREFIX", "https://cdn.example.com")
+	ResetCDNInstance()
+	c := GetCDN()
+	if c == nil {
+		t.Fatalf("expected GenericCDN instance, got nil")
+	}
+	if _, ok := c.(*GenericCDN); !ok {
+		t.Fatalf("expected *GenericCDN, got %T", c)
+	}
+}

--- a/internal/cdn/generic.go
+++ b/internal/cdn/generic.go
@@ -1,0 +1,18 @@
+package cdn
+
+import (
+	"expo-open-ota/config"
+	"fmt"
+)
+
+type GenericCDN struct{}
+
+func (c *GenericCDN) isCDNAvailable() bool {
+	return config.GetEnv("STORAGE_MODE") == "s3" && config.GetEnv("S3_BUCKET_NAME") != "" && config.GetEnv("S3_CDN_PREFIX") != ""
+}
+
+func (c *GenericCDN) ComputeRedirectionURLForAsset(branch, runtimeVersion, updateId, asset string) (string, error) {
+	prefix := config.GetEnv("S3_CDN_PREFIX")
+	url := fmt.Sprintf("%s/%s/%s/%s/%s", prefix, branch, runtimeVersion, updateId, asset)
+	return url, nil
+}

--- a/internal/cdn/generic.go
+++ b/internal/cdn/generic.go
@@ -2,7 +2,7 @@ package cdn
 
 import (
 	"expo-open-ota/config"
-	"fmt"
+	"net/url"
 )
 
 type GenericCDN struct{}
@@ -13,6 +13,14 @@ func (c *GenericCDN) isCDNAvailable() bool {
 
 func (c *GenericCDN) ComputeRedirectionURLForAsset(branch, runtimeVersion, updateId, asset string) (string, error) {
 	prefix := config.GetEnv("S3_CDN_PREFIX")
-	url := fmt.Sprintf("%s/%s/%s/%s/%s", prefix, branch, runtimeVersion, updateId, asset)
-	return url, nil
+	keyPrefix := config.GetEnv("S3_KEY_PREFIX")
+	elems := []string{branch, runtimeVersion, updateId, asset}
+	if keyPrefix != "" {
+		elems = append([]string{keyPrefix}, elems...)
+	}
+	cdnUrl, err := url.JoinPath(prefix, elems...)
+	if err != nil {
+		return "", err
+	}
+	return cdnUrl, nil
 }

--- a/internal/handlers/assets_handler.go
+++ b/internal/handlers/assets_handler.go
@@ -57,5 +57,9 @@ func AssetsHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
+	if resp.StatusCode != http.StatusOK {
+		http.Error(w, string(resp.Body), resp.StatusCode)
+		return
+	}
 	http.Redirect(w, r, resp.URL, http.StatusFound)
 }

--- a/internal/handlers/dashboard_handler.go
+++ b/internal/handlers/dashboard_handler.go
@@ -11,11 +11,12 @@ import (
 	"expo-open-ota/internal/types"
 	update2 "expo-open-ota/internal/update"
 	"fmt"
-	"github.com/gorilla/mux"
 	"net/http"
 	"sort"
 	"strconv"
 	"time"
+
+	"github.com/gorilla/mux"
 )
 
 type BranchMapping struct {
@@ -60,6 +61,7 @@ type SettingsEnv struct {
 	REDIS_PORT                             string `json:"REDIS_PORT"`
 	STORAGE_MODE                           string `json:"STORAGE_MODE"`
 	S3_BUCKET_NAME                         string `json:"S3_BUCKET_NAME"`
+	S3_CDN_PREFIX                          string `json:"S3_CDN_PREFIX"`
 	LOCAL_BUCKET_BASE_PATH                 string `json:"LOCAL_BUCKET_BASE_PATH"`
 	KEYS_STORAGE_TYPE                      string `json:"KEYS_STORAGE_TYPE"`
 	AWSSM_EXPO_PUBLIC_KEY_SECRET_ID        string `json:"AWSSM_EXPO_PUBLIC_KEY_SECRET_ID"`
@@ -99,6 +101,7 @@ func GetSettingsHandler(w http.ResponseWriter, r *http.Request) {
 		REDIS_PORT:                             config.GetEnv("REDIS_PORT"),
 		STORAGE_MODE:                           config.GetEnv("STORAGE_MODE"),
 		S3_BUCKET_NAME:                         config.GetEnv("S3_BUCKET_NAME"),
+		S3_CDN_PREFIX:                          config.GetEnv("S3_CDN_PREFIX"),
 		LOCAL_BUCKET_BASE_PATH:                 config.GetEnv("LOCAL_BUCKET_BASE_PATH"),
 		KEYS_STORAGE_TYPE:                      config.GetEnv("KEYS_STORAGE_TYPE"),
 		AWSSM_EXPO_PUBLIC_KEY_SECRET_ID:        config.GetEnv("AWSSM_EXPO_PUBLIC_KEY_SECRET_ID"),

--- a/test/assets_test.go
+++ b/test/assets_test.go
@@ -334,7 +334,7 @@ func TestAutomaticUrlRedirectionIfCDNIsSet(t *testing.T) {
 	os.Setenv("CLOUDFRONT_KEY_PAIR_ID", "test")
 
 	mockWorkingExpoResponse("staging")
-	url, _ := update.BuildFinalManifestAssetUrlURL("http://localhost:3000", "bundles/ios-9d01842d6ee1224f7188971c5d397115.js", "1", "android", "staging")
+	url, _ := update.BuildFinalManifestAssetUrlURL("http://localhost:3000", "bundles/android-82adadb1fb6e489d04ad95fd79670deb.js", "1", "android", "staging")
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", url, nil)
 	r.Header.Set("Accept-Encoding", "gzip")
@@ -343,6 +343,25 @@ func TestAutomaticUrlRedirectionIfCDNIsSet(t *testing.T) {
 	handlers.AssetsHandler(w, r)
 
 	assert.Equal(t, 302, w.Code, "Expected status code 302")
+}
+
+func TestPathTraversalRejectedForCDNAsset(t *testing.T) {
+	teardown := setup(t)
+	defer teardown()
+	mockWorkingExpoResponse("staging")
+	os.Setenv("S3_CDN_PREFIX", "https://cdn.example.com")
+	defer os.Unsetenv("S3_CDN_PREFIX")
+	request := assets.AssetsRequest{
+		Branch:         "branch-1",
+		AssetName:      "../../etc/passwd",
+		RuntimeVersion: "1",
+		Platform:       "android",
+		RequestID:      "test",
+	}
+	response, err := assets.HandleAssetsWithURL(request, &cdn.GenericCDN{})
+	assert.Nil(t, err)
+	assert.Equal(t, 404, response.StatusCode)
+	assert.Empty(t, response.URL)
 }
 
 func TestPreventCDNRedirectionHeader(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR implemented a new CDN provider, `GenericCDN`, to allow custom url prefix for assets stored in s3. By replacing the redirect url prefix to a custom `S3_CDN_PREFIX` env var, users can specify their own CDN domain for asset downloads.

### Motivation

Some S3-compatible storage providers (like Qiniu Cloud) supports custom CDN domains for file access. However, they doesn't follow Cloudfront compatible APIs, making it hard to configure this type of CDN domain in `expo-open-ota`.

### Changes

**`internal/cdn/generic.go`**
- Implements the `GenericCDN` provider
- Detect availability by probing whether `STORAGE_MODE` is set to be `s3`, whether `S3_BUCKET_NAME` and `S3_CDN_PREFIX` are set.

**`internal/cdn/cdn.go`**
- Added `GenericCDN` detecting and implementing logic in `GetCDN` function.

**`apps/dashboard/src/lib/api.ts`**
- Added display for `S3_CDN_PREFIX` environment variable.

**`apps/docs/docs/deployment/helm.mdx` and `helm/values.yaml`**
- Added configure for generic CDN in helm chart

**`apps/docs/docs/reference/environment.mdx` and `apps/docs/docs/server-configuration/cdn/generic.mdx`**
- Added documentation for usage of generic CDN provider

### New Environment Variables

| Variable | Required | Description |
|----------|----------|-------------|
| `S3_CDN_PREFIX` | Optional | CDN domain prefix for S3 assets |

### Example Configuration

```
S3_CDN_PREFIX=https://cdn.example.com
```

Asset download url becomes: `https://cdn.example.com/{branch}/{runtimeVersion}/{timestamp}/{asset}`

### Backward Compatible

Fully backward compatible. When `S3_CDN_PREFIX` is not set or empty, all asset urls remain unchanged.