### PR TITLE
feat(eoas): add --dumpSourcemap flag to publish command

### DIFF
--- a/apps/docs/docs/eoas/publish.mdx
+++ b/apps/docs/docs/eoas/publish.mdx
@@ -14,7 +14,7 @@ It supports the fingerprint policy.
 To publish an update, run the following command in your Expo project:
 
 ```bash
-npx eoas publish --branch <branch-name> [--nonInteractive] [--outputDir <outputDir>] [--platform <platform>] [--packageRunner <runner>] [--message <message>]
+npx eoas publish --branch <branch-name> [--nonInteractive] [--outputDir <outputDir>] [--platform <platform>] [--packageRunner <runner>] [--message <message>] [--dumpSourcemap]
 ```
 
 This command will retrieve the expo credentials from your .expo/state.json file or an EXPO_TOKEN in your runtime environment to authenticate
@@ -65,6 +65,16 @@ npx eoas publish --branch production --packageRunner bunx
 # Via environment variable
 EOAS_PACKAGE_RUNNER=bunx eoas publish --branch production
 ```
+
+## Source maps
+
+Pass `--dumpSourcemap` to emit Hermes source maps alongside the bundle in the output directory. This forwards `--dump-sourcemap` to the underlying `expo export` call.
+
+```bash
+npx eoas publish --branch production --dumpSourcemap
+```
+
+The source maps land next to each platform's bundle (e.g. `dist/_expo/static/js/ios/*.map`) and are not uploaded to the OTA server. They can be uploaded to a symbolication service like Sentry or PostHog from the same `dist/` directory, guaranteeing the source maps match the bundle that was published.
 
 ## CI/CD
 

--- a/apps/eoas/src/commands/publish.ts
+++ b/apps/eoas/src/commands/publish.ts
@@ -73,6 +73,11 @@ export default class Publish extends Command {
         'A short message describing the update. Defaults to the latest git commit message.',
       required: false,
     }),
+    dumpSourcemap: Flags.boolean({
+      description:
+        'Emit Hermes source maps alongside the bundle so the published artifact can be symbolicated by tools like Sentry or PostHog.',
+      default: false,
+    }),
   };
   private sanitizeFlags(flags: any): {
     platform: RequestedPlatform;
@@ -83,6 +88,7 @@ export default class Publish extends Command {
     packageRunner: string;
     providedDeprecatedChannel?: string;
     message?: string;
+    dumpSourcemap: boolean;
   } {
     return {
       disableRepositoryCheck: flags.disableRepositoryCheck,
@@ -93,6 +99,7 @@ export default class Publish extends Command {
       packageRunner: resolvePackageRunner(flags.packageRunner, process.cwd()),
       providedDeprecatedChannel: flags.channel,
       message: flags.message,
+      dumpSourcemap: flags.dumpSourcemap,
     };
   }
   public async run(): Promise<void> {
@@ -112,6 +119,7 @@ export default class Publish extends Command {
       providedDeprecatedChannel,
       disableRepositoryCheck,
       message,
+      dumpSourcemap,
     } = this.sanitizeFlags(flags);
     if (!branch) {
       Log.error('Branch name is required');
@@ -220,7 +228,8 @@ export default class Publish extends Command {
     const exportSpinner = ora('📦 Exporting project files...').start();
     try {
       const specifiedPlatform = platform === RequestedPlatform.All ? [] : ['--platform', platform];
-      const { stdout } = await spawnAsync(packageRunner, ['expo', 'export', '--output-dir', outputDir, ...specifiedPlatform], {
+      const sourcemapArgs = dumpSourcemap ? ['--dump-sourcemap'] : [];
+      const { stdout } = await spawnAsync(packageRunner, ['expo', 'export', '--output-dir', outputDir, ...sourcemapArgs, ...specifiedPlatform], {
         cwd: projectDir,
         env: {
           ...process.env,


### PR DESCRIPTION
## Summary

Adds a `--dumpSourcemap` boolean flag to `eoas publish` that forwards `--dump-sourcemap` to the internal `expo export` call. When set, Hermes source maps are emitted alongside the bundle in the output directory (e.g. `dist/_expo/static/js/ios/*.hbc.map`).

## Why

Today there is no first-class way to get source maps for a published bundle. The workaround is to run a second `expo export --dump-sourcemap` after `eoas publish` and upload those maps to a symbolication service (Sentry, PostHog, etc.).

That doesn't work in practice: `eoas publish` and a second `expo export` are two independent Metro runs. Their inputs differ (one is invoked with `--dump-sourcemap`, the other isn't; `eoas` sets `EXPO_NO_DOTENV=1`, the second invocation typically doesn't; the default platform set differs). Hermes derives chunk IDs from bundle bytes, so the chunk IDs in the published `.hbc` won't match the chunk IDs in the uploaded `.map`. Symbolication silently fails — the symbolication service accepts the maps and stack traces still come back minified.

With `--dumpSourcemap`, the same Metro run produces both the bundle that ships and the source maps that get uploaded, so chunk IDs line up.

## Notes

- Source maps are sidecar `.map` files and aren't listed in `metadata.json`, so they aren't uploaded to the OTA server by `computeFilesRequests` — this is purely a local artifact for downstream tools to consume.
- Default is `false` so existing users see no change.
- Docs updated at `apps/docs/docs/eoas/publish.mdx`.

## Test plan

- [x] Verified end-to-end against a real OTA server: with the flag set, `dist/_expo/static/js/{ios,android}/index-*.hbc.map` are produced alongside the `.hbc`, and the OTA upload step's file list still only contains the bundle + assets enumerated in `metadata.json`. No source maps are sent to the OTA server.
- [x] Verified the flag is opt-in: without it, behavior is identical to before.