### PR TITLE
fix: cache expo auth to prevent ENHANCE_YOUR_CALM rate limit (#58)

### DIFF
--- a/internal/services/expo.go
+++ b/internal/services/expo.go
@@ -258,6 +258,22 @@ func FetchExpoBranches() ([]string, error) {
 }
 
 func FetchExpoUserAccountInformations(expoAuth types.ExpoAuth) (*ExpoUserAccount, error) {
+	cache := cache2.GetCache()
+	var cacheKey string
+	if expoAuth.Token != nil {
+		cacheKey = fmt.Sprintf("expoUserAccount:token:%s", *expoAuth.Token)
+	} else if expoAuth.SessionSecret != nil {
+		cacheKey = fmt.Sprintf("expoUserAccount:session:%s", *expoAuth.SessionSecret)
+	}
+	if cacheKey != "" {
+		if cachedValue := cache.Get(cacheKey); cachedValue != "" {
+			var account ExpoUserAccount
+			if err := json.Unmarshal([]byte(cachedValue), &account); err == nil {
+				return &account, nil
+			}
+		}
+	}
+
 	query := `
 		query GetCurrentUserAccount {
 			me {
@@ -284,10 +300,22 @@ func FetchExpoUserAccountInformations(expoAuth types.ExpoAuth) (*ExpoUserAccount
 		return nil, err
 	}
 
+	if cacheKey != "" {
+		if cacheValue, err := json.Marshal(resp.Data.Me); err == nil {
+			ttl := 300
+			_ = cache.Set(cacheKey, string(cacheValue), &ttl)
+		}
+	}
+
 	return &resp.Data.Me, nil
 }
 
 func FetchSelfExpoUsername() string {
+	cache := cache2.GetCache()
+	cacheKey := fmt.Sprintf("selfExpoUsername:%s", version.Version)
+	if cachedValue := cache.Get(cacheKey); cachedValue != "" {
+		return cachedValue
+	}
 	token := GetExpoAccessToken()
 	expoAccount, err := FetchExpoUserAccountInformations(types.ExpoAuth{
 		Token: &token,
@@ -295,6 +323,8 @@ func FetchSelfExpoUsername() string {
 	if err != nil {
 		return ""
 	}
+	ttl := 86400
+	_ = cache.Set(cacheKey, expoAccount.Username, &ttl)
 	return expoAccount.Username
 }
 

--- a/internal/services/expo.go
+++ b/internal/services/expo.go
@@ -3,6 +3,7 @@ package services
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"expo-open-ota/config"
@@ -261,9 +262,11 @@ func FetchExpoUserAccountInformations(expoAuth types.ExpoAuth) (*ExpoUserAccount
 	cache := cache2.GetCache()
 	var cacheKey string
 	if expoAuth.Token != nil {
-		cacheKey = fmt.Sprintf("expoUserAccount:token:%s", *expoAuth.Token)
+		h := sha256.Sum256([]byte(*expoAuth.Token))
+		cacheKey = fmt.Sprintf("expoUserAccount:token:%x", h)
 	} else if expoAuth.SessionSecret != nil {
-		cacheKey = fmt.Sprintf("expoUserAccount:session:%s", *expoAuth.SessionSecret)
+		h := sha256.Sum256([]byte(*expoAuth.SessionSecret))
+		cacheKey = fmt.Sprintf("expoUserAccount:session:%x", h)
 	}
 	if cacheKey != "" {
 		if cachedValue := cache.Get(cacheKey); cachedValue != "" {

--- a/internal/services/expo.go
+++ b/internal/services/expo.go
@@ -315,11 +315,11 @@ func FetchExpoUserAccountInformations(expoAuth types.ExpoAuth) (*ExpoUserAccount
 
 func FetchSelfExpoUsername() string {
 	cache := cache2.GetCache()
-	cacheKey := fmt.Sprintf("selfExpoUsername:%s", version.Version)
+	token := GetExpoAccessToken()
+	cacheKey := fmt.Sprintf("selfExpoUsername:%s:%x", version.Version, sha256.Sum256([]byte(token)))
 	if cachedValue := cache.Get(cacheKey); cachedValue != "" {
 		return cachedValue
 	}
-	token := GetExpoAccessToken()
 	expoAccount, err := FetchExpoUserAccountInformations(types.ExpoAuth{
 		Token: &token,
 	})


### PR DESCRIPTION
Fixes #58

## Problem
`ValidateExpoAuth()` was making 2 GraphQL calls to api.expo.dev on 
every `/uploadLocalFile` request with no caching. With 527 assets, 
this results in 1054 rapid API calls, triggering Expo's rate limit.
## Fix
Applied the same caching pattern already used in `FetchExpoChannelMapping()` to:
- `FetchSelfExpoUsername()` — cached indefinitely (never changes at runtime)
- `FetchExpoUserAccountInformations()` — cached per token with a short TTL
## Testing
Verified fix resolves the rate-limit error with 527 assets on AWS EKS.