### PR TITLE
fix: send content-length in s3 object put for republish

### DIFF
--- a/internal/bucket/s3Bucket.go
+++ b/internal/bucket/s3Bucket.go
@@ -7,9 +7,6 @@ import (
 	"expo-open-ota/internal/services"
 	"expo-open-ota/internal/types"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
-	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"io"
 	"runtime"
 	"sort"
@@ -17,6 +14,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 type S3Bucket struct {
@@ -355,9 +356,10 @@ func (b *S3Bucket) CreateUpdateFrom(previousUpdate *types.Update, newUpdateId st
 				defer getObjOutput.Body.Close()
 
 				_, err = s3Client.PutObject(context.TODO(), &s3.PutObjectInput{
-					Bucket: aws.String(b.BucketName),
-					Key:    aws.String(dstKey),
-					Body:   getObjOutput.Body,
+					Bucket:        aws.String(b.BucketName),
+					Key:           aws.String(dstKey),
+					Body:          getObjOutput.Body,
+					ContentLength: getObjOutput.ContentLength,
 				})
 				if err != nil {
 					errChan <- fmt.Errorf("error putting object %s: %w", dstKey, err)


### PR DESCRIPTION
## Context

We were experiencing an issue using an S3 bucket as storage, specifically in the republish step.

The issue manifested as a hang during the republish, consistently.

After a bit of debugging it was attributed to the S3 bucket returning 501's for the PutObject requests, filling up the error channel, deadlocking.

We have tested this through a new built docker image with this fix and it no longer locked up.

## Description

- Added a Content-Length to the payload for the S3 bucket. Avoids the 501's

### Notes

- My understanding of go is limited, so please feel free to suggest other implementations, solutions and if the diagnostic is wrong
- Publish and Rollbacks were fine