### PR TITLE
Fix dashboard update count to include only valid updates(#63)

### DIFF
--- a/internal/bucket/gcsBucket.go
+++ b/internal/bucket/gcsBucket.go
@@ -114,6 +114,10 @@ func (b *GCSBucket) GetRuntimeVersions(branch string) ([]RuntimeVersionWithStats
                 continue
             }
             upd := strings.TrimSuffix(strings.TrimPrefix(uattrs.Prefix, rvPrefix), "/")
+            _, err = bh.Object(uattrs.Prefix + ".check").Attrs(ctx)
+            if err != nil {
+                continue
+            }
             ts, err := strconv.ParseInt(upd, 10, 64)
             if err == nil {
                 updateTimestamps = append(updateTimestamps, ts)

--- a/internal/bucket/localBucket.go
+++ b/internal/bucket/localBucket.go
@@ -164,6 +164,9 @@ func (b *LocalBucket) GetRuntimeVersions(branch string) ([]RuntimeVersionWithSta
 			if !update.IsDir() {
 				continue
 			}
+			if _, err := os.Stat(filepath.Join(updatesPath, update.Name(), ".check")); err != nil {
+				continue
+			}
 			timestamp, err := strconv.ParseInt(update.Name(), 10, 64)
 			if err != nil {
 				continue

--- a/internal/bucket/s3Bucket.go
+++ b/internal/bucket/s3Bucket.go
@@ -127,6 +127,13 @@ func (b *S3Bucket) GetRuntimeVersions(branch string) ([]RuntimeVersionWithStats,
 		var updateTimestamps []int64
 		for _, commonPrefix := range updateResp.CommonPrefixes {
 			updateID := strings.TrimSuffix((*commonPrefix.Prefix)[len(updatesPath):], "/")
+			_, err := s3Client.HeadObject(context.TODO(), &s3.HeadObjectInput{
+				Bucket: aws.String(b.BucketName),
+				Key:    aws.String(*commonPrefix.Prefix + ".check"),
+			})
+			if err != nil {
+				continue
+			}
 			timestamp, err := strconv.ParseInt(updateID, 10, 64)
 			if err != nil {
 				continue

--- a/test/dashboard_test.go
+++ b/test/dashboard_test.go
@@ -203,6 +203,25 @@ func TestRuntimeVersions(t *testing.T) {
 	assert.Equal(t, "[{\"runtimeVersion\":\"1\",\"lastUpdatedAt\":\"1970-01-20T09:02:50Z\",\"createdAt\":\"1970-01-20T09:02:50Z\",\"numberOfUpdates\":1}]", strings.TrimSpace(string(respRec.Body.Bytes())))
 }
 
+func TestRuntimeVersionsOnlyCountsValidUpdates(t *testing.T) {
+	teardown := setup(t)
+	defer teardown()
+	router := infrastructure.NewRouter()
+	respRec := httptest.NewRecorder()
+	httpmock.RegisterResponder("POST", "https://api.expo.dev/graphql",
+		func(req *http.Request) (*http.Response, error) {
+			return MockExpoBranchesMappingResponse([]map[string]interface{}{{"id": "branch-1", "name": "branch-1"}, {"id": "branch-2", "name": "branch-2"}}, []map[string]interface{}{{"id": "staging", "name": "staging", "branchMapping": "{\"data\":[{\"branchId\":\"branch-1\",\"branchMappingLogic\":\"true\"}],\"version\":0}"}})
+		})
+	req, _ := http.NewRequest("GET", "/api/branch/branch-4/runtimeVersions", nil)
+	req.Header.Set("Authorization", "Bearer "+login().Token)
+	router.ServeHTTP(respRec, req)
+	assert.Equal(t, http.StatusOK, respRec.Code)
+	var response []bucket.RuntimeVersionWithStats
+	err := json.Unmarshal(respRec.Body.Bytes(), &response)
+	assert.Nil(t, err)
+	assert.Equal(t, "[{\"runtimeVersion\":\"1\",\"lastUpdatedAt\":\"1970-01-20T09:02:50Z\",\"createdAt\":\"1970-01-20T09:02:50Z\",\"numberOfUpdates\":1}]", strings.TrimSpace(string(respRec.Body.Bytes())))
+}
+
 func TestUpdatesWithoutAuth(t *testing.T) {
 	teardown := setup(t)
 	defer teardown()


### PR DESCRIPTION
Fixes #63.

I originally reported this dashboard inconsistency after seeing it in a local Docker-based setup. Since the fix is small, I opened this PR with a minimal change.

The runtime version summary now only counts updates marked as valid with `.check`, matching the updates shown on the details page.

Tested with:

- `go test ./...`
- Local Docker verification with existing update data