### PR TITLE
feat: publish Helm chart as OCI artifact to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,9 +142,10 @@ jobs:
 
       - name: Compute release metadata
         run: |
-          IMAGE_TAG="${GITHUB_REF#refs/tags/}"
-          echo "CHART_VERSION=${IMAGE_TAG#v}" >> "$GITHUB_ENV"
-          echo "OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+IMAGE_TAG="${GITHUB_REF#refs/tags/}"
+OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+echo "CHART_VERSION=${IMAGE_TAG#v}" >> "$GITHUB_ENV"
+echo "OWNER=$OWNER" >> "$GITHUB_ENV"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,8 +74,30 @@ jobs:
       - name: Package Helm chart
         run: |
           IMAGE_TAG="${GITHUB_REF#refs/tags/}"
-          helm package ./helm -d ./charts
-          mv ./charts/expo-open-ota-*.tgz ./charts/expo-open-ota-helm-charts-${IMAGE_TAG}.tgz
+          CHART_VERSION="${IMAGE_TAG#v}"
+          helm package ./helm -d ./charts --version "$CHART_VERSION" --app-version "$IMAGE_TAG"
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push Helm chart to GHCR
+        run: |
+          IMAGE_TAG="${GITHUB_REF#refs/tags/}"
+          CHART_VERSION="${IMAGE_TAG#v}"
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          helm push "./charts/expo-open-ota-${CHART_VERSION}.tgz" "oci://ghcr.io/${OWNER}/charts"
+
+      - name: Rename chart archive for release assets
+        run: |
+          IMAGE_TAG="${GITHUB_REF#refs/tags/}"
+          CHART_VERSION="${IMAGE_TAG#v}"
+          mv "./charts/expo-open-ota-${CHART_VERSION}.tgz" "./charts/expo-open-ota-helm-charts-${IMAGE_TAG}.tgz"
+
+      - name: Upload chart artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: helm-chart
+          path: ./charts/*.tgz
 
   npm:
     runs-on: ubuntu-latest
@@ -112,6 +134,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Download chart artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: helm-chart
+          path: ./charts
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -120,6 +148,6 @@ jobs:
           body: |
             ## Changes
             - Docker image: `ghcr.io/${{ github.repository_owner }}/expo-open-ota:${{ github.ref_name }}`
-            - Helm chart version updated
+            - Helm chart: `oci://ghcr.io/${{ github.repository_owner }}/charts/expo-open-ota` (version `${{ github.ref_name }}` without the `v` prefix)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,10 +142,10 @@ jobs:
 
       - name: Compute release metadata
         run: |
-IMAGE_TAG="${GITHUB_REF#refs/tags/}"
-OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-echo "CHART_VERSION=${IMAGE_TAG#v}" >> "$GITHUB_ENV"
-echo "OWNER=$OWNER" >> "$GITHUB_ENV"
+          IMAGE_TAG="${GITHUB_REF#refs/tags/}"
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "CHART_VERSION=${IMAGE_TAG#v}" >> "$GITHUB_ENV"
+          echo "OWNER=$OWNER" >> "$GITHUB_ENV"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,12 @@ jobs:
           name: helm-chart
           path: ./charts
 
+      - name: Compute release metadata
+        run: |
+          IMAGE_TAG="${GITHUB_REF#refs/tags/}"
+          echo "CHART_VERSION=${IMAGE_TAG#v}" >> "$GITHUB_ENV"
+          echo "OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -148,6 +154,6 @@ jobs:
           body: |
             ## Changes
             - Docker image: `ghcr.io/${{ github.repository_owner }}/expo-open-ota:${{ github.ref_name }}`
-            - Helm chart: `oci://ghcr.io/${{ github.repository_owner }}/charts/expo-open-ota` (version `${{ github.ref_name }}` without the `v` prefix)
+            - Helm chart: `helm install expo-open-ota oci://ghcr.io/${{ env.OWNER }}/charts/expo-open-ota --version ${{ env.CHART_VERSION }}`
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/docs/docs/deployment/helm.mdx
+++ b/apps/docs/docs/deployment/helm.mdx
@@ -7,15 +7,24 @@ Deploy **Expo Open OTA** using Helm, a package manager for Kubernetes.
 A ready-to-use Helm chart is available to deploy **Expo Open OTA** on your Kubernetes cluster.
 
 ## Prerequisites
-A running Kubernetes cluster and Helm installed on your local machine are required to deploy the application.
+A running Kubernetes cluster and Helm (>= 3.8) installed on your local machine are required to deploy the application.
 If you are not familiar with Helm or Kubernetes, we recommend you to deploy the server with [custom docker deployment](/docs/deployment/custom) or [railway](/docs/deployment/railway).
 
-Clone the repository and navigate to the `helm` directory.
+## Installation
+
+The chart is published as an OCI artifact to the GitHub Container Registry alongside the Docker image, so there is no need to clone the repository:
 
 ```bash
-git clone https://github.com/axelmarciano/expo-open-ota
-cd expo-open-ota/helm
+helm install expo-open-ota oci://ghcr.io/axelmarciano/charts/expo-open-ota -n NAMESPACE
 ```
+
+To pin a specific version (chart versions follow the application releases, without the `v` prefix):
+
+```bash
+helm install expo-open-ota oci://ghcr.io/axelmarciano/charts/expo-open-ota --version 1.2.3 -n NAMESPACE
+```
+
+This also works with GitOps tools such as ArgoCD or Flux by referencing `oci://ghcr.io/axelmarciano/charts` as an OCI Helm repository.
 
 ## Configuration
 
@@ -42,22 +51,16 @@ The environment variables used by the application depend on the following key se
 
 ### Deployment
 
-To install the Helm chart with default values:
-
-```bash
-helm install expo-open-ota -n NAMESPACE ./chart
-```
-
 To override values, create a custom `my-values.yaml` file and run:
 
 ```bash
-helm install expo-open-ota ./chart -n NAMESPACE -f my-values.yaml
+helm install expo-open-ota oci://ghcr.io/axelmarciano/charts/expo-open-ota -n NAMESPACE -f my-values.yaml
 ```
 
 To upgrade an existing release:
 
 ```bash
-helm upgrade expo-open-ota -n NAMESPACE ./chart -f my-values.yaml
+helm upgrade expo-open-ota oci://ghcr.io/axelmarciano/charts/expo-open-ota -n NAMESPACE -f my-values.yaml
 ```
 
 For additional configuration details, refer to the [Environment Variables](/docs/reference/environment) documentation.

--- a/apps/docs/docs/deployment/helm.mdx
+++ b/apps/docs/docs/deployment/helm.mdx
@@ -12,13 +12,9 @@ If you are not familiar with Helm or Kubernetes, we recommend you to deploy the 
 
 ## Installation
 
-The chart is published as an OCI artifact to the GitHub Container Registry alongside the Docker image, so there is no need to clone the repository:
+The chart is published as an OCI artifact to the GitHub Container Registry alongside the Docker image, so there is no need to clone the repository.
 
-```bash
-helm install expo-open-ota oci://ghcr.io/axelmarciano/charts/expo-open-ota -n NAMESPACE
-```
-
-To pin a specific version (chart versions follow the application releases, without the `v` prefix):
+Chart versions follow the [application releases](https://github.com/axelmarciano/expo-open-ota/releases), without the `v` prefix (release `v1.2.3` → chart version `1.2.3`). Always pass an explicit `--version`:
 
 ```bash
 helm install expo-open-ota oci://ghcr.io/axelmarciano/charts/expo-open-ota --version 1.2.3 -n NAMESPACE
@@ -54,13 +50,13 @@ The environment variables used by the application depend on the following key se
 To override values, create a custom `my-values.yaml` file and run:
 
 ```bash
-helm install expo-open-ota oci://ghcr.io/axelmarciano/charts/expo-open-ota -n NAMESPACE -f my-values.yaml
+helm install expo-open-ota oci://ghcr.io/axelmarciano/charts/expo-open-ota --version 1.2.3 -n NAMESPACE -f my-values.yaml
 ```
 
 To upgrade an existing release:
 
 ```bash
-helm upgrade expo-open-ota oci://ghcr.io/axelmarciano/charts/expo-open-ota -n NAMESPACE -f my-values.yaml
+helm upgrade expo-open-ota oci://ghcr.io/axelmarciano/charts/expo-open-ota --version 1.2.3 -n NAMESPACE -f my-values.yaml
 ```
 
 For additional configuration details, refer to the [Environment Variables](/docs/reference/environment) documentation.


### PR DESCRIPTION
## Summary

Closes the feature request asking for the Helm chart to be published to a registry so GitOps users don't have to clone the repo.

- On each `v*` tag, the release workflow now pushes the packaged chart to `oci://ghcr.io/<owner>/charts/expo-open-ota` (chart version = release tag without the `v` prefix, `appVersion` = the tag). The `charts/` sub-namespace avoids colliding with the `expo-open-ota` container image package on GHCR.
- Users can now install with:
  ```bash
  helm install expo-open-ota oci://ghcr.io/axelmarciano/charts/expo-open-ota --version 1.2.3 -n NAMESPACE
  ```
  and reference the chart from ArgoCD/Flux as an OCI repository.
- Fixes a latent bug: the packaged chart `.tgz` was built in the `helm` job but referenced from the `github-release` job on a different runner, so it was never actually attached to releases. It is now passed via `upload-artifact`/`download-artifact`.
- Docs updated (`deployment/helm.mdx`) to use the OCI install instead of `git clone`.

## Post-merge note

⚠️ After the first release publishes the chart, the new `charts/expo-open-ota` GHCR package must be made **public** once in the GitHub package settings (new GHCR packages default to private), otherwise `helm install` will fail with an auth error for anonymous users.

## Test plan

- YAML validated locally.
- Real verification requires cutting a tag (e.g. a `-rc` pre-release) and running `helm install` from the published OCI ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)