### PR TITLE
perf(update): O(1) cold-miss scan in GetLatestUpdateBundlePathForRuntimeVersion

### DIFF
--- a/internal/update/updates.go
+++ b/internal/update/updates.go
@@ -199,24 +199,37 @@ func GetLatestUpdateBundlePathForRuntimeVersion(branch string, runtimeVersion st
 		}
 		return &update, nil
 	}
-	updates, err := GetAllUpdatesForRuntimeVersion(branch, runtimeVersion, platform)
+	// List the runtime's updates (the bucket derives CreatedAt from the updateId, so
+	// we can sort newest-first WITHOUT reading any per-update metadata) and scan once,
+	// reading update-metadata.json + .check only until the first update that matches
+	// the platform AND is valid. That update is the latest (newest-first order), so
+	// the result is identical to filtering+validating every update — but a cold cache
+	// miss now does O(1) bucket reads in the common case (newest update matches)
+	// instead of O(N) (N=82 for an active runtime). The previous code read metadata
+	// for every update (filterPlatformUpdates) AND .check for every update, so a
+	// foreground herd at the 1800s lastUpdate TTL expiry stampeded the origin.
+	resolvedBucket := bucket.GetBucket()
+	updates, err := resolvedBucket.GetUpdates(branch, runtimeVersion)
 	if err != nil {
 		return nil, err
 	}
-	filteredUpdates := make([]types.Update, 0)
-	for _, update := range updates {
-		if IsUpdateValid(update) {
-			filteredUpdates = append(filteredUpdates, update)
+	updates = sortUpdates(updates)
+	for i := range updates {
+		storedMetadata, metaErr := RetrieveUpdateStoredMetadata(updates[i])
+		if metaErr != nil || storedMetadata == nil || storedMetadata.Platform != platform {
+			continue
 		}
-	}
-	if len(filteredUpdates) > 0 {
-		cacheValue, err := json.Marshal(filteredUpdates[0])
-		if err != nil {
-			return &filteredUpdates[0], nil
+		if !IsUpdateValid(updates[i]) {
+			continue
+		}
+		latest := updates[i]
+		cacheValue, marshalErr := json.Marshal(latest)
+		if marshalErr != nil {
+			return &latest, nil
 		}
 		ttl := 1800
-		err = cache.Set(cacheKey, string(cacheValue), &ttl)
-		return &filteredUpdates[0], nil
+		_ = cache.Set(cacheKey, string(cacheValue), &ttl)
+		return &latest, nil
 	}
 	return nil, nil
 }


### PR DESCRIPTION
## Problem

On a cold `lastUpdate` cache miss, `GetLatestUpdateBundlePathForRuntimeVersion` resolves the latest update by reading `update-metadata.json` for **every** update of the runtime (`filterPlatformUpdates`) **and** `.check` for every update (`IsUpdateValid`) — O(N) bucket reads per miss, with no single-flight.

For an active runtime this stampedes the origin: we run expo-open-ota v2.3.19 in production for a football World Cup betting-pool app (~450k users, huge synchronized foreground herds at match whistles). Our main channel accumulated 84 updates, so each cold miss cost ~170 bucket reads (multi-second). At the 1800s TTL expiry — or right after a publish, which deletes the cache key — concurrent misses piled up recomputes: we measured bursts of **9.6k–20k ELB 504s** with tasks pegged at 100% CPU, and horizontal scaling (13 Fargate tasks) did not help because each request still cost O(N).

## Fix

The bucket layer already derives `CreatedAt` from the millisecond-timestamp update id with **zero** per-update metadata reads. So: list the runtime's updates, sort newest-first, and scan reading `update-metadata.json` + `.check` **only until the first update that matches the platform and is valid**. Newest-first order makes that update exactly the one the previous code returned (filter-all → sort → take first), so the result is identical — but the common case (newest update matches) is now O(1) bucket reads instead of O(N).

Error semantics preserved: `GetUpdates` errors propagate as before; per-update metadata errors skip the update exactly like `filterPlatformUpdates` did.

## Production results (v2.3.19 + this patch)

- The half-hourly 100%-CPU recompute spikes at the 1800s TTL expiry disappeared completely (30-min cycles now peak <2% CPU).
- Worst-case herd measured after the patch: **54,292 manifest requests / 5 min** → **~0 5xx** (16 across a 3.5h window) at **<7% peak CPU** on fewer tasks than before.
- Post-publish cache-flush storms (previously ~20k 504s/5min) no longer register.

## Testing

- `gofmt` clean on the touched file; `go build ./...`; `go vet ./...`
- `go test ./...` (all packages) and `go test ./test/ -count=3` green.

## Notes

A natural companion (not included) is single-flighting the recompute per cache key; with the O(1) scan the recompute is cheap enough that we no longer need it, but it would harden the worst case where many leading updates are invalid or wrong-platform.