### PR TITLE
fix: gate Expo auth on configuration and stop logging credentials

### DIFF
--- a/internal/middleware/auth_middleware.go
+++ b/internal/middleware/auth_middleware.go
@@ -4,7 +4,6 @@ import (
 	"expo-open-ota/internal/auth"
 	"expo-open-ota/internal/helpers"
 	"expo-open-ota/internal/services"
-	"fmt"
 	"net/http"
 )
 
@@ -12,11 +11,13 @@ func AuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		useExpoAuth := r.Header.Get("Use-Expo-Auth")
 		if useExpoAuth == "true" {
+			if services.GetExpoAccessToken() == "" {
+				http.Error(w, "Expo authentication is not enabled on this server", http.StatusUnauthorized)
+				return
+			}
 			expoAuth := helpers.GetExpoAuth(r)
-			fmt.Println(expoAuth)
 			_, err := services.ValidateExpoAuth(expoAuth)
 			if err != nil {
-				fmt.Println("lel", err)
 				http.Error(w, "Invalid Expo auth", http.StatusUnauthorized)
 				return
 			}

--- a/internal/middleware/auth_middleware_test.go
+++ b/internal/middleware/auth_middleware_test.go
@@ -1,0 +1,66 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"expo-open-ota/internal/auth"
+)
+
+func runAuthMiddleware(t *testing.T, configure func(r *http.Request)) *httptest.ResponseRecorder {
+	t.Helper()
+	handler := AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	r := httptest.NewRequest("POST", "/requestUploadUrl/branch", nil)
+	configure(r)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	return w
+}
+
+func TestAuthMiddleware(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret")
+	t.Setenv("ADMIN_PASSWORD", "test-password")
+
+	t.Run("expo auth rejected when EXPO_ACCESS_TOKEN is not configured", func(t *testing.T) {
+		t.Setenv("EXPO_ACCESS_TOKEN", "")
+		w := runAuthMiddleware(t, func(r *http.Request) {
+			r.Header.Set("Use-Expo-Auth", "true")
+			r.Header.Set("Authorization", "Bearer some-expo-token")
+		})
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401 when expo auth is not enabled, got %d", w.Code)
+		}
+	})
+
+	t.Run("valid admin JWT is accepted", func(t *testing.T) {
+		resp, err := auth.NewAuth().LoginWithPassword("test-password")
+		if err != nil {
+			t.Fatalf("login failed: %v", err)
+		}
+		w := runAuthMiddleware(t, func(r *http.Request) {
+			r.Header.Set("Authorization", "Bearer "+resp.Token)
+		})
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200 with valid JWT, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid bearer token is rejected", func(t *testing.T) {
+		w := runAuthMiddleware(t, func(r *http.Request) {
+			r.Header.Set("Authorization", "Bearer not-a-jwt")
+		})
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401 with invalid token, got %d", w.Code)
+		}
+	})
+
+	t.Run("missing Authorization header is rejected", func(t *testing.T) {
+		w := runAuthMiddleware(t, func(r *http.Request) {})
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401 with no Authorization header, got %d", w.Code)
+		}
+	})
+}


### PR DESCRIPTION
## What

- Removes `fmt.Println(expoAuth)` in `AuthMiddleware` — it printed the caller's Expo credentials (token / session secret) to stdout on every `Use-Expo-Auth` request — along with a stray `fmt.Println("lel", err)` debug line.
- Gates the `Use-Expo-Auth` branch on `EXPO_ACCESS_TOKEN` being configured. Servers without an Expo integration now answer these requests with an explicit 401 instead of forwarding the caller's credentials to the Expo API. Deployments that configure `EXPO_ACCESS_TOKEN` are unaffected.

## Why

Credentials in stdout end up in log aggregation — that's a leak for anyone running this in production. We hit it while hardening our self-hosted deployment.

## Tests

Adds `internal/middleware/auth_middleware_test.go` covering: expo-auth rejected when unconfigured, valid admin JWT accepted, invalid bearer rejected, missing Authorization rejected. `go test ./...` green.