### PR TITLE
fix: run the runtime container as a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,11 @@ COPY updates ./updates
 RUN GOOS=linux GOARCH=${TARGETARCH} go build -o main ./cmd/api
 
 FROM alpine:latest
-RUN apk add --no-cache bash
+RUN apk add --no-cache bash && \
+    addgroup -S ota && adduser -S ota -G ota
 WORKDIR /app
 COPY --from=builder /app/main /app/main
 COPY --from=dashboard-builder /app/apps/dashboard/dist /app/apps/dashboard/dist
+USER ota
 EXPOSE 3000
 CMD ["/app/main"]


### PR DESCRIPTION
## What

Adds a dedicated system user (`ota`) to the runtime stage and sets `USER ota`. Build stages are unchanged.

## Why

Without a `USER` directive the server runs as root inside the container. It doesn't need to: it listens on an unprivileged port (3000), and runtime writes go to cloud storage (S3/GCS) or to a path the operator mounts (`LOCAL_BUCKET_BASE_PATH`).

Running as non-root matters for anyone deploying this in a hardened cluster: the image currently fails Kubernetes **restricted Pod Security Standards** (`runAsNonRoot`), OpenShift's default SCCs, and most container-security scanners' policies, forcing per-deployment overrides. With this change the stock image passes them, and a Helm `securityContext` (e.g. `runAsNonRoot: true`) works without a custom image. This also caps the blast radius of any future container escape or file-write vulnerability to an unprivileged user.

We hit this deploying to our EKS cluster, where non-root is enforced cluster-wide.

## Verification

- `docker run ... id` → `uid=100(ota) gid=101(ota)`
- Boots with `STORAGE_MODE=local` pointing at a writable mount: migrations apply, server starts, `/hc` → 200
- Port 3000 is >1024, so no capability needed to bind

🤖 Generated with [Claude Code](https://claude.com/claude-code)