### PR TITLE
fix: resolve pnpm projects to pnpm exec instead of the removed pnpx

### DIFF
--- a/apps/docs/docs/eoas/publish.mdx
+++ b/apps/docs/docs/eoas/publish.mdx
@@ -45,13 +45,13 @@ By default, EOAS uses `npx` to spawn Expo CLI commands (`expo export`, `expo con
 
 1. `--packageRunner` CLI flag
 2. `EOAS_PACKAGE_RUNNER` environment variable
-3. `packageManager` field in the nearest `package.json` (e.g. `"packageManager": "bun@1.3.6"` → `bunx`)
+3. `packageManager` field in the nearest `package.json` (e.g. `"packageManager": "bun@1.3.6"` → `bunx`, `"pnpm@9.0.0"` → `pnpm exec`)
 4. Falls back to `npx`
 
 | `packageManager` value | Resolved runner |
 | --- | --- |
 | `bun@x.x.x` | `bunx` |
-| `pnpm@x.x.x` | `pnpx` |
+| `pnpm@x.x.x` | `pnpm exec` |
 | `yarn@x.x.x` | `npx` |
 | `npm@x.x.x` | `npx` |
 

--- a/apps/eoas/src/commands/publish.ts
+++ b/apps/eoas/src/commands/publish.ts
@@ -18,7 +18,7 @@ import { fetchWithRetries } from '../lib/fetch';
 import Log from '../lib/log';
 import { ora } from '../lib/ora';
 import { isExpoInstalled } from '../lib/package';
-import { resolvePackageRunner } from '../lib/packageRunner';
+import { resolvePackageRunner, splitPackageRunner } from '../lib/packageRunner';
 import { confirmAsync } from '../lib/prompts';
 import { ensureRepoIsCleanAsync } from '../lib/repo';
 import { resolveRuntimeVersionAsync } from '../lib/runtimeVersion';
@@ -64,7 +64,7 @@ export default class Publish extends Command {
     }),
     packageRunner: Flags.string({
       description:
-        'Package runner to use for spawning Expo CLI commands (e.g. npx, bunx, pnpx). Can also be set via EOAS_PACKAGE_RUNNER env var. Defaults to npx.',
+        'Package runner to use for spawning Expo CLI commands (e.g. npx, bunx, "pnpm exec"). Can also be set via EOAS_PACKAGE_RUNNER env var. Defaults to npx.',
       required: false,
     }),
     message: Flags.string({
@@ -229,7 +229,8 @@ export default class Publish extends Command {
     try {
       const specifiedPlatform = platform === RequestedPlatform.All ? [] : ['--platform', platform];
       const sourcemapArgs = dumpSourcemap ? ['--dump-sourcemap'] : [];
-      const { stdout } = await spawnAsync(packageRunner, ['expo', 'export', '--output-dir', outputDir, ...sourcemapArgs, ...specifiedPlatform], {
+      const [runnerCommand, runnerArgs] = splitPackageRunner(packageRunner);
+      const { stdout } = await spawnAsync(runnerCommand, [...runnerArgs, 'expo', 'export', '--output-dir', outputDir, ...sourcemapArgs, ...specifiedPlatform], {
         cwd: projectDir,
         env: {
           ...process.env,

--- a/apps/eoas/src/lib/expoConfig.ts
+++ b/apps/eoas/src/lib/expoConfig.ts
@@ -9,7 +9,7 @@ import path from 'path';
 
 import Log from './log';
 import { isExpoInstalled } from './package';
-import { resolvePackageRunner } from './packageRunner';
+import { resolvePackageRunner, splitPackageRunner } from './packageRunner';
 
 export enum RequestedPlatform {
   Android = 'android',
@@ -53,10 +53,11 @@ async function getExpoConfigInternalAsync(
     let exp: ExpoConfig;
     if (isExpoInstalled(projectDir)) {
       const runner = resolvePackageRunner(opts.packageRunner, projectDir);
+      const [runnerCommand, runnerArgs] = splitPackageRunner(runner);
       try {
         const { stdout } = await spawnAsync(
-          runner,
-          ['expo', 'config', '--json', ...(opts.isPublicConfig ? ['--type', 'public'] : [])],
+          runnerCommand,
+          [...runnerArgs, 'expo', 'config', '--json', ...(opts.isPublicConfig ? ['--type', 'public'] : [])],
 
           {
             cwd: projectDir,

--- a/apps/eoas/src/lib/packageRunner.ts
+++ b/apps/eoas/src/lib/packageRunner.ts
@@ -3,19 +3,21 @@ import path from 'path';
 
 const DEFAULT_PACKAGE_RUNNER = 'npx';
 
-const VALID_RUNNER_RE = /^[a-zA-Z0-9._-]+$/;
+const VALID_RUNNER_RE = /^[a-zA-Z0-9._-]+( [a-zA-Z0-9._-]+)*$/;
 
 function assertValidRunner(value: string, source: string): void {
   if (!VALID_RUNNER_RE.test(value)) {
     throw new Error(
-      `Invalid package runner "${value}" (from ${source}). Expected a simple binary name like npx, bunx or pnpx.`
+      `Invalid package runner "${value}" (from ${source}). Expected a binary name with optional subcommands like npx, bunx or "pnpm exec".`
     );
   }
 }
 
 const PACKAGE_MANAGER_RUNNERS: Record<string, string> = {
   bun: 'bunx',
-  pnpm: 'pnpx',
+  // pnpm removed the `pnpx` binary in v7. `pnpm exec` runs the project-local
+  // Expo CLI with the same local-first semantics as npx and bunx.
+  pnpm: 'pnpm exec',
   yarn: 'npx',
   npm: 'npx',
 };
@@ -29,7 +31,8 @@ const PACKAGE_MANAGER_RUNNERS: Record<string, string> = {
  * 3. Inferred from packageManager field in package.json
  * 4. Falls back to 'npx'
  *
- * Supported values: npx, bunx, pnpx, or any other package runner binary.
+ * Supported values: npx, bunx, "pnpm exec", or any other package runner
+ * binary, optionally followed by subcommand words.
  */
 export function resolvePackageRunner(explicit?: string, projectDir?: string): string {
   if (explicit) {
@@ -74,4 +77,13 @@ function detectRunnerFromPackageJson(startDir: string): string | undefined {
   }
 
   return undefined;
+}
+
+/**
+ * Splits a resolved package runner into a spawnable command and its leading
+ * arguments (e.g. "pnpm exec" -> ['pnpm', ['exec']]).
+ */
+export function splitPackageRunner(runner: string): [string, string[]] {
+  const [command, ...args] = runner.split(' ');
+  return [command, args];
 }


### PR DESCRIPTION
## Problem

The automatic package runner detection maps `packageManager: pnpm@x` to `pnpx`, but pnpm removed the `pnpx` binary in v7 (2022). On any modern pnpm project, `eoas publish` fails at the first spawn:

```
Failed to read the app config from the project using "pnpx expo config" command: pnpx expo config --json exited with non-zero code: 1.
...
❌ Failed to export the project, Error: pnpx expo export --output-dir dist --dump-sourcemap exited with non-zero code: 1
```

`--packageRunner` / `EOAS_PACKAGE_RUNNER` can't work around it either, because the validation regex only accepts a single bare binary name, and pnpm's replacements are two words.

## Fix

- Map pnpm to `pnpm exec`, which runs the project-local Expo CLI with the same local-first semantics as `npx` and `bunx` (`pnpm dlx` would fetch from the registry instead of using the project's pinned `expo`, so `exec` is the correct equivalent).
- Support multi-word runners: the validation regex accepts space-separated words, and a small `splitPackageRunner` helper splits the resolved runner into command + leading args at both spawn sites (`expo config`, `expo export`).
- Update the `--packageRunner` flag description and the docs table in `eoas/publish.mdx`.

Backwards compatible: single-word runners (`npx`, `bunx`, or an explicit `pnpx` where it still exists) behave exactly as before.

## Verification

- `npm run build` (tsc) passes; `eslint` on the touched files reports the same pre-existing issues as `main` and nothing new.
- Reproduced the failure and verified the fix end to end against a real Expo SDK 56 app on pnpm 11 + a self-hosted expo-open-ota v2.3.19 server: with `pnpm exec` semantics the export (both platforms, `--dump-sourcemap`) and upload flow work.