### PR TITLE
fix: use a fresh reader for the PKCS#1 fallback in the CloudFront signer

### DIFF
--- a/internal/cdn/cloudfront.go
+++ b/internal/cdn/cloudfront.go
@@ -29,10 +29,12 @@ func (c *CloudfrontCDN) isCDNAvailable() bool {
 }
 
 func getSigner(key string) (crypto.Signer, error) {
-	reader := bytes.NewReader([]byte(key))
-	privateKey, err := sign.LoadPEMPrivKeyPKCS8AsSigner(reader)
+	privateKey, err := sign.LoadPEMPrivKeyPKCS8AsSigner(bytes.NewReader([]byte(key)))
 	if err != nil {
-		privateKey, err = sign.LoadPEMPrivKey(reader)
+		// A fresh reader is required: the failed PKCS#8 attempt above has
+		// already consumed the previous one, so reusing it would make this
+		// fallback always fail with "no valid PEM data provided".
+		privateKey, err = sign.LoadPEMPrivKey(bytes.NewReader([]byte(key)))
 		if err != nil {
 			return nil, fmt.Errorf("error parsing private key: %w", err)
 		}


### PR DESCRIPTION
## Problem

`getSigner` in `internal/cdn/cloudfront.go` passes the same `bytes.Reader` to `sign.LoadPEMPrivKeyPKCS8AsSigner` and then, when that fails, to the `sign.LoadPEMPrivKey` fallback. The first call consumes the reader to EOF, so the fallback always parses an empty stream and every non-PKCS#8 key fails with:

```
Error computing redirection URL: error parsing private key: error parsing private key: no valid PEM data provided
```

In practice this means CloudFront signing only works with PKCS#8 keys (`BEGIN PRIVATE KEY`); any PKCS#1 key (`BEGIN RSA PRIVATE KEY`, e.g. from `openssl genrsa` or Terraform's `tls_private_key.private_key_pem`) makes every `/assets` request return 500, even though the key is valid and the intended fallback exists precisely for that format.

Hit in production with a Terraform-provisioned key; confirmed by storing the same key as PKCS#8, which works.

## Fix

Give each parse attempt its own reader. `go build` and `go vet` pass on the package.