### PR TITLE
fix: tolerate scheme-less CLOUDFRONT_DOMAIN values

### DIFF
--- a/internal/cdn/cloudfront.go
+++ b/internal/cdn/cloudfront.go
@@ -7,14 +7,22 @@ import (
 	"expo-open-ota/config"
 	"expo-open-ota/internal/keyStore"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/feature/cloudfront/sign"
+	"strings"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/feature/cloudfront/sign"
 )
 
 type CloudfrontCDN struct{}
 
 func getCloudfrontDomain() string {
-	return config.GetEnv("CLOUDFRONT_DOMAIN")
+	domain := config.GetEnv("CLOUDFRONT_DOMAIN")
+	// The AWS SDK URL signer requires a scheme; tolerate the bare domain
+	// shown in the documentation examples.
+	if domain != "" && !strings.HasPrefix(domain, "http://") && !strings.HasPrefix(domain, "https://") {
+		domain = "https://" + domain
+	}
+	return domain
 }
 
 func getCloudfrontKeyPairId() string {


### PR DESCRIPTION
## Problem

The docs show `CLOUDFRONT_DOMAIN=your-cloudfront-domain` (bare hostname), but `ComputeRedirectionURLForAsset` concatenates that value with the asset path and passes it to the AWS SDK's CloudFront URL signer, which rejects scheme-less resources. Every `/assets` request then returns 500 with:

```
Error computing redirection URL: invalid URL, missing scheme and domain/path
```

Hit in production following the documented configuration (surfaced right after #77's key parsing was worked around, the two bugs mask each other).

## Fix

Normalize in `getCloudfrontDomain`: prepend `https://` when no scheme is present, keeping explicit `http(s)://` values untouched. This makes the documented bare-domain form work as written.

`go build` and `go vet` pass. Verified against a live deployment: with a scheme-qualified domain, `/assets` returns a correctly signed 302 and CloudFront serves the bundle.