### PR TITLE
fix: resolve asset branch from query param instead of channel header

### DIFF
--- a/internal/handlers/assets_handler.go
+++ b/internal/handlers/assets_handler.go
@@ -12,22 +12,31 @@ import (
 
 func AssetsHandler(w http.ResponseWriter, r *http.Request) {
 	requestID := uuid.New().String()
-	channelName := r.Header.Get("expo-channel-name")
 	preventCDNRedirection := r.Header.Get("prevent-cdn-redirection") == "true"
-	branchMap, err := services.FetchExpoChannelMapping(channelName)
-	if err != nil {
-		log.Printf("[RequestID: %s] Error fetching channel mapping: %v", requestID, err)
-		http.Error(w, "Error fetching channel mapping", http.StatusInternalServerError)
-		return
-	}
-	if branchMap == nil {
-		log.Printf("[RequestID: %s] No branch mapping found for channel: %s", requestID, channelName)
-		http.Error(w, "No branch mapping found", http.StatusNotFound)
-		return
+
+	// Asset URLs embed their branch directly as a query param (set by the
+	// manifest that referenced them) - the expo-updates client never sends
+	// expo-channel-name on asset requests, only on /manifest ones. Fall back
+	// to the channel-mapping lookup for callers that still rely on the header.
+	branch := r.URL.Query().Get("branch")
+	if branch == "" {
+		channelName := r.Header.Get("expo-channel-name")
+		branchMap, err := services.FetchExpoChannelMapping(channelName)
+		if err != nil {
+			log.Printf("[RequestID: %s] Error fetching channel mapping: %v", requestID, err)
+			http.Error(w, "Error fetching channel mapping", http.StatusInternalServerError)
+			return
+		}
+		if branchMap == nil {
+			log.Printf("[RequestID: %s] No branch mapping found for channel: %s", requestID, channelName)
+			http.Error(w, "No branch mapping found", http.StatusNotFound)
+			return
+		}
+		branch = branchMap.BranchName
 	}
 
 	req := assets.AssetsRequest{
-		Branch:         branchMap.BranchName,
+		Branch:         branch,
 		AssetName:      r.URL.Query().Get("asset"),
 		RuntimeVersion: r.URL.Query().Get("runtimeVersion"),
 		Platform:       r.URL.Query().Get("platform"),


### PR DESCRIPTION
## Summary

`AssetsHandler` resolves `branch` via the `expo-channel-name` header, but the expo-updates client only ever sends that header on `/manifest` requests. Asset downloads carry `branch` as a URL query param instead — the handler already reads `asset`, `runtimeVersion`, and `platform` from `r.URL.Query()` in the same function, just not `branch`. So `channelName` is always empty on real asset requests, `FetchExpoChannelMapping("")` fails, and every asset download 500s with `STORAGE_MODE=local`, unconditionally, for any app/channel.

This fix reads `branch` from the query string first (already present on every asset URL the server itself generates in the manifest), falling back to the existing channel-mapping lookup only if it's absent, for backward compatibility with any caller not passing `branch`.

Fixes #81

## Test plan

- [x] `go build ./...` succeeds
- [x] Full Docker image builds cleanly (Go binary + dashboard)
- [x] Reproduced the original bug against a live `STORAGE_MODE=local` deployment (manifest resolves and signs correctly, every asset URL 500s with "Error fetching channel mapping: unexpected end of JSON input"); confirmed the patched build's logic resolves branch from the query param the client actually sends