### PR TITLE
feat: implement readiness and liveness probes for bucket migration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# updates/ is the default LOCAL_BUCKET_BASE_PATH, so a dev machine accumulates
+# real update payloads there (hundreds of MB). None of it belongs in an image:
+# the server recreates the tree at runtime. The directory itself must survive
+# the exclusion because both Dockerfiles do `COPY updates ./updates`, which
+# fails outright when the path is absent from the context. Re-including the
+# tracked .keep files is what keeps it present but empty.
+updates/**
+!updates/.keep
+!updates/DO_NOT_USE/.keep

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -22,6 +22,7 @@ RUN go mod download
 # Copy the source from the current directory to the Working Directory inside the container
 COPY cmd ./cmd
 COPY internal ./internal
+COPY ee ./ee
 COPY keys ./keys
 COPY config ./config
 COPY updates ./updates

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"sync/atomic"
+	"time"
 
 	"github.com/gorilla/handlers"
 
@@ -50,6 +51,8 @@ func main() {
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			(*handler.Load()).ServeHTTP(w, r)
 		}),
+		ReadHeaderTimeout:  10 * time.Second,
+		IdleTimeout:        120 * time.Second,
 	}
 	// Bind the port before running migrations so /hc answers from the very
 	// first probe; ListenAndServe only returns on failure.

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -8,6 +8,7 @@ import (
 	infrastructure "expo-open-ota/internal/router"
 	"log"
 	"net/http"
+	"sync/atomic"
 
 	"github.com/gorilla/handlers"
 
@@ -19,21 +20,61 @@ func init() {
 	metrics.InitMetrics()
 }
 
+// bootHandler answers while the bucket migrations run, and splits the two probes
+// on purpose. /hc (liveness) is registered below and answers 200 throughout, so
+// the orchestrator does not kill a pod in the middle of a long migration.
+// /ready (readiness) is deliberately NOT registered: it falls into the catch-all
+// and answers 503 + Retry-After, which drops the pod from the Service endpoints
+// without killing it, so nothing is served from a half-migrated bucket. Every
+// other request gets that same 503. Once main swaps in the real router, /ready
+// answers 200 like /hc (see internal/router/router.go).
+func bootHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hc", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "15")
+		http.Error(w, "storage migration in progress, updates are on hold", http.StatusServiceUnavailable)
+	})
+	return mux
+}
+
 func main() {
-	bucketmigration.RunMigrationsWithLock()
+	var handler atomic.Pointer[http.Handler]
+	boot := bootHandler()
+	handler.Store(&boot)
+
+	server := &http.Server{
+		Addr: "0.0.0.0:" + config.GetPort(),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			(*handler.Load()).ServeHTTP(w, r)
+		}),
+	}
+	// Bind the port before running migrations so /hc answers from the very
+	// first probe; ListenAndServe only returns on failure.
+	go func() {
+		log.Fatalf("Server failed to start: %v", server.ListenAndServe())
+	}()
+	log.Println("Server is running on port " + config.GetPort())
+
+	// The lock is released on failure, so a crash-looping pod retries the
+	// migration on every boot instead of skipping it while the lock expires.
+	if err := bucketmigration.EnsureMigrations(); err != nil {
+		log.Fatalf("🚨 [BUCKET] %v", err)
+	}
 
 	container, cleanup := infrastructure.InitDependencies(context.Background())
 	defer cleanup()
 	router := infrastructure.NewRouter(container)
-	log.Println("Server is running on port " + config.GetPort())
 	corsOptions := handlers.CORS(
 		handlers.AllowedHeaders([]string{"Authorization", "Content-Type"}),
 		handlers.AllowedMethods([]string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"}),
 		handlers.AllowedOrigins([]string{"*"}),
 		handlers.AllowCredentials(),
 	)
-	err := http.ListenAndServe("0.0.0.0:"+config.GetPort(), corsOptions(router))
-	if err != nil {
-		log.Fatalf("Server failed to start: %v", err)
-	}
+	ready := http.Handler(corsOptions(router))
+	handler.Store(&ready)
+	log.Println("✅ Server is ready to serve traffic.")
+	select {}
 }

--- a/helm/helm_template_test.go
+++ b/helm/helm_template_test.go
@@ -63,7 +63,153 @@ func TestRedisSentinelModeRendersRedisAuthAndTLSEnvVars(t *testing.T) {
 	}
 }
 
-func deploymentEnvByName(t *testing.T, manifest []byte) map[string]map[string]any {
+// A control-plane deploy upgrading from v2 still needs the flat single-app
+// vars: the legacy import reads them to migrate the app into the database and
+// EXPO_APP_ID keeps serving v1 clients that send no expo-app-id header. They
+// must therefore render (as optional) even when controlPlane=true.
+func TestControlPlaneModeStillRendersLegacyFlatEnvVars(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm is not installed")
+	}
+
+	cmd := exec.Command(
+		"helm",
+		"template",
+		"expo-open-ota",
+		".",
+		"--set-string",
+		"controlPlane=true",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helm template failed: %v\n%s", err, out)
+	}
+
+	env := deploymentEnvByName(t, out)
+
+	for _, name := range []string{
+		"EXPO_APP_ID",
+		"EXPO_ACCESS_TOKEN",
+		"SKIP_LEGACY_APP_ID_FALLBACK",
+		// Default keysStorageType is aws-secrets-manager, so the matching
+		// key vars must be offered to the legacy import too.
+		"AWSSM_EXPO_PUBLIC_KEY_SECRET_ID",
+		"AWSSM_EXPO_PRIVATE_KEY_SECRET_ID",
+		"KEYS_STORAGE_TYPE",
+		"DB_URL",
+	} {
+		if _, ok := env[name]; !ok {
+			t.Fatalf("expected %s to be rendered in control-plane mode", name)
+		}
+	}
+
+	for _, name := range []string{
+		"EXPO_APP_ID",
+		"EXPO_ACCESS_TOKEN",
+		"SKIP_LEGACY_APP_ID_FALLBACK",
+		"AWSSM_EXPO_PUBLIC_KEY_SECRET_ID",
+		"AWSSM_EXPO_PRIVATE_KEY_SECRET_ID",
+	} {
+		if !secretKeyRefOptional(env[name]) {
+			t.Fatalf("expected %s to be optional in control-plane mode", name)
+		}
+	}
+
+	if secretKeyRefOptional(env["DB_URL"]) {
+		t.Fatal("expected DB_URL to be required in control-plane mode")
+	}
+
+	// Key vars of the non-selected storage modes stay hidden.
+	for _, name := range []string{
+		"PUBLIC_LOCAL_EXPO_KEY_PATH",
+		"PRIVATE_LOCAL_EXPO_KEY_PATH",
+		"PUBLIC_EXPO_KEY_B64",
+		"PRIVATE_EXPO_KEY_B64",
+	} {
+		if _, ok := env[name]; ok {
+			t.Fatalf("did not expect %s with keysStorageType=aws-secrets-manager", name)
+		}
+	}
+}
+
+func TestStatelessModeRequiresFlatEnvVars(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm is not installed")
+	}
+
+	cmd := exec.Command("helm", "template", "expo-open-ota", ".")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helm template failed: %v\n%s", err, out)
+	}
+
+	env := deploymentEnvByName(t, out)
+
+	for _, name := range []string{"EXPO_APP_ID", "EXPO_ACCESS_TOKEN"} {
+		if _, ok := env[name]; !ok {
+			t.Fatalf("expected %s to be rendered in stateless mode", name)
+		}
+		if secretKeyRefOptional(env[name]) {
+			t.Fatalf("expected %s to be required in stateless mode", name)
+		}
+	}
+}
+
+// Optional tuning vars carry `required: false` plus `enabled: true`; without
+// the latter the template renders nothing at all, which is how these vars
+// silently disappeared from deployments in the past.
+func TestOptionalTuningVarsAreRendered(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm is not installed")
+	}
+
+	cmd := exec.Command("helm", "template", "expo-open-ota", ".")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helm template failed: %v\n%s", err, out)
+	}
+
+	env := deploymentEnvByName(t, out)
+
+	for _, name := range []string{
+		"BUCKET_KEY_PREFIX",
+		"S3_KEY_PREFIX",
+		"AWS_BASE_ENDPOINT",
+		"AWS_S3_FORCE_PATH_STYLE",
+		"SKIP_LEGACY_APP_ID_FALLBACK",
+	} {
+		if !secretKeyRefOptional(env[name]) {
+			t.Fatalf("expected %s to be rendered as an optional secret key ref", name)
+		}
+	}
+}
+
+// Liveness must stay on /hc (green during long bucket migrations) while
+// readiness moves to /ready (red until the migrations are done), otherwise
+// the orchestrator either kills migrating pods or routes traffic to them.
+func TestProbePaths(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm is not installed")
+	}
+
+	cmd := exec.Command("helm", "template", "expo-open-ota", ".")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helm template failed: %v\n%s", err, out)
+	}
+
+	container := deploymentContainer(t, out)
+	liveness := asMap(t, asMap(t, container["livenessProbe"])["httpGet"])
+	readiness := asMap(t, asMap(t, container["readinessProbe"])["httpGet"])
+	if liveness["path"] != "/hc" {
+		t.Fatalf("expected livenessProbe on /hc, got %v", liveness["path"])
+	}
+	if readiness["path"] != "/ready" {
+		t.Fatalf("expected readinessProbe on /ready, got %v", readiness["path"])
+	}
+}
+
+func deploymentContainer(t *testing.T, manifest []byte) map[string]any {
 	t.Helper()
 
 	decoder := yaml.NewDecoder(bytes.NewReader(manifest))
@@ -79,24 +225,29 @@ func deploymentEnvByName(t *testing.T, manifest []byte) map[string]map[string]an
 		if doc["kind"] != "Deployment" {
 			continue
 		}
-
 		containers := asSlice(t, asMap(t, asMap(t, asMap(t, doc["spec"])["template"])["spec"])["containers"])
-		container := asMap(t, containers[0])
-		envList := asSlice(t, container["env"])
-		envByName := make(map[string]map[string]any, len(envList))
-		for _, envItem := range envList {
-			envMap := asMap(t, envItem)
-			name, ok := envMap["name"].(string)
-			if !ok {
-				t.Fatalf("env item is missing string name: %#v", envMap)
-			}
-			envByName[name] = envMap
-		}
-		return envByName
+		return asMap(t, containers[0])
 	}
 
 	t.Fatal("deployment manifest not found")
 	return nil
+}
+
+func deploymentEnvByName(t *testing.T, manifest []byte) map[string]map[string]any {
+	t.Helper()
+
+	container := deploymentContainer(t, manifest)
+	envList := asSlice(t, container["env"])
+	envByName := make(map[string]map[string]any, len(envList))
+	for _, envItem := range envList {
+		envMap := asMap(t, envItem)
+		name, ok := envMap["name"].(string)
+		if !ok {
+			t.Fatalf("env item is missing string name: %#v", envMap)
+		}
+		envByName[name] = envMap
+	}
+	return envByName
 }
 
 func secretKeyRefOptional(env map[string]any) bool {

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -35,13 +35,18 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: 3000
+          # /hc is liveness: it answers 200 as soon as the process is up, even
+          # while a bucket migration is still running, so the orchestrator
+          # never kills a pod in the middle of a long migration. /ready flips
+          # to 200 only once migrations are done and the real router is
+          # mounted, which is what keeps traffic away until then.
           livenessProbe:
             httpGet:
               path: /hc
               port: 3000
           readinessProbe:
             httpGet:
-              path: /hc
+              path: /ready
               port: 3000
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
@@ -72,15 +77,19 @@ spec:
               {{- end }}
               {{- $isEnabled = $isRequired }}
               {{- if hasKey $env "enabled" }}
-                {{- $isEnabled = true }}
-                {{- range $condition := $env.enabled }}
-                  {{- $keyValue := toString (index $.Values $condition.key) }}
-                  {{- if hasKey $condition "in" }}
-                    {{- if not (has $keyValue $condition.in) }}
+                {{- if eq (typeOf $env.enabled) "bool" }}
+                  {{- $isEnabled = $env.enabled }}
+                {{- else }}
+                  {{- $isEnabled = true }}
+                  {{- range $condition := $env.enabled }}
+                    {{- $keyValue := toString (index $.Values $condition.key) }}
+                    {{- if hasKey $condition "in" }}
+                      {{- if not (has $keyValue $condition.in) }}
+                        {{- $isEnabled = false }}
+                      {{- end }}
+                    {{- else if or (not $keyValue) (ne $keyValue (toString $condition.is)) }}
                       {{- $isEnabled = false }}
                     {{- end }}
-                  {{- else if or (not $keyValue) (ne $keyValue (toString $condition.is)) }}
-                    {{- $isEnabled = false }}
                   {{- end }}
                 {{- end }}
               {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -165,11 +165,16 @@ environment:
     required:
       - key: "storageMode"
         is: "s3"
+  # `required: false` alone never renders an env var (the template treats a
+  # non-required, non-enabled entry as disabled), so every optional var below
+  # also carries `enabled: true`.
   - name: "AWS_BASE_ENDPOINT"
     value: ""
+    enabled: true
     required: false
   - name: "AWS_S3_FORCE_PATH_STYLE"
     value: ""
+    enabled: true
     required: false
   - name: "S3_BUCKET_NAME"
     value: ""
@@ -178,10 +183,12 @@ environment:
         is: "s3"
   - name: "BUCKET_KEY_PREFIX"
     value: ""
+    enabled: true
     required: false
   # TODO: remove S3_KEY_PREFIX once users have migrated to BUCKET_KEY_PREFIX
   - name: "S3_KEY_PREFIX"
     value: ""
+    enabled: true
     required: false
   - name: "S3_CDN_PREFIX"
     value: ""
@@ -217,18 +224,26 @@ environment:
         is: "true"
       - key: "keysStorageType"
         is: "aws-secrets-manager"
-  # Per-app identity and signing keys for the single-app stateless mode. In
-  # control-plane mode (controlPlane="true") apps live in the database and are
-  # managed from the dashboard, so none of these flat vars are rendered — each
-  # ANDs its existing key-mode condition with `controlPlane=false`.
+  # Per-app identity and signing keys for the single-app stateless mode. They
+  # are REQUIRED when controlPlane="false", but still rendered (as optional)
+  # in control-plane mode: a v2 deploy upgrading into the control plane must
+  # keep them set so the one-shot legacy import can find the flat-env app,
+  # re-path its bucket data under the app id and seal its signing keys into
+  # the database, and so that v1 clients sending no expo-app-id header keep
+  # resolving to that app. Only a control plane created from scratch leaves
+  # them unset.
   - name: "KEYS_STORAGE_TYPE"
     key: "keysStorageType"
     computed: true
+    enabled: true
     required:
       - key: "controlPlane"
         is: "false"
   - name: "AWSSM_EXPO_PUBLIC_KEY_SECRET_ID"
     value: ""
+    enabled:
+      - key: "keysStorageType"
+        is: "aws-secrets-manager"
     required:
       - key: "controlPlane"
         is: "false"
@@ -236,6 +251,9 @@ environment:
         is: "aws-secrets-manager"
   - name: "AWSSM_EXPO_PRIVATE_KEY_SECRET_ID"
     value: ""
+    enabled:
+      - key: "keysStorageType"
+        is: "aws-secrets-manager"
     required:
       - key: "controlPlane"
         is: "false"
@@ -243,6 +261,9 @@ environment:
         is: "aws-secrets-manager"
   - name: "PUBLIC_LOCAL_EXPO_KEY_PATH"
     value: ""
+    enabled:
+      - key: "keysStorageType"
+        is: "local"
     required:
       - key: "controlPlane"
         is: "false"
@@ -250,6 +271,9 @@ environment:
         is: "local"
   - name: "PRIVATE_LOCAL_EXPO_KEY_PATH"
     value: ""
+    enabled:
+      - key: "keysStorageType"
+        is: "local"
     required:
       - key: "controlPlane"
         is: "false"
@@ -257,6 +281,9 @@ environment:
         is: "local"
   - name: "PUBLIC_EXPO_KEY_B64"
     value: ""
+    enabled:
+      - key: "keysStorageType"
+        is: "environment"
     required:
       - key: "controlPlane"
         is: "false"
@@ -264,6 +291,9 @@ environment:
         is: "environment"
   - name: "PRIVATE_EXPO_KEY_B64"
     value: ""
+    enabled:
+      - key: "keysStorageType"
+        is: "environment"
     required:
       - key: "controlPlane"
         is: "false"
@@ -289,16 +319,31 @@ environment:
     enabled:
       - key: "trustProxyHeaders"
         is: "true"
+  # EXPO_ACCESS_TOKEN and EXPO_APP_ID follow the same rule as the key vars
+  # above: required in stateless mode, still rendered (optional) in
+  # control-plane mode. EXPO_APP_ID in particular is what backward
+  # compatibility hangs on when upgrading a v2 deploy: it drives the bucket
+  # re-path, the legacy import into the database, and the fallback that keeps
+  # serving v1 clients whose requests carry no expo-app-id header.
   - name: "EXPO_ACCESS_TOKEN"
     value: ""
+    enabled: true
     required:
       - key: "controlPlane"
         is: "false"
   - name: "EXPO_APP_ID"
     value: ""
+    enabled: true
     required:
       - key: "controlPlane"
         is: "false"
+  # Once every client in the field ships the expo-app-id header (v2+ builds
+  # only), set to "true" to stop routing header-less requests to the legacy
+  # EXPO_APP_ID app.
+  - name: "SKIP_LEGACY_APP_ID_FALLBACK"
+    value: ""
+    enabled: true
+    required: false
   # Control Plane (DB mode). Rendered only when controlPlane="true". Set DB_URL
   # and the master key, whose source is picked by dbKeysMasterKeySource. The
   # master key seals per-app signing keys at rest — generate it with

--- a/internal/bucket/v2_migration.go
+++ b/internal/bucket/v2_migration.go
@@ -4,14 +4,18 @@ import (
 	"context"
 	"expo-open-ota/internal/providers/aws"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync/atomic"
 
 	"cloud.google.com/go/storage"
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/iterator"
 )
 
@@ -39,6 +43,34 @@ import (
 // here because the corruption it prevents is silent and unrecoverable,
 // not because it is expected to fire.
 var ErrAppIdCollidesWithV1Branch = fmt.Errorf("app id collides with a v1 branch of the same name; rename that branch in the bucket, then reboot to retry the migration")
+
+// migrationConcurrency is how many objects MoveRootEntriesUnder moves in
+// parallel on the remote backends, tunable with BUCKET_MIGRATION_CONCURRENCY.
+// Copy+delete is a pair of network round-trips per object, so the move is
+// latency-bound: the default cuts hours to minutes on large buckets while
+// staying far below S3/GCS per-prefix rate limits.
+func migrationConcurrency() int {
+	if v := os.Getenv("BUCKET_MIGRATION_CONCURRENCY"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+		log.Printf("⚠️ Ignoring invalid BUCKET_MIGRATION_CONCURRENCY=%q, using the default", v)
+	}
+	return 16
+}
+
+// moveProgress counts moved objects across workers and logs a heartbeat line
+// every 500 objects, so a long migration shows life in the pod logs instead
+// of going silent for its whole duration.
+type moveProgress struct {
+	moved atomic.Int64
+}
+
+func (p *moveProgress) tick() {
+	if n := p.moved.Add(1); n%500 == 0 {
+		log.Printf("🚚 [BUCKET] v1 re-path progress: %d objects moved...", n)
+	}
+}
 
 // MoveRootEntriesUnder walks the LocalBucket root and moves every
 // immediate child directory that LOOKS LIKE a v1 branch into
@@ -202,14 +234,52 @@ func (b *S3Bucket) MoveRootEntriesUnder(appId string) error {
 		return nil
 	}
 
+	progress := &moveProgress{}
+	moveKey := func(ctx context.Context, key string) error {
+		newKey := appPrefix + strings.TrimPrefix(key, b.KeyPrefix)
+
+		// CopySource is `bucket/key` with ONLY the key URL-escaped.
+		// url.PathEscape(bucket+"/"+key) would also escape the
+		// bucket/key separator, producing an invalid CopySource that
+		// S3 rejects with InvalidArgument.
+		source := b.BucketName + "/" + escapeKeyForCopySource(key)
+		if _, err := client.CopyObject(ctx, &s3.CopyObjectInput{
+			Bucket:     awssdk.String(b.BucketName),
+			CopySource: awssdk.String(source),
+			Key:        awssdk.String(newKey),
+		}); err != nil {
+			return fmt.Errorf("copy %s -> %s: %w", key, newKey, err)
+		}
+		if _, err := client.DeleteObject(ctx, &s3.DeleteObjectInput{
+			Bucket: awssdk.String(b.BucketName),
+			Key:    awssdk.String(key),
+		}); err != nil {
+			return fmt.Errorf("delete %s after copy: %w", key, err)
+		}
+		progress.tick()
+		return nil
+	}
+
+	// Pass 2 moves objects concurrently (the move is latency-bound, see
+	// migrationConcurrency), with one deliberate exception: marker files are
+	// collected and moved only after every other object has landed. The
+	// markers are what pass 1 uses to confirm a triple, so as long as a
+	// marker is still at the root, an interrupted run re-confirms its triple
+	// on retry and finishes the job. Moving markers alongside their siblings
+	// could strand assets at the root with nothing left to re-confirm them.
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(migrationConcurrency())
+	var markers []string
+	var listErr error
 	p2 := s3.NewListObjectsV2Paginator(client, &s3.ListObjectsV2Input{
 		Bucket: awssdk.String(b.BucketName),
 		Prefix: awssdk.String(b.KeyPrefix),
 	})
 	for p2.HasMorePages() {
-		page, err := p2.NextPage(ctx)
+		page, err := p2.NextPage(gctx)
 		if err != nil {
-			return fmt.Errorf("list objects: %w", err)
+			listErr = fmt.Errorf("list objects: %w", err)
+			break
 		}
 		for _, obj := range page.Contents {
 			key := *obj.Key
@@ -223,29 +293,28 @@ func (b *S3Bucket) MoveRootEntriesUnder(appId string) error {
 			if !inConfirmedTriple(relKey, confirmed) {
 				continue
 			}
-			newKey := appPrefix + relKey
-
-			// CopySource is `bucket/key` with ONLY the key URL-escaped.
-			// url.PathEscape(bucket+"/"+key) would also escape the
-			// bucket/key separator, producing an invalid CopySource that
-			// S3 rejects with InvalidArgument.
-			source := b.BucketName + "/" + escapeKeyForCopySource(key)
-			if _, err := client.CopyObject(ctx, &s3.CopyObjectInput{
-				Bucket:     awssdk.String(b.BucketName),
-				CopySource: awssdk.String(source),
-				Key:        awssdk.String(newKey),
-			}); err != nil {
-				return fmt.Errorf("copy %s -> %s: %w", key, newKey, err)
+			if _, isMarker := v1BranchTripleFromMarker(relKey); isMarker {
+				markers = append(markers, key)
+				continue
 			}
-			if _, err := client.DeleteObject(ctx, &s3.DeleteObjectInput{
-				Bucket: awssdk.String(b.BucketName),
-				Key:    awssdk.String(key),
-			}); err != nil {
-				return fmt.Errorf("delete %s after copy: %w", key, err)
-			}
+			g.Go(func() error { return moveKey(gctx, key) })
 		}
 	}
-	return nil
+	// A worker error cancels gctx, which also aborts the listing above; the
+	// worker error is the interesting one, so report it first.
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	if listErr != nil {
+		return listErr
+	}
+
+	gm, gmctx := errgroup.WithContext(ctx)
+	gm.SetLimit(migrationConcurrency())
+	for _, key := range markers {
+		gm.Go(func() error { return moveKey(gmctx, key) })
+	}
+	return gm.Wait()
 }
 
 // v1BranchTripleFromMarker returns (triple, true) iff relKey is exactly
@@ -348,14 +417,36 @@ func (b *GCSBucket) MoveRootEntriesUnder(appId string) error {
 		return nil
 	}
 
-	it2 := bh.Objects(ctx, &storage.Query{Prefix: b.KeyPrefix})
+	progress := &moveProgress{}
+	moveKey := func(ctx context.Context, key string) error {
+		newKey := appPrefix + strings.TrimPrefix(key, b.KeyPrefix)
+		src := bh.Object(key)
+		dst := bh.Object(newKey)
+		if _, err := dst.CopierFrom(src).Run(ctx); err != nil {
+			return fmt.Errorf("copy %s -> %s: %w", key, newKey, err)
+		}
+		if err := src.Delete(ctx); err != nil {
+			return fmt.Errorf("delete %s after copy: %w", key, err)
+		}
+		progress.tick()
+		return nil
+	}
+
+	// Same concurrent pass-2 strategy as S3, markers-last included; see the
+	// S3 implementation for the rationale.
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(migrationConcurrency())
+	var markers []string
+	var listErr error
+	it2 := bh.Objects(gctx, &storage.Query{Prefix: b.KeyPrefix})
 	for {
 		attrs, err := it2.Next()
 		if err == iterator.Done {
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("list objects: %w", err)
+			listErr = fmt.Errorf("list objects: %w", err)
+			break
 		}
 		key := attrs.Name
 		if strings.HasPrefix(key, appPrefix) {
@@ -368,18 +459,25 @@ func (b *GCSBucket) MoveRootEntriesUnder(appId string) error {
 		if !inConfirmedTriple(relKey, confirmed) {
 			continue
 		}
-		newKey := appPrefix + relKey
-
-		src := bh.Object(key)
-		dst := bh.Object(newKey)
-		if _, err := dst.CopierFrom(src).Run(ctx); err != nil {
-			return fmt.Errorf("copy %s -> %s: %w", key, newKey, err)
+		if _, isMarker := v1BranchTripleFromMarker(relKey); isMarker {
+			markers = append(markers, key)
+			continue
 		}
-		if err := src.Delete(ctx); err != nil {
-			return fmt.Errorf("delete %s after copy: %w", key, err)
-		}
+		g.Go(func() error { return moveKey(gctx, key) })
 	}
-	return nil
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	if listErr != nil {
+		return listErr
+	}
+
+	gm, gmctx := errgroup.WithContext(ctx)
+	gm.SetLimit(migrationConcurrency())
+	for _, key := range markers {
+		gm.Go(func() error { return moveKey(gmctx, key) })
+	}
+	return gm.Wait()
 }
 
 // UnwrapBucket returns the underlying concrete backend when b is a

--- a/internal/bucketmigration/runner.go
+++ b/internal/bucketmigration/runner.go
@@ -5,22 +5,49 @@ import (
 	"expo-open-ota/internal/cache"
 	"fmt"
 	"log"
+	"time"
 )
 
-func RunMigrations(b bucket.Bucket) error {
-	all := All()
+const (
+	lockKey = "migration-lock"
+	// The TTL only has to cover the gap between two renewals plus scheduling
+	// jitter: the holder renews the lock every lockRenewInterval for as long
+	// as a migration is running. A holder that dies stops renewing, so the
+	// lock frees itself within one TTL and a waiting replica picks the work
+	// up where the idempotent migration left off.
+	lockTTLSeconds    = 60
+	lockRenewInterval = 20 * time.Second
+	// How often waiting replicas re-read the migration history to see if the
+	// holder is done. One small bucket read per tick.
+	waitPollInterval = 5 * time.Second
+)
+
+// Pending returns the registered migrations that are not yet recorded in the
+// bucket's migration history, in application order.
+func Pending(b bucket.Bucket) ([]Migration, error) {
 	applied, err := b.RetrieveMigrationHistory()
 	if err != nil {
-		return fmt.Errorf("read history: %w", err)
+		return nil, fmt.Errorf("read history: %w", err)
 	}
-	appliedSet := make(map[string]bool)
+	appliedSet := make(map[string]bool, len(applied))
 	for _, id := range applied {
 		appliedSet[id] = true
 	}
-	for _, m := range all {
-		if appliedSet[m.ID()] {
-			continue
+	var pending []Migration
+	for _, m := range All() {
+		if !appliedSet[m.ID()] {
+			pending = append(pending, m)
 		}
+	}
+	return pending, nil
+}
+
+func RunMigrations(b bucket.Bucket) error {
+	pending, err := Pending(b)
+	if err != nil {
+		return err
+	}
+	for _, m := range pending {
 		fmt.Printf("🔼 Applying migration: %s\n", m.ID())
 		if err := m.Up(b); err != nil {
 			return fmt.Errorf("migration %s failed: %w", m.ID(), err)
@@ -59,21 +86,76 @@ func RollbackLastMigration(b bucket.Bucket) error {
 	return b.RemoveMigrationFromHistory(last)
 }
 
-func RunMigrationsWithLock() {
-	log.Println("🔧 [BUCKET] Checking if migrations should run...")
+// EnsureMigrations brings the bucket fully up to date before the caller starts
+// serving traffic. Exactly one instance applies the pending migrations, under
+// a cache lock it keeps renewing while the work runs; every other instance
+// waits here until the history shows nothing pending, instead of skipping
+// ahead and serving from a half-migrated bucket. The lock is always released
+// when the holder is done, on failure included, so a crashed attempt can be
+// retried by the very next boot instead of sitting out a stale lock.
+func EnsureMigrations() error {
 	b := bucket.GetBucket()
 	c := cache.GetCache()
-	ok, err := c.TryLock("migration-lock", 120)
+	waiting := false
+	for {
+		pending, err := Pending(b)
+		if err != nil {
+			return err
+		}
+		if len(pending) == 0 {
+			if waiting {
+				log.Println("✅ [BUCKET] Migrations finished on another instance, resuming boot.")
+			}
+			return nil
+		}
+		ok, err := c.TryLock(lockKey, lockTTLSeconds)
+		if err != nil {
+			return fmt.Errorf("acquire migration lock: %w", err)
+		}
+		if !ok {
+			if !waiting {
+				log.Printf("⏳ [BUCKET] %d migration(s) pending but another instance holds the lock. Holding boot until it finishes...", len(pending))
+				waiting = true
+			}
+			time.Sleep(waitPollInterval)
+			continue
+		}
+		log.Printf("✅ [BUCKET] Migration lock acquired, applying %d migration(s)...", len(pending))
+		if err := runWhileRenewingLock(b, c); err != nil {
+			return err
+		}
+		log.Println("🎉 [BUCKET] Migrations completed successfully.")
+		return nil
+	}
+}
+
+// runWhileRenewingLock runs the pending migrations while a background ticker
+// keeps the cache lock alive, then releases the lock whatever the outcome.
+func runWhileRenewingLock(b bucket.Bucket, c cache.Cache) error {
+	stopRenew := make(chan struct{})
+	renewDone := make(chan struct{})
+	go func() {
+		defer close(renewDone)
+		ticker := time.NewTicker(lockRenewInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopRenew:
+				return
+			case <-ticker.C:
+				ttl := lockTTLSeconds
+				if err := c.Set(lockKey, "locked", &ttl); err != nil {
+					log.Printf("⚠️ [BUCKET] Failed to renew the migration lock: %v", err)
+				}
+			}
+		}
+	}()
+	err := RunMigrations(b)
+	close(stopRenew)
+	<-renewDone
+	c.Delete(lockKey)
 	if err != nil {
-		log.Fatalf("❌ Failed to acquire migration lock: %v", err)
+		return fmt.Errorf("bucket migration failed: %w", err)
 	}
-	if !ok {
-		log.Println("⏩ [BUCKET] Migration already in progress or completed on another instance – skipping.")
-		return
-	}
-	log.Println("✅ [BUCKET] Migration lock acquired – starting migrations...")
-	if err := RunMigrations(b); err != nil {
-		log.Fatalf("🚨 [BUCKET] Migration failed: %v", err)
-	}
-	log.Println("🎉 [BUCKET] Migrations completed successfully.")
+	return nil
 }

--- a/internal/database/postgres/migrations/20260613110419_migrate_infra_to_db.go
+++ b/internal/database/postgres/migrations/20260613110419_migrate_infra_to_db.go
@@ -73,6 +73,20 @@ func sealLegacyKeysIntoDB(app config.AppConfig, params *pgdb.MigrateLegacyAppPar
 		return nil
 	}
 
+	// The migration reads the flat env without the full stateless-boot
+	// validation, so a control-plane pod whose deployment carries EXPO_APP_ID
+	// but not the key vars arrives here as mode=local (the KEYS_STORAGE_TYPE
+	// default) with empty paths. Name the real problem, missing env vars,
+	// instead of failing later with a generic unreadable-keys error.
+	structurallyEmpty := (app.Keys.Mode == config.KeysModeLocal && (app.Keys.PublicPath == "" || app.Keys.PrivatePath == "")) ||
+		(app.Keys.Mode == config.KeysModeEnvironment && (app.Keys.PublicB64 == "" || app.Keys.PrivateB64 == ""))
+	if structurallyEmpty {
+		return fmt.Errorf("app %q: the flat env resolves to keys mode=%s but its key env vars are empty. "+
+			"When upgrading into the control plane, keep the v2 key vars set (KEYS_STORAGE_TYPE and its mode-specific siblings) "+
+			"so the legacy app's signing keys can be sealed into the database, then retry the migration",
+			app.Id, app.Keys.Mode)
+	}
+
 	// Read through keyStore so each legacy mode is resolved the same way the
 	// v1 server resolved it (file read, or b64 decode). Both return "" on any
 	// failure, which must abort: sealing an empty string would migrate cleanly

--- a/internal/database/postgres/migrations/seal_legacy_keys_test.go
+++ b/internal/database/postgres/migrations/seal_legacy_keys_test.go
@@ -9,6 +9,7 @@ import (
 	"expo-open-ota/internal/store"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -198,6 +199,36 @@ func TestSealLegacyKeysIntoDBFailsWhenKeysAreUnreadable(t *testing.T) {
 	}
 	if params.SealedPrivateKey != nil {
 		t.Error("no key should have been sealed on the failure path")
+	}
+}
+
+// A control-plane deployment that carries EXPO_APP_ID but none of the key
+// vars parses as mode=local (the KEYS_STORAGE_TYPE default) with empty paths.
+// The error must call out the missing env vars, not a generic read failure,
+// because that is what the operator actually has to fix.
+func TestSealLegacyKeysIntoDBNamesMissingKeyEnvVars(t *testing.T) {
+	setMasterKey(t)
+	for _, app := range []config.AppConfig{
+		{
+			Id:   "77777777-7777-7777-7777-777777777777",
+			Keys: config.KeysConfig{Mode: config.KeysModeLocal},
+		},
+		{
+			Id:   "77777777-7777-7777-7777-777777777777",
+			Keys: config.KeysConfig{Mode: config.KeysModeEnvironment, PublicB64: "notempty"},
+		},
+	} {
+		params := pgdb.MigrateLegacyAppParams{}
+		err := sealLegacyKeysIntoDB(app, &params)
+		if err == nil {
+			t.Fatalf("expected the migration to abort on empty %s key config, got nil", app.Keys.Mode)
+		}
+		if !strings.Contains(err.Error(), "KEYS_STORAGE_TYPE") {
+			t.Errorf("mode=%s: error should point at the missing key env vars, got: %v", app.Keys.Mode, err)
+		}
+		if params.SealedPrivateKey != nil {
+			t.Error("no key should have been sealed on the failure path")
+		}
 	}
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -44,6 +44,14 @@ func NewRouter(container *AppContainer) *mux.Router {
 	}
 
 	r.HandleFunc("/hc", HealthCheck).Methods(http.MethodGet)
+	// Both routes answer 200 here, and that is correct: this router is only
+	// swapped in once the bucket migrations are done, so the pod is by then both
+	// alive and ready. The liveness/readiness split happens earlier, in
+	// cmd/api/main.go's bootHandler, which registers /hc (200 throughout, so a
+	// long migration never gets the pod killed) but deliberately leaves /ready
+	// unregistered so it falls into that handler's catch-all 503 and keeps
+	// traffic away until this router takes over.
+	r.HandleFunc("/ready", HealthCheck).Methods(http.MethodGet)
 
 	appSubrouter := r.PathPrefix("/{APP_ID}").Subrouter()
 	appSubrouter.Use(middleware.AppResolverMiddleware(container.AppRepo))


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the migration process, Helm chart, and deployment readiness for the Expo Open OTA service. The main focus is on making bucket migrations safer and more observable, improving environment variable rendering for different deployment modes, and updating health probes to better coordinate with orchestrators. The most significant changes are grouped below.

**Deployment and Migration Readiness Improvements:**

* The API server now starts immediately and serves `/hc` (liveness) during bucket migrations, returning 503 for all other endpoints until migrations complete. This prevents the orchestrator from killing pods during long migrations and only marks them as ready when safe to serve traffic. `/ready` is not registered until migrations finish. (`cmd/api/main.go`)
* Health probes in the Helm deployment are updated: `/hc` is used for liveness (always 200), and `/ready` for readiness (only 200 after migrations), ensuring correct orchestration behavior during upgrades. (`helm/templates/deployment.yaml`)

**Bucket Migration Parallelization and Observability:**

* The S3 bucket migration now moves objects in parallel (default 16 workers, configurable via `BUCKET_MIGRATION_CONCURRENCY`), significantly speeding up migrations. Marker files are moved only after all other objects to ensure safe retries. Progress is logged every 500 objects to provide visibility during long migrations. (`internal/bucket/v2_migration.go`) [[1]](diffhunk://#diff-0022cb9a8d1c465b10b108b6a3e2d3c16890bc0eee54fa81763ac716ebc1b53aR47-R74) [[2]](diffhunk://#diff-0022cb9a8d1c465b10b108b6a3e2d3c16890bc0eee54fa81763ac716ebc1b53aR237-R282) [[3]](diffhunk://#diff-0022cb9a8d1c465b10b108b6a3e2d3c16890bc0eee54fa81763ac716ebc1b53aL226-R317)

**Helm Chart Environment Variable Rendering:**

* Environment variables required for both stateless and control-plane modes are now rendered according to deployment mode: required in stateless mode, optional (but present) in control-plane mode for smooth upgrades and backward compatibility. This ensures legacy variables are available for migration and v1 client support. (`helm/values.yaml`, `helm/templates/deployment.yaml`) [[1]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279L220-R296) [[2]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279R322-R346) [[3]](diffhunk://#diff-a63ea33c81187c63a5163e4042419e5cce470581f485a1c99914c655f5570435R80-R82) [[4]](diffhunk://#diff-a63ea33c81187c63a5163e4042419e5cce470581f485a1c99914c655f5570435R95)
* Optional tuning variables (e.g., `AWS_BASE_ENDPOINT`, `BUCKET_KEY_PREFIX`) are now always rendered with `enabled: true` to prevent accidental omission from deployments. (`helm/values.yaml`) [[1]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279R168-R177) [[2]](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279R186-R191)

**Helm Chart Testing Enhancements:**

* New tests verify that environment variables are rendered correctly for both stateless and control-plane modes, that optional variables are present, and that health probe paths are set as intended. (`helm/helm_template_test.go`) [[1]](diffhunk://#diff-7252d494e2f73258a8af0045c2836c42326ea2d45c08881a507cf8968f5dd37dL66-R212) [[2]](diffhunk://#diff-7252d494e2f73258a8af0045c2836c42326ea2d45c08881a507cf8968f5dd37dL82-R239) [[3]](diffhunk://#diff-7252d494e2f73258a8af0045c2836c42326ea2d45c08881a507cf8968f5dd37dL98-L101)

These changes together make migrations safer and more robust, improve deployment reliability, and ensure smooth upgrades with strong backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Services now start responding to health checks immediately while migrations complete.
  * Readiness reporting is separated from liveness reporting: `/hc` remains available during startup, while `/ready` becomes available after migrations finish.
  * Bucket migrations now process large object sets concurrently for faster completion.

* **Bug Fixes**
  * Improved handling and diagnostics for missing legacy signing-key configuration.
  * Corrected rendering of optional Helm environment variables and conditional settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->