### PR TITLE
feat: add manual validation for SSO

### DIFF
--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -15,6 +15,8 @@ import {
   Users,
 } from 'lucide-react';
 import clsx from 'clsx';
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
 import { Combobox } from '@/components/Combobox';
 import { useSelectedApp } from '@/lib/SelectedAppContext';
 import { CreateAppModal } from '@/components/app-creation-modal';
@@ -62,6 +64,16 @@ const EnterpriseNavBadge = () => (
   </span>
 );
 
+// Counts the accounts waiting for an admin to approve them. Without it nobody
+// notices there is anything to approve, and new members sit blocked in silence.
+const PendingUsersBadge = ({ count }: { count: number }) => (
+  <span
+    className="ml-auto rounded-full border border-amber-200/80 bg-amber-50/80 px-1.5 py-px text-[10px] font-medium text-amber-700"
+    title={`${count} account${count > 1 ? 's' : ''} waiting for approval`}>
+    {count}
+  </span>
+);
+
 const SectionLabel = ({ children }: { children: React.ReactNode }) => (
   <p className="px-3 pb-1.5 pt-5 text-[11px] font-medium uppercase tracking-widest text-muted-foreground/70">
     {children}
@@ -73,6 +85,15 @@ export function AppSidebar() {
   const { isAdmin } = useCurrentUser();
   const { apps, selectedAppId, setSelectedAppId, refreshApps, isLoading } = useSelectedApp();
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+
+  // Same query key as the Users page, so react-query serves both from one
+  // request and approving an account refreshes the badge on its own.
+  const usersQuery = useQuery({
+    queryKey: ['users'],
+    queryFn: () => api.getUsers(),
+    enabled: CONTROL_PLANE_ENABLED && isAdmin,
+  });
+  const pendingUsersCount = (usersQuery.data ?? []).filter(user => !user.enabled).length;
 
   const handleAppCreated = async (newAppId: string) => {
     await refreshApps();
@@ -166,7 +187,14 @@ export function AppSidebar() {
             <>
               <SectionLabel>Access & Security</SectionLabel>
               <div className="space-y-0.5">
-                <NavLink to="/users" icon={Users}>
+                <NavLink
+                  to="/users"
+                  icon={Users}
+                  badge={
+                    pendingUsersCount > 0 ? (
+                      <PendingUsersBadge count={pendingUsersCount} />
+                    ) : undefined
+                  }>
                   Users
                 </NavLink>
                 <NavLink to="/sso" icon={Fingerprint} badge={<EnterpriseNavBadge />}>

--- a/apps/dashboard/src/ee/components/SsoConfigCard.tsx
+++ b/apps/dashboard/src/ee/components/SsoConfigCard.tsx
@@ -32,6 +32,7 @@ type SsoFormState = {
   allowedEmailDomains: string[];
   allowedGroups: string[];
   trustUnverifiedEmail: boolean;
+  manualUserValidation: boolean;
 };
 
 const DEFAULT_SCOPES = 'openid profile email';
@@ -47,6 +48,7 @@ const emptyForm: SsoFormState = {
   allowedEmailDomains: [],
   allowedGroups: [],
   trustUnverifiedEmail: false,
+  manualUserValidation: false,
 };
 
 const formFromSettings = (settings: SsoSettings): SsoFormState => ({
@@ -61,6 +63,7 @@ const formFromSettings = (settings: SsoSettings): SsoFormState => ({
   allowedEmailDomains: settings.allowedEmailDomains,
   allowedGroups: settings.allowedGroups,
   trustUnverifiedEmail: settings.trustUnverifiedEmail,
+  manualUserValidation: settings.manualUserValidation,
 });
 
 // Signature of the stored values the form is populated from. The live enabled
@@ -78,6 +81,7 @@ const settingsFormSignature = (settings: SsoSettings | null): string | null =>
         settings.allowedEmailDomains,
         settings.allowedGroups,
         settings.trustUnverifiedEmail,
+        settings.manualUserValidation,
       ])
     : null;
 
@@ -241,6 +245,7 @@ export const SsoConfigCard = () => {
         allowedGroups: form.allowedGroups,
         groupsClaim: form.groupsClaim.trim(),
         trustUnverifiedEmail: form.trustUnverifiedEmail,
+        manualUserValidation: form.manualUserValidation,
       });
       queryClient.setQueryData(['ssoSettings'], saved);
       queryClient.invalidateQueries({ queryKey: ['ssoPublicConfig'] });
@@ -278,6 +283,7 @@ export const SsoConfigCard = () => {
         allowedGroups: settings.allowedGroups,
         groupsClaim: settings.groupsClaim,
         trustUnverifiedEmail: settings.trustUnverifiedEmail,
+        manualUserValidation: settings.manualUserValidation,
       });
       queryClient.setQueryData(['ssoSettings'], saved);
       queryClient.invalidateQueries({ queryKey: ['ssoPublicConfig'] });
@@ -364,7 +370,10 @@ export const SsoConfigCard = () => {
             <AlertTitle>Could not load the SSO configuration</AlertTitle>
             <AlertDescription className="flex flex-col items-start gap-3">
               <span className="break-words">
-                {describeApiError(settingsQuery.error, 'The server could not be reached.').description}
+                {
+                  describeApiError(settingsQuery.error, 'The server could not be reached.')
+                    .description
+                }
               </span>
               <Button
                 variant="outline"
@@ -428,12 +437,16 @@ export const SsoConfigCard = () => {
                   size="icon"
                   onClick={handleCopyRedirectUri}
                   title="Copy the redirect URI">
-                  {copied ? <Check className="h-4 w-4 text-emerald-600" /> : <Copy className="h-4 w-4" />}
+                  {copied ? (
+                    <Check className="h-4 w-4 text-emerald-600" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
                 </Button>
               </div>
               <FieldHint>
-                Derived from BASE_URL. Register it as a web redirect URI in your identity
-                provider's app registration before saving.
+                Derived from BASE_URL. Register it as a web redirect URI in your identity provider's
+                app registration before saving.
               </FieldHint>
             </div>
 
@@ -448,8 +461,10 @@ export const SsoConfigCard = () => {
                   spellCheck={false}
                 />
                 <FieldHint>
-                  The OpenID Connect issuer of your provider. Saving fetches
-                  {' '}<code className="rounded bg-muted px-1 py-0.5 text-[11px]">/.well-known/openid-configuration</code>{' '}
+                  The OpenID Connect issuer of your provider. Saving fetches{' '}
+                  <code className="rounded bg-muted px-1 py-0.5 text-[11px]">
+                    /.well-known/openid-configuration
+                  </code>{' '}
                   from it and reports any error right here.
                 </FieldHint>
               </div>
@@ -545,6 +560,24 @@ export const SsoConfigCard = () => {
                   aria-label="Trust emails from this provider"
                   checked={form.trustUnverifiedEmail}
                   onCheckedChange={checked => setField('trustUnverifiedEmail', checked)}
+                />
+              </div>
+
+              <div className="flex items-start justify-between gap-4 border-t pt-4">
+                <div className="space-y-0.5">
+                  <Label htmlFor="sso-manual-validation">Require admin approval</Label>
+                  <FieldHint>
+                    New accounts are created on their first sign-in but cannot enter until an admin
+                    approves them on the Users page, where they show up as pending. Use this when
+                    your provider authenticates more people than should reach this dashboard and
+                    does not send group claims to filter on, which is the case for Google Workspace.
+                    Accounts that already exist keep their access.
+                  </FieldHint>
+                </div>
+                <Switch
+                  aria-label="Require admin approval"
+                  checked={form.manualUserValidation}
+                  onCheckedChange={checked => setField('manualUserValidation', checked)}
                 />
               </div>
             </div>

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -111,6 +111,9 @@ export type UserRecord = {
   id: string;
   email: string;
   isAdmin: boolean;
+  // False for an account an admin revoked, or one awaiting approval under SSO
+  // manual validation. Disabled accounts cannot sign in.
+  enabled: boolean;
   createdAt?: string;
   lastConnectedAt?: string;
 };
@@ -154,6 +157,9 @@ export type SsoSettings = {
   // Whether the server accepts an email the provider did not verify
   // (email_verified false or absent) for account lookup and authorization.
   trustUnverifiedEmail: boolean;
+  // Whether accounts discovered on their first SSO sign-in are provisioned
+  // disabled, waiting for an admin to approve them on the Users page.
+  manualUserValidation: boolean;
   redirectUri: string;
 };
 
@@ -169,6 +175,7 @@ export type SaveSsoSettingsPayload = {
   allowedGroups: string[];
   groupsClaim: string;
   trustUnverifiedEmail: boolean;
+  manualUserValidation: boolean;
 };
 
 // Mirror of the server's SettingsEnv payload (/api/settings). Field names are
@@ -347,6 +354,14 @@ export class ApiClient {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ isAdmin }),
+    });
+  }
+
+  public async updateUserEnabled(userId: string, enabled: boolean) {
+    return this.request<void>(`/api/users/${encodeURIComponent(userId)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled }),
     });
   }
 

--- a/apps/dashboard/src/pages/Login/index.tsx
+++ b/apps/dashboard/src/pages/Login/index.tsx
@@ -26,13 +26,18 @@ const FormSchema = z.object({
 // underlying cause stays in the server logs; the code alone reaches the URL.
 const SSO_ERROR_MESSAGES: Record<string, string> = {
   sso_denied: 'Sign-in was cancelled at the identity provider.',
-  sso_license: 'Single sign-on requires an active enterprise license. Sign in with your password instead.',
+  sso_license:
+    'Single sign-on requires an active enterprise license. Sign in with your password instead.',
   sso_email_missing:
     'Your identity provider did not return an email address for your account. Contact your administrator.',
   sso_email_unverified:
     'Your identity provider did not verify your email address. Contact your administrator.',
-  sso_forbidden: 'Your account is not allowed to access this dashboard. Contact your administrator.',
-  sso_failed: 'SSO sign-in failed. Try again, and contact your administrator if it keeps happening.',
+  sso_forbidden:
+    'Your account is not allowed to access this dashboard. Contact your administrator.',
+  sso_pending:
+    'Your account has been created and is waiting for an administrator to approve it. You will be able to sign in once it is approved.',
+  sso_failed:
+    'SSO sign-in failed. Try again, and contact your administrator if it keeps happening.',
 };
 
 export const Login = () => {
@@ -44,7 +49,10 @@ export const Login = () => {
     },
   });
   const navigate = useNavigate();
-  const [ssoError, setSsoError] = useState<string | null>(null);
+  // Shared by both sign-in paths: the SSO callback's error codes and the
+  // password path's 403s (SSO enforced, account awaiting approval). Both are
+  // account-state messages rather than credential mistakes.
+  const [signInNotice, setSignInNotice] = useState<string | null>(null);
 
   // The SSO callback lands here with the session pair (or an error code) in
   // the URL fragment: fragments never reach a server, so tokens cannot end up
@@ -70,7 +78,7 @@ export const Login = () => {
       navigate('/');
       return;
     }
-    setSsoError(SSO_ERROR_MESSAGES[errorCode ?? ''] ?? SSO_ERROR_MESSAGES.sso_failed);
+    setSignInNotice(SSO_ERROR_MESSAGES[errorCode ?? ''] ?? SSO_ERROR_MESSAGES.sso_failed);
   }, [navigate]);
 
   const onSubmit = useCallback(
@@ -80,6 +88,14 @@ export const Login = () => {
         setTokens(response.token, response.refreshToken);
         navigate('/');
       } catch (error) {
+        // A 403 means the credentials were right but the account may not use
+        // this door: SSO is enforced for it, or it is waiting for approval.
+        // That is not a password mistake, so it belongs in the notice above
+        // the form rather than under the password field.
+        if (error instanceof ApiProblemError && error.status === 403) {
+          setSignInNotice(error.detail);
+          return;
+        }
         // Only an actual 401 means wrong credentials. A misconfigured server
         // (e.g. ADMIN_EMAIL not set in stateless mode) answers with an
         // actionable detail, and a fetch that never reached the server must
@@ -121,10 +137,10 @@ export const Login = () => {
             </div>
           </div>
 
-          {ssoError && (
+          {signInNotice && (
             <Alert variant="destructive" className="mb-5">
               <TriangleAlert className="h-4 w-4" />
-              <AlertDescription>{ssoError}</AlertDescription>
+              <AlertDescription>{signInNotice}</AlertDescription>
             </Alert>
           )}
 

--- a/apps/dashboard/src/pages/Users/index.tsx
+++ b/apps/dashboard/src/pages/Users/index.tsx
@@ -7,6 +7,7 @@ import { useCurrentUser } from '@/lib/CurrentUserContext';
 import { useToast } from '@/hooks/use-toast';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { Switch } from '@/components/ui/switch';
 import { PageHeader } from '@/components/PageHeader';
 import { DataTable } from '@/components/DataTable';
 import { TimestampCell } from '@/components/ui/timestamp-cell';
@@ -23,6 +24,7 @@ export const Users = () => {
   const [userToDelete, setUserToDelete] = useState<UserRecord | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [togglingUserId, setTogglingUserId] = useState<string | null>(null);
+  const [togglingEnabledId, setTogglingEnabledId] = useState<string | null>(null);
 
   const usersQuery = useQuery({
     queryKey: ['users'],
@@ -49,13 +51,34 @@ export const Users = () => {
     }
   };
 
+  const handleToggleEnabled = async (user: UserRecord) => {
+    setTogglingEnabledId(user.id);
+    try {
+      await api.updateUserEnabled(user.id, !user.enabled);
+      queryClient.invalidateQueries({ queryKey: ['users'] });
+      toast({
+        title: user.enabled ? 'Access revoked' : 'Account approved',
+        description: user.enabled
+          ? `"${user.email}" can no longer sign in.`
+          : `"${user.email}" can now sign in.`,
+      });
+    } catch (error) {
+      notifyError(error, 'Error updating user');
+    } finally {
+      setTogglingEnabledId(null);
+    }
+  };
+
   const handleExecuteDeletion = async () => {
     if (!userToDelete) return;
     setIsDeleting(true);
     try {
       await api.deleteUser(userToDelete.id);
       queryClient.invalidateQueries({ queryKey: ['users'] });
-      toast({ title: 'User deleted', description: `"${userToDelete.email}" can no longer sign in.` });
+      toast({
+        title: 'User deleted',
+        description: `"${userToDelete.email}" can no longer sign in.`,
+      });
       setUserToDelete(null);
     } catch (error) {
       notifyError(error, 'Deletion failed');
@@ -67,10 +90,7 @@ export const Users = () => {
   if (!CONTROL_PLANE_ENABLED) {
     return (
       <div className="w-full">
-        <PageHeader
-          title="Users"
-          description="User accounts for this dashboard."
-        />
+        <PageHeader title="Users" description="User accounts for this dashboard." />
         <div className="rounded-xl border border-dashed bg-muted/30 p-8 text-center text-sm text-muted-foreground">
           On a stateless deployment there is a single account, configured through the ADMIN_EMAIL
           and ADMIN_PASSWORD environment variables.
@@ -139,6 +159,36 @@ export const Users = () => {
                 ) : (
                   <Badge variant="secondary">Member</Badge>
                 ),
+            },
+            {
+              header: 'Access',
+              accessorKey: 'enabled',
+              cell: ({ row }) => {
+                const { enabled, lastConnectedAt } = row.original;
+                // A disabled account that never connected is one nobody has
+                // approved yet; one that did connect had its access revoked.
+                // Same flag, but the two read very differently to an admin.
+                const label = enabled ? 'Active' : lastConnectedAt ? 'Disabled' : 'Pending';
+                const badge = enabled ? (
+                  <Badge variant="secondary">Active</Badge>
+                ) : (
+                  <Badge variant="destructive">{label}</Badge>
+                );
+                // The server refuses disabling your own account, so do not
+                // offer the switch on your own row.
+                if (row.original.id === currentUser?.id) return badge;
+                return (
+                  <div className="flex items-center gap-2">
+                    <Switch
+                      checked={enabled}
+                      onCheckedChange={() => handleToggleEnabled(row.original)}
+                      disabled={togglingEnabledId === row.original.id}
+                      aria-label={enabled ? 'Revoke access' : 'Approve account'}
+                    />
+                    {badge}
+                  </div>
+                );
+              },
             },
             {
               header: 'Created',

--- a/ee/sso/handler.go
+++ b/ee/sso/handler.go
@@ -28,6 +28,7 @@ const (
 	ssoErrEmailMissing    = "sso_email_missing"
 	ssoErrEmailUnverified = "sso_email_unverified"
 	ssoErrForbidden       = "sso_forbidden"
+	ssoErrPending         = "sso_pending"
 	ssoErrFailed          = "sso_failed"
 )
 
@@ -77,6 +78,8 @@ func ssoErrorCode(err error) string {
 		return ssoErrEmailUnverified
 	case errors.Is(err, ErrSSOAccessRestricted):
 		return ssoErrForbidden
+	case errors.Is(err, ErrSSOAccountPendingApproval):
+		return ssoErrPending
 	default:
 		return ssoErrFailed
 	}
@@ -207,6 +210,7 @@ type adminConfigResponse struct {
 	AllowedGroups        []string `json:"allowedGroups"`
 	GroupsClaim          string   `json:"groupsClaim"`
 	TrustUnverifiedEmail bool     `json:"trustUnverifiedEmail"`
+	ManualUserValidation bool     `json:"manualUserValidation"`
 	RedirectURI          string   `json:"redirectUri"`
 }
 
@@ -222,6 +226,7 @@ func adminConfigResponseFrom(view *AdminConfig) adminConfigResponse {
 		AllowedGroups:        view.AllowedGroups,
 		GroupsClaim:          view.GroupsClaim,
 		TrustUnverifiedEmail: view.TrustUnverifiedEmail,
+		ManualUserValidation: view.ManualUserValidation,
 		RedirectURI:          view.RedirectURI,
 	}
 	// Encode empty lists as [], never null: the dashboard maps over them.
@@ -255,6 +260,7 @@ func (h *SSOHandler) SaveConfigHandler(w http.ResponseWriter, r *http.Request) {
 		AllowedGroups        []string `json:"allowedGroups"`
 		GroupsClaim          string   `json:"groupsClaim"`
 		TrustUnverifiedEmail bool     `json:"trustUnverifiedEmail"`
+		ManualUserValidation bool     `json:"manualUserValidation"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
 		handlers.RenderError(w, http.StatusBadRequest, "Invalid request body: "+err.Error())
@@ -271,6 +277,7 @@ func (h *SSOHandler) SaveConfigHandler(w http.ResponseWriter, r *http.Request) {
 		AllowedGroups:        requestBody.AllowedGroups,
 		GroupsClaim:          requestBody.GroupsClaim,
 		TrustUnverifiedEmail: requestBody.TrustUnverifiedEmail,
+		ManualUserValidation: requestBody.ManualUserValidation,
 	})
 	if err != nil {
 		renderSSOServiceError(w, err)

--- a/ee/sso/service.go
+++ b/ee/sso/service.go
@@ -58,6 +58,13 @@ type SSOConfig struct {
 	// for a trusted provider that omits email_verified (notably Entra ID) on a
 	// single tenant where users cannot self-assert addresses.
 	TrustUnverifiedEmail bool
+	// ManualUserValidation provisions newly discovered accounts disabled, so an
+	// admin approves each one on the Users page before it can sign in. It is
+	// the answer to "everyone in my Google Workspace can reach the dashboard"
+	// for providers that do not emit group claims: the allowlist lives here
+	// rather than at the IdP. Accounts linked to a pre-existing user are
+	// untouched, and turning the toggle on never disables existing accounts.
+	ManualUserValidation bool
 }
 
 // SSORepository persists the singleton configuration and the mapping from
@@ -91,6 +98,11 @@ var (
 	// ErrSSOAccessRestricted is answered when the token verified but the
 	// account falls outside the configured domain/group restrictions.
 	ErrSSOAccessRestricted = errors.New("this account is not allowed to sign in to this dashboard")
+	// ErrSSOAccountPendingApproval is answered when the identity verified and
+	// the account exists, but an admin has not approved it (manual user
+	// validation) or has revoked it. Distinct from ErrSSOAccessRestricted so
+	// the login page can tell the person to wait rather than to go away.
+	ErrSSOAccountPendingApproval = errors.New("this account is waiting for an administrator to approve it")
 	// ErrClientSecretUnreadable marks a stored client secret that can no
 	// longer be unsealed (the DB keys master key changed). Sign-ins fail until
 	// an admin re-enters the secret, which re-seals it under the current key.
@@ -146,6 +158,7 @@ type AdminConfig struct {
 	AllowedGroups        []string
 	GroupsClaim          string
 	TrustUnverifiedEmail bool
+	ManualUserValidation bool
 	RedirectURI          string
 }
 
@@ -163,6 +176,7 @@ type SaveConfigInput struct {
 	AllowedGroups        []string
 	GroupsClaim          string
 	TrustUnverifiedEmail bool
+	ManualUserValidation bool
 }
 
 // SSOService owns the OIDC sign-in flow (authorization code + PKCE against a
@@ -266,6 +280,7 @@ func (s *SSOService) adminView(cfg *SSOConfig) *AdminConfig {
 		AllowedGroups:        cfg.AllowedGroups,
 		GroupsClaim:          cfg.GroupsClaim,
 		TrustUnverifiedEmail: cfg.TrustUnverifiedEmail,
+		ManualUserValidation: cfg.ManualUserValidation,
 		RedirectURI:          s.RedirectURI(),
 	}
 }
@@ -432,9 +447,15 @@ func (s *SSOService) CompleteLogin(ctx context.Context, flowToken string, state 
 	if err := checkSignInRestrictions(cfg, email, claims); err != nil {
 		return nil, err
 	}
-	user, err := s.resolveUser(ctx, cfg.Issuer, idToken.Subject, email)
+	user, err := s.resolveUser(ctx, cfg, idToken.Subject, email)
 	if err != nil {
 		return nil, err
+	}
+	// Answered before IssueSession, which refuses disabled accounts too: this
+	// path just needs its own error so the login page can explain that the
+	// account exists and is waiting, rather than showing a generic refusal.
+	if !user.Enabled {
+		return nil, fmt.Errorf("%w: %q is not approved yet", ErrSSOAccountPendingApproval, email)
 	}
 	return s.sessions.IssueSession(ctx, user)
 }
@@ -538,21 +559,22 @@ func (s *SSOService) discover(issuer string) (*oidc.Provider, error) {
 // resolveUser maps a verified identity onto a dashboard account:
 // known subject first (stable even when the email changes at the IdP), then
 // account linking by email, then JIT provisioning of a non-admin member.
-func (s *SSOService) resolveUser(ctx context.Context, issuer string, subject string, email string) (store.User, error) {
-	user, err := s.lookupOrProvision(ctx, issuer, subject, email)
+func (s *SSOService) resolveUser(ctx context.Context, cfg *SSOConfig, subject string, email string) (store.User, error) {
+	user, err := s.lookupOrProvision(ctx, cfg, subject, email)
 	if err != nil {
 		// A concurrent first sign-in handled by another replica may have
 		// provisioned or linked the same identity between our lookup and our
 		// write; one retry then finds it by subject.
 		if alreadyExistsErr := (*store.ErrResourceAlreadyExists)(nil); errors.As(err, &alreadyExistsErr) {
-			return s.lookupOrProvision(ctx, issuer, subject, email)
+			return s.lookupOrProvision(ctx, cfg, subject, email)
 		}
 		return store.User{}, err
 	}
 	return user, nil
 }
 
-func (s *SSOService) lookupOrProvision(ctx context.Context, issuer string, subject string, email string) (store.User, error) {
+func (s *SSOService) lookupOrProvision(ctx context.Context, cfg *SSOConfig, subject string, email string) (store.User, error) {
+	issuer := cfg.Issuer
 	user, err := s.repo.FindUserBySubject(ctx, issuer, subject)
 	if err == nil {
 		// Best effort: a failed touch must not fail the sign-in.
@@ -567,7 +589,9 @@ func (s *SSOService) lookupOrProvision(ctx context.Context, issuer string, subje
 	existing, err := s.userRepo.GetUserByEmail(ctx, email)
 	if err == nil {
 		// First SSO sign-in of an account that already exists with this email:
-		// link it instead of duplicating. Role and password are untouched.
+		// link it instead of duplicating. Role, password and enabled flag are
+		// untouched, so turning manual validation on never demands re-approval
+		// of accounts that already had access.
 		if err := s.repo.LinkIdentity(ctx, issuer, subject, existing.Id, email); err != nil {
 			return store.User{}, err
 		}
@@ -579,11 +603,14 @@ func (s *SSOService) lookupOrProvision(ctx context.Context, issuer string, subje
 	// JIT provisioning: always a non-admin member; promotion happens on the
 	// Users page. The empty password hash can never verify against bcrypt, so
 	// the account is SSO-only until SSO is turned off and an admin intervenes.
+	// Under manual validation the row lands disabled and the sign-in that
+	// created it is refused, so the admin has something concrete to approve.
 	return s.repo.ProvisionUser(ctx, store.InsertUserParameters{
 		ID:           uuid.New().String(),
 		Email:        email,
 		PasswordHash: "",
 		IsAdmin:      false,
+		Enabled:      !cfg.ManualUserValidation,
 	}, issuer, subject)
 }
 
@@ -729,6 +756,7 @@ func normalizeConfigInput(input SaveConfigInput) (*SSOConfig, error) {
 		AllowedGroups:        normalizeList(input.AllowedGroups),
 		GroupsClaim:          groupsClaim,
 		TrustUnverifiedEmail: input.TrustUnverifiedEmail,
+		ManualUserValidation: input.ManualUserValidation,
 	}, nil
 }
 

--- a/ee/sso/service_test.go
+++ b/ee/sso/service_test.go
@@ -47,7 +47,7 @@ func (r *fakeUserRepo) InsertUser(_ context.Context, params store.InsertUserPara
 			return store.User{}, &store.ErrResourceAlreadyExists{Resource: "user", Identifier: email}
 		}
 	}
-	user := store.User{Id: params.ID, Email: email, PasswordHash: params.PasswordHash, IsAdmin: params.IsAdmin, CreatedAt: time.Now()}
+	user := store.User{Id: params.ID, Email: email, PasswordHash: params.PasswordHash, IsAdmin: params.IsAdmin, Enabled: params.Enabled, CreatedAt: time.Now()}
 	r.users[params.ID] = user
 	return user, nil
 }
@@ -93,6 +93,13 @@ func (r *fakeUserRepo) UpdateUserPassword(_ context.Context, id string, password
 func (r *fakeUserRepo) UpdateUserIsAdmin(_ context.Context, id string, isAdmin bool) error {
 	user := r.users[id]
 	user.IsAdmin = isAdmin
+	r.users[id] = user
+	return nil
+}
+
+func (r *fakeUserRepo) UpdateUserEnabled(_ context.Context, id string, enabled bool) error {
+	user := r.users[id]
+	user.Enabled = enabled
 	r.users[id] = user
 	return nil
 }
@@ -176,7 +183,7 @@ func (r *fakeSSORepo) ProvisionUser(ctx context.Context, params store.InsertUser
 	if r.provisionRaces {
 		r.provisionRaces = false
 		otherReplicaID := "other-replica-" + params.ID
-		if _, err := r.users.InsertUser(ctx, store.InsertUserParameters{ID: otherReplicaID, Email: params.Email}); err != nil {
+		if _, err := r.users.InsertUser(ctx, store.InsertUserParameters{ID: otherReplicaID, Email: params.Email, Enabled: params.Enabled}); err != nil {
 			return store.User{}, err
 		}
 		r.identities[key] = otherReplicaID
@@ -412,7 +419,7 @@ func TestCompleteLoginLinksExistingAccountByEmail(t *testing.T) {
 	idp := newFakeIdP(t)
 	users := newFakeUserRepo()
 	existing, err := users.InsertUser(context.Background(), store.InsertUserParameters{
-		ID: "existing-user", Email: testEmail, PasswordHash: "some-bcrypt-hash", IsAdmin: true,
+		ID: "existing-user", Email: testEmail, PasswordHash: "some-bcrypt-hash", IsAdmin: true, Enabled: true,
 	})
 	require.NoError(t, err)
 	repo := newFakeSSORepo(users, testConfigFor(idp))
@@ -448,6 +455,80 @@ func TestCompleteLoginRetriesAfterConcurrentFirstSignIn(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, repo.identities[identityKey(idp.issuer, testSubject)], principal.UserId)
 	assert.Len(t, users.users, 1)
+}
+
+// With manual validation on, a first sign-in creates the account but does not
+// let it in: the admin gets something concrete to approve on the Users page,
+// and the person gets an error saying to wait rather than a generic refusal.
+func TestManualUserValidationProvisionsDisabledAccounts(t *testing.T) {
+	idp := newFakeIdP(t)
+	users := newFakeUserRepo()
+	cfg := testConfigFor(idp)
+	cfg.ManualUserValidation = true
+	service, sessions := newTestService(t, newFakeSSORepo(users, cfg), users)
+
+	_, err := completeFlow(t, service, idp, nil)
+	assert.ErrorIs(t, err, ErrSSOAccountPendingApproval)
+
+	// The account exists, disabled, so an admin can find and approve it.
+	provisioned, err := users.GetUserByEmail(context.Background(), testEmail)
+	require.NoError(t, err)
+	assert.False(t, provisioned.Enabled)
+	assert.False(t, provisioned.IsAdmin)
+
+	// Retrying before approval keeps failing, without duplicating the account.
+	_, err = completeFlow(t, service, idp, nil)
+	assert.ErrorIs(t, err, ErrSSOAccountPendingApproval)
+	all, err := users.GetUsers(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, all, 1)
+
+	// Once approved, the very same flow signs in.
+	require.NoError(t, users.UpdateUserEnabled(context.Background(), provisioned.Id, true))
+	session, err := completeFlow(t, service, idp, nil)
+	require.NoError(t, err)
+	principal, err := sessions.ValidateSession(session.Token)
+	require.NoError(t, err)
+	assert.Equal(t, testEmail, principal.Email)
+}
+
+// Turning manual validation on must not strand people who already had access:
+// linking an identity onto an existing account leaves its enabled flag alone.
+func TestManualUserValidationLeavesExistingAccountsAlone(t *testing.T) {
+	idp := newFakeIdP(t)
+	users := newFakeUserRepo()
+	existing, err := users.InsertUser(context.Background(), store.InsertUserParameters{
+		ID: "existing-user", Email: testEmail, PasswordHash: "some-bcrypt-hash", IsAdmin: true, Enabled: true,
+	})
+	require.NoError(t, err)
+	cfg := testConfigFor(idp)
+	cfg.ManualUserValidation = true
+	service, _ := newTestService(t, newFakeSSORepo(users, cfg), users)
+
+	_, err = completeFlow(t, service, idp, nil)
+	require.NoError(t, err)
+
+	linked, err := users.GetUserByID(context.Background(), existing.Id)
+	require.NoError(t, err)
+	assert.True(t, linked.Enabled)
+}
+
+// A disabled account is refused whatever put it in that state: manual
+// validation is one way in, an admin revoking access is the other.
+func TestCompleteLoginRejectsRevokedAccount(t *testing.T) {
+	idp := newFakeIdP(t)
+	users := newFakeUserRepo()
+	service, _ := newTestService(t, newFakeSSORepo(users, testConfigFor(idp)), users)
+
+	_, err := completeFlow(t, service, idp, nil)
+	require.NoError(t, err)
+
+	provisioned, err := users.GetUserByEmail(context.Background(), testEmail)
+	require.NoError(t, err)
+	require.NoError(t, users.UpdateUserEnabled(context.Background(), provisioned.Id, false))
+
+	_, err = completeFlow(t, service, idp, nil)
+	assert.ErrorIs(t, err, ErrSSOAccountPendingApproval)
 }
 
 func TestCompleteLoginRejectsNonceMismatch(t *testing.T) {
@@ -570,7 +651,7 @@ func TestCompleteLoginRejectsUnverifiedEmail(t *testing.T) {
 	// An existing account an attacker would try to take over by asserting its
 	// address from a tenant they control.
 	victim, err := users.InsertUser(context.Background(), store.InsertUserParameters{
-		ID: "victim", Email: testEmail, PasswordHash: "victim-hash", IsAdmin: true,
+		ID: "victim", Email: testEmail, PasswordHash: "victim-hash", IsAdmin: true, Enabled: true,
 	})
 	require.NoError(t, err)
 	repo := newFakeSSORepo(users, testConfigFor(idp))

--- a/ee/sso/store_postgres.go
+++ b/ee/sso/store_postgres.go
@@ -48,6 +48,7 @@ func (s *PostgresSSOStore) GetConfig(ctx context.Context) (*SSOConfig, error) {
 		AllowedGroups:        row.AllowedGroups,
 		GroupsClaim:          row.GroupsClaim,
 		TrustUnverifiedEmail: row.TrustUnverifiedEmail,
+		ManualUserValidation: row.ManualUserValidation,
 	}
 	secret, err := crypto.UnsealAESGCM(row.SealedClientSecret, []byte(keyStore.ReadDBKeysMasterKey()), clientSecretAAD())
 	if err != nil {
@@ -75,6 +76,7 @@ func (s *PostgresSSOStore) SaveConfig(ctx context.Context, cfg SSOConfig) error 
 		AllowedGroups:        emptyIfNil(cfg.AllowedGroups),
 		GroupsClaim:          cfg.GroupsClaim,
 		TrustUnverifiedEmail: cfg.TrustUnverifiedEmail,
+		ManualUserValidation: cfg.ManualUserValidation,
 	}); err != nil {
 		return fmt.Errorf("failed to store the sso configuration in database: %w", err)
 	}
@@ -139,6 +141,7 @@ func (s *PostgresSSOStore) ProvisionUser(ctx context.Context, params store.Inser
 			Email:        email,
 			PasswordHash: params.PasswordHash,
 			IsAdmin:      params.IsAdmin,
+			Enabled:      params.Enabled,
 		})
 		if err != nil {
 			if database.IsUniqueViolation(err) {
@@ -150,6 +153,7 @@ func (s *PostgresSSOStore) ProvisionUser(ctx context.Context, params store.Inser
 			Id:        row.ID.String(),
 			Email:     row.Email,
 			IsAdmin:   row.IsAdmin,
+			Enabled:   row.Enabled,
 			CreatedAt: row.CreatedAt.Time,
 		}
 		if err := q.InsertSSOIdentity(ctx, pgdb.InsertSSOIdentityParams{

--- a/internal/database/postgres/migrations/20260719110000_add_manual_user_validation.sql
+++ b/internal/database/postgres/migrations/20260719110000_add_manual_user_validation.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Provides a mechanism for admins to manually validate a user account, which is useful for SSO providers
+ALTER TABLE users ADD COLUMN enabled BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE sso_config ADD COLUMN manual_user_validation BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE users DROP COLUMN IF EXISTS enabled;
+ALTER TABLE sso_config DROP COLUMN IF EXISTS manual_user_validation;
+-- +goose StatementEnd

--- a/internal/database/postgres/pgdb/models.go
+++ b/internal/database/postgres/pgdb/models.go
@@ -82,6 +82,7 @@ type SsoConfig struct {
 	CreatedAt            pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt            pgtype.Timestamptz `json:"updated_at"`
 	TrustUnverifiedEmail bool               `json:"trust_unverified_email"`
+	ManualUserValidation bool               `json:"manual_user_validation"`
 }
 
 type SsoIdentity struct {
@@ -114,4 +115,5 @@ type User struct {
 	CreatedAt       pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt       pgtype.Timestamptz `json:"updated_at"`
 	LastConnectedAt pgtype.Timestamptz `json:"last_connected_at"`
+	Enabled         bool               `json:"enabled"`
 }

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -70,16 +70,17 @@ func (q *Queries) DeleteSSOConfig(ctx context.Context) error {
 
 const deleteUserByID = `-- name: DeleteUserByID :execresult
 WITH admins AS (
-    SELECT id FROM users WHERE is_admin ORDER BY id FOR UPDATE
+    SELECT id FROM users WHERE is_admin AND enabled ORDER BY id FOR UPDATE
 )
 DELETE FROM users
 WHERE users.id = $1
   AND (users.id NOT IN (SELECT id FROM admins) OR (SELECT COUNT(*) FROM admins) > 1)
 `
 
-// Locks the admin rows first so concurrent deletes/demotions serialize:
-// deleting the last remaining admin matches no row instead of leaving the
-// dashboard without any admin.
+// Locks the admin rows first so concurrent deletes/demotions/disables
+// serialize: deleting the last remaining admin matches no row instead of
+// leaving the dashboard without any admin. Disabled admins are excluded, since
+// an account that cannot sign in is no safety net.
 func (q *Queries) DeleteUserByID(ctx context.Context, id pgtype.UUID) (pgconn.CommandTag, error) {
 	return q.db.Exec(ctx, deleteUserByID, id)
 }
@@ -548,7 +549,7 @@ func (q *Queries) GetRuntimeVersionsWithUpdateCount(ctx context.Context, arg Get
 }
 
 const getSSOConfig = `-- name: GetSSOConfig :one
-SELECT singleton, issuer, client_id, sealed_client_secret, provider_name, scopes, enabled, allowed_email_domains, allowed_groups, groups_claim, created_at, updated_at, trust_unverified_email FROM sso_config
+SELECT singleton, issuer, client_id, sealed_client_secret, provider_name, scopes, enabled, allowed_email_domains, allowed_groups, groups_claim, created_at, updated_at, trust_unverified_email, manual_user_validation FROM sso_config
 WHERE singleton
 `
 
@@ -569,6 +570,7 @@ func (q *Queries) GetSSOConfig(ctx context.Context) (SsoConfig, error) {
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.TrustUnverifiedEmail,
+		&i.ManualUserValidation,
 	)
 	return i, err
 }
@@ -810,7 +812,7 @@ func (q *Queries) GetUpdatesMetadataByBranchName(ctx context.Context, arg GetUpd
 }
 
 const getUserByEmail = `-- name: GetUserByEmail :one
-SELECT id, email, password_hash, is_admin, created_at, updated_at, last_connected_at FROM users
+SELECT id, email, password_hash, is_admin, created_at, updated_at, last_connected_at, enabled FROM users
 WHERE email = $1 LIMIT 1
 `
 
@@ -825,12 +827,13 @@ func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.LastConnectedAt,
+		&i.Enabled,
 	)
 	return i, err
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, email, password_hash, is_admin, created_at, updated_at, last_connected_at FROM users
+SELECT id, email, password_hash, is_admin, created_at, updated_at, last_connected_at, enabled FROM users
 WHERE id = $1 LIMIT 1
 `
 
@@ -845,12 +848,13 @@ func (q *Queries) GetUserByID(ctx context.Context, id pgtype.UUID) (User, error)
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.LastConnectedAt,
+		&i.Enabled,
 	)
 	return i, err
 }
 
 const getUserBySSOSubject = `-- name: GetUserBySSOSubject :one
-SELECT u.id, u.email, u.password_hash, u.is_admin, u.created_at, u.updated_at, u.last_connected_at FROM users u
+SELECT u.id, u.email, u.password_hash, u.is_admin, u.created_at, u.updated_at, u.last_connected_at, u.enabled FROM users u
 JOIN sso_identities si ON si.user_id = u.id
 WHERE si.issuer = $1 AND si.subject = $2
 `
@@ -871,12 +875,13 @@ func (q *Queries) GetUserBySSOSubject(ctx context.Context, arg GetUserBySSOSubje
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.LastConnectedAt,
+		&i.Enabled,
 	)
 	return i, err
 }
 
 const getUsers = `-- name: GetUsers :many
-SELECT id, email, is_admin, created_at, last_connected_at FROM users
+SELECT id, email, is_admin, enabled, created_at, last_connected_at FROM users
 ORDER BY created_at ASC
 `
 
@@ -884,6 +889,7 @@ type GetUsersRow struct {
 	ID              pgtype.UUID        `json:"id"`
 	Email           string             `json:"email"`
 	IsAdmin         bool               `json:"is_admin"`
+	Enabled         bool               `json:"enabled"`
 	CreatedAt       pgtype.Timestamptz `json:"created_at"`
 	LastConnectedAt pgtype.Timestamptz `json:"last_connected_at"`
 }
@@ -901,6 +907,7 @@ func (q *Queries) GetUsers(ctx context.Context) ([]GetUsersRow, error) {
 			&i.ID,
 			&i.Email,
 			&i.IsAdmin,
+			&i.Enabled,
 			&i.CreatedAt,
 			&i.LastConnectedAt,
 		); err != nil {
@@ -1138,9 +1145,9 @@ func (q *Queries) InsertUpdate(ctx context.Context, arg InsertUpdateParams) (Ins
 }
 
 const insertUser = `-- name: InsertUser :one
-INSERT INTO users (id, email, password_hash, is_admin)
-VALUES ($1, $2, $3, $4)
-RETURNING id, email, is_admin, created_at
+INSERT INTO users (id, email, password_hash, is_admin, enabled)
+VALUES ($1, $2, $3, $4, $5)
+RETURNING id, email, is_admin, enabled, created_at
 `
 
 type InsertUserParams struct {
@@ -1148,12 +1155,14 @@ type InsertUserParams struct {
 	Email        string      `json:"email"`
 	PasswordHash string      `json:"password_hash"`
 	IsAdmin      bool        `json:"is_admin"`
+	Enabled      bool        `json:"enabled"`
 }
 
 type InsertUserRow struct {
 	ID        pgtype.UUID        `json:"id"`
 	Email     string             `json:"email"`
 	IsAdmin   bool               `json:"is_admin"`
+	Enabled   bool               `json:"enabled"`
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
 }
 
@@ -1163,12 +1172,14 @@ func (q *Queries) InsertUser(ctx context.Context, arg InsertUserParams) (InsertU
 		arg.Email,
 		arg.PasswordHash,
 		arg.IsAdmin,
+		arg.Enabled,
 	)
 	var i InsertUserRow
 	err := row.Scan(
 		&i.ID,
 		&i.Email,
 		&i.IsAdmin,
+		&i.Enabled,
 		&i.CreatedAt,
 	)
 	return i, err
@@ -1574,9 +1585,34 @@ func (q *Queries) UpdateChannelBranchMapping(ctx context.Context, arg UpdateChan
 	return q.db.Exec(ctx, updateChannelBranchMapping, arg.BranchID, arg.AppID, arg.ID)
 }
 
+const updateUserEnabledByID = `-- name: UpdateUserEnabledByID :execresult
+WITH admins AS (
+    SELECT id FROM users WHERE is_admin AND enabled ORDER BY id FOR UPDATE
+)
+UPDATE users
+SET enabled = $2, updated_at = CURRENT_TIMESTAMP
+WHERE users.id = $1
+  AND ($2::boolean
+       OR users.id NOT IN (SELECT id FROM admins)
+       OR (SELECT COUNT(*) FROM admins) > 1)
+`
+
+type UpdateUserEnabledByIDParams struct {
+	ID      pgtype.UUID `json:"id"`
+	Enabled bool        `json:"enabled"`
+}
+
+// Same admin-row lock as DeleteUserByID: disabling the last remaining enabled
+// admin matches no row, so approving/revoking accounts can never lock the
+// dashboard out. Enabling ($2 true) always passes the guard but still takes
+// the lock, so it serializes with concurrent disables.
+func (q *Queries) UpdateUserEnabledByID(ctx context.Context, arg UpdateUserEnabledByIDParams) (pgconn.CommandTag, error) {
+	return q.db.Exec(ctx, updateUserEnabledByID, arg.ID, arg.Enabled)
+}
+
 const updateUserIsAdminByID = `-- name: UpdateUserIsAdminByID :execresult
 WITH admins AS (
-    SELECT id FROM users WHERE is_admin ORDER BY id FOR UPDATE
+    SELECT id FROM users WHERE is_admin AND enabled ORDER BY id FOR UPDATE
 )
 UPDATE users
 SET is_admin = $2, updated_at = CURRENT_TIMESTAMP
@@ -1634,8 +1670,8 @@ func (q *Queries) UpsertEnterpriseLicense(ctx context.Context, licenseKey string
 }
 
 const upsertSSOConfig = `-- name: UpsertSSOConfig :one
-INSERT INTO sso_config (singleton, issuer, client_id, sealed_client_secret, provider_name, scopes, enabled, allowed_email_domains, allowed_groups, groups_claim, trust_unverified_email)
-VALUES (TRUE, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+INSERT INTO sso_config (singleton, issuer, client_id, sealed_client_secret, provider_name, scopes, enabled, allowed_email_domains, allowed_groups, groups_claim, trust_unverified_email, manual_user_validation)
+VALUES (TRUE, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 ON CONFLICT (singleton) DO UPDATE
 SET issuer = EXCLUDED.issuer,
     client_id = EXCLUDED.client_id,
@@ -1647,8 +1683,9 @@ SET issuer = EXCLUDED.issuer,
     allowed_groups = EXCLUDED.allowed_groups,
     groups_claim = EXCLUDED.groups_claim,
     trust_unverified_email = EXCLUDED.trust_unverified_email,
+    manual_user_validation = EXCLUDED.manual_user_validation,
     updated_at = CURRENT_TIMESTAMP
-RETURNING singleton, issuer, client_id, sealed_client_secret, provider_name, scopes, enabled, allowed_email_domains, allowed_groups, groups_claim, created_at, updated_at, trust_unverified_email
+RETURNING singleton, issuer, client_id, sealed_client_secret, provider_name, scopes, enabled, allowed_email_domains, allowed_groups, groups_claim, created_at, updated_at, trust_unverified_email, manual_user_validation
 `
 
 type UpsertSSOConfigParams struct {
@@ -1662,6 +1699,7 @@ type UpsertSSOConfigParams struct {
 	AllowedGroups        []string `json:"allowed_groups"`
 	GroupsClaim          string   `json:"groups_claim"`
 	TrustUnverifiedEmail bool     `json:"trust_unverified_email"`
+	ManualUserValidation bool     `json:"manual_user_validation"`
 }
 
 func (q *Queries) UpsertSSOConfig(ctx context.Context, arg UpsertSSOConfigParams) (SsoConfig, error) {
@@ -1676,6 +1714,7 @@ func (q *Queries) UpsertSSOConfig(ctx context.Context, arg UpsertSSOConfigParams
 		arg.AllowedGroups,
 		arg.GroupsClaim,
 		arg.TrustUnverifiedEmail,
+		arg.ManualUserValidation,
 	)
 	var i SsoConfig
 	err := row.Scan(
@@ -1692,6 +1731,7 @@ func (q *Queries) UpsertSSOConfig(ctx context.Context, arg UpsertSSOConfigParams
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.TrustUnverifiedEmail,
+		&i.ManualUserValidation,
 	)
 	return i, err
 }

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -289,9 +289,9 @@ WHERE app_id = $1
 RETURNING id;
 
 -- name: InsertUser :one
-INSERT INTO users (id, email, password_hash, is_admin)
-VALUES ($1, $2, $3, $4)
-RETURNING id, email, is_admin, created_at;
+INSERT INTO users (id, email, password_hash, is_admin, enabled)
+VALUES ($1, $2, $3, $4, $5)
+RETURNING id, email, is_admin, enabled, created_at;
 
 -- name: GetUserByEmail :one
 SELECT * FROM users
@@ -302,7 +302,7 @@ SELECT * FROM users
 WHERE id = $1 LIMIT 1;
 
 -- name: GetUsers :many
-SELECT id, email, is_admin, created_at, last_connected_at FROM users
+SELECT id, email, is_admin, enabled, created_at, last_connected_at FROM users
 ORDER BY created_at ASC;
 
 -- name: TouchUserLastConnectedAt :exec
@@ -311,11 +311,12 @@ SET last_connected_at = CURRENT_TIMESTAMP
 WHERE id = $1;
 
 -- name: DeleteUserByID :execresult
--- Locks the admin rows first so concurrent deletes/demotions serialize:
--- deleting the last remaining admin matches no row instead of leaving the
--- dashboard without any admin.
+-- Locks the admin rows first so concurrent deletes/demotions/disables
+-- serialize: deleting the last remaining admin matches no row instead of
+-- leaving the dashboard without any admin. Disabled admins are excluded, since
+-- an account that cannot sign in is no safety net.
 WITH admins AS (
-    SELECT id FROM users WHERE is_admin ORDER BY id FOR UPDATE
+    SELECT id FROM users WHERE is_admin AND enabled ORDER BY id FOR UPDATE
 )
 DELETE FROM users
 WHERE users.id = $1
@@ -331,10 +332,25 @@ WHERE id = $1;
 -- matches no row. Promotions ($2 true) always pass the guard but still take
 -- the lock, so they serialize with concurrent demotions.
 WITH admins AS (
-    SELECT id FROM users WHERE is_admin ORDER BY id FOR UPDATE
+    SELECT id FROM users WHERE is_admin AND enabled ORDER BY id FOR UPDATE
 )
 UPDATE users
 SET is_admin = $2, updated_at = CURRENT_TIMESTAMP
+WHERE users.id = $1
+  AND ($2::boolean
+       OR users.id NOT IN (SELECT id FROM admins)
+       OR (SELECT COUNT(*) FROM admins) > 1);
+
+-- name: UpdateUserEnabledByID :execresult
+-- Same admin-row lock as DeleteUserByID: disabling the last remaining enabled
+-- admin matches no row, so approving/revoking accounts can never lock the
+-- dashboard out. Enabling ($2 true) always passes the guard but still takes
+-- the lock, so it serializes with concurrent disables.
+WITH admins AS (
+    SELECT id FROM users WHERE is_admin AND enabled ORDER BY id FOR UPDATE
+)
+UPDATE users
+SET enabled = $2, updated_at = CURRENT_TIMESTAMP
 WHERE users.id = $1
   AND ($2::boolean
        OR users.id NOT IN (SELECT id FROM admins)
@@ -456,8 +472,8 @@ SELECT * FROM sso_config
 WHERE singleton;
 
 -- name: UpsertSSOConfig :one
-INSERT INTO sso_config (singleton, issuer, client_id, sealed_client_secret, provider_name, scopes, enabled, allowed_email_domains, allowed_groups, groups_claim, trust_unverified_email)
-VALUES (TRUE, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+INSERT INTO sso_config (singleton, issuer, client_id, sealed_client_secret, provider_name, scopes, enabled, allowed_email_domains, allowed_groups, groups_claim, trust_unverified_email, manual_user_validation)
+VALUES (TRUE, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 ON CONFLICT (singleton) DO UPDATE
 SET issuer = EXCLUDED.issuer,
     client_id = EXCLUDED.client_id,
@@ -469,6 +485,7 @@ SET issuer = EXCLUDED.issuer,
     allowed_groups = EXCLUDED.allowed_groups,
     groups_claim = EXCLUDED.groups_claim,
     trust_unverified_email = EXCLUDED.trust_unverified_email,
+    manual_user_validation = EXCLUDED.manual_user_validation,
     updated_at = CURRENT_TIMESTAMP
 RETURNING *;
 

--- a/internal/handlers/dashboard/auth_handler.go
+++ b/internal/handlers/dashboard/auth_handler.go
@@ -53,6 +53,13 @@ func (ah *AuthHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 			handlers.RenderError(w, http.StatusForbidden, err.Error())
 			return
 		}
+		// Credentials were valid but the account is not approved (or was
+		// revoked). Distinct from invalid credentials so the person knows to
+		// wait for an admin instead of retrying their password.
+		if errors.Is(err, services.ErrAccountPendingApproval) {
+			handlers.RenderError(w, http.StatusForbidden, err.Error())
+			return
+		}
 		handlers.RenderError(w, http.StatusUnauthorized, "Invalid credentials")
 		return
 	}

--- a/internal/handlers/dashboard/users_handler.go
+++ b/internal/handlers/dashboard/users_handler.go
@@ -28,9 +28,12 @@ func NewUsersHandler(userService *services.UserService) *UsersHandler {
 // stateless mode, where the account is ADMIN_EMAIL and not a database row.
 // LastConnectedAt is empty until the account's first successful sign-in.
 type UserResponse struct {
-	Id              string `json:"id"`
-	Email           string `json:"email"`
-	IsAdmin         bool   `json:"isAdmin"`
+	Id      string `json:"id"`
+	Email   string `json:"email"`
+	IsAdmin bool   `json:"isAdmin"`
+	// Enabled is false for an account an admin revoked, or one awaiting
+	// approval under SSO manual validation.
+	Enabled         bool   `json:"enabled"`
 	CreatedAt       string `json:"createdAt,omitempty"`
 	LastConnectedAt string `json:"lastConnectedAt,omitempty"`
 }
@@ -48,6 +51,7 @@ func userResponseFrom(user store.User) UserResponse {
 		Id:              user.Id,
 		Email:           user.Email,
 		IsAdmin:         user.IsAdmin,
+		Enabled:         user.Enabled,
 		CreatedAt:       createdAt,
 		LastConnectedAt: lastConnectedAt,
 	}
@@ -67,6 +71,7 @@ func renderUserServiceError(w http.ResponseWriter, err error) {
 	case errors.Is(err, services.ErrUsersRequireControlPlane),
 		errors.Is(err, services.ErrCannotChangeOwnAdminFlag),
 		errors.Is(err, services.ErrCannotDeleteOwnAccount),
+		errors.Is(err, services.ErrCannotDisableOwnAccount),
 		errors.Is(err, services.ErrInvalidCurrentPassword):
 		handlers.RenderError(w, http.StatusBadRequest, err.Error())
 	case errors.Is(err, services.ErrLastAdmin),
@@ -99,7 +104,7 @@ func (h *UsersHandler) GetMeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !config.IsDBMode() {
-		renderJSON(w, http.StatusOK, UserResponse{Email: principal.Email, IsAdmin: true})
+		renderJSON(w, http.StatusOK, UserResponse{Email: principal.Email, IsAdmin: true, Enabled: true})
 		return
 	}
 	user, err := h.userService.GetUserByID(r.Context(), principal.UserId)
@@ -177,7 +182,10 @@ func (h *UsersHandler) CreateUserHandler(w http.ResponseWriter, r *http.Request)
 	renderJSON(w, http.StatusCreated, userResponseFrom(user))
 }
 
-func (h *UsersHandler) UpdateUserAdminHandler(w http.ResponseWriter, r *http.Request) {
+// UpdateUserHandler patches the two admin-controlled flags of an account. Both
+// fields are optional pointers so a request can carry either one without the
+// absent one reading as "set to false"; sending both applies both.
+func (h *UsersHandler) UpdateUserHandler(w http.ResponseWriter, r *http.Request) {
 	principal := middleware.PrincipalFromContext(r.Context())
 	if principal == nil {
 		handlers.RenderError(w, http.StatusUnauthorized, "This route requires a dashboard session")
@@ -186,19 +194,27 @@ func (h *UsersHandler) UpdateUserAdminHandler(w http.ResponseWriter, r *http.Req
 	targetUserId := mux.Vars(r)["USER_ID"]
 	var requestBody struct {
 		IsAdmin *bool `json:"isAdmin"`
+		Enabled *bool `json:"enabled"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
 		handlers.RenderError(w, http.StatusBadRequest, "Invalid request body: "+err.Error())
 		return
 	}
-	if requestBody.IsAdmin == nil {
-		handlers.RenderError(w, http.StatusBadRequest, "isAdmin is required")
+	if requestBody.IsAdmin == nil && requestBody.Enabled == nil {
+		handlers.RenderError(w, http.StatusBadRequest, "isAdmin or enabled is required")
 		return
 	}
-	err := h.userService.SetUserAdmin(r.Context(), principal.UserId, targetUserId, *requestBody.IsAdmin)
-	if err != nil {
-		renderUserServiceError(w, err)
-		return
+	if requestBody.IsAdmin != nil {
+		if err := h.userService.SetUserAdmin(r.Context(), principal.UserId, targetUserId, *requestBody.IsAdmin); err != nil {
+			renderUserServiceError(w, err)
+			return
+		}
+	}
+	if requestBody.Enabled != nil {
+		if err := h.userService.SetUserEnabled(r.Context(), principal.UserId, targetUserId, *requestBody.Enabled); err != nil {
+			renderUserServiceError(w, err)
+			return
+		}
 	}
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/handlers/dashboard/users_handler.go
+++ b/internal/handlers/dashboard/users_handler.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
-	"expo-open-ota/config"
 	"expo-open-ota/internal/handlers"
 	"expo-open-ota/internal/middleware"
 	"expo-open-ota/internal/services"
@@ -95,19 +94,15 @@ func renderUserServiceError(w http.ResponseWriter, err error) {
 }
 
 // GetMeHandler answers with the account behind the current session. In
-// control-plane mode the row is re-read so the dashboard sees a revoked admin
-// flag on its next load, not at token refresh.
+// control-plane mode the service re-reads the row so the dashboard sees a
+// revoked admin flag on its next load, not at token refresh.
 func (h *UsersHandler) GetMeHandler(w http.ResponseWriter, r *http.Request) {
 	principal := middleware.PrincipalFromContext(r.Context())
 	if principal == nil {
 		handlers.RenderError(w, http.StatusUnauthorized, "This route requires a dashboard session")
 		return
 	}
-	if !config.IsDBMode() {
-		renderJSON(w, http.StatusOK, UserResponse{Email: principal.Email, IsAdmin: true, Enabled: true})
-		return
-	}
-	user, err := h.userService.GetUserByID(r.Context(), principal.UserId)
+	user, err := h.userService.GetMe(r.Context(), principal.UserId, principal.Email)
 	if err != nil {
 		// Only a missing row means the session is a leftover of a deleted
 		// account; an infrastructure failure must not read as a dead session.

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -139,7 +139,7 @@ func NewRouter(container *AppContainer) *mux.Router {
 	// Users management router (control-plane only, admin only)
 	authSubrouter.Handle("/users", adminOnly(http.HandlerFunc(container.UsersHandler.GetUsersHandler))).Methods(http.MethodGet)
 	authSubrouter.Handle("/users", adminOnly(http.HandlerFunc(container.UsersHandler.CreateUserHandler))).Methods(http.MethodPost)
-	authSubrouter.Handle("/users/{USER_ID}", adminOnly(http.HandlerFunc(container.UsersHandler.UpdateUserAdminHandler))).Methods(http.MethodPatch)
+	authSubrouter.Handle("/users/{USER_ID}", adminOnly(http.HandlerFunc(container.UsersHandler.UpdateUserHandler))).Methods(http.MethodPatch)
 	authSubrouter.Handle("/users/{USER_ID}", adminOnly(http.HandlerFunc(container.UsersHandler.DeleteUserHandler))).Methods(http.MethodDelete)
 
 	// Apps management router

--- a/internal/services/dashboard_auth_service.go
+++ b/internal/services/dashboard_auth_service.go
@@ -55,6 +55,13 @@ var ErrAdminEmailNotSet = errors.New("ADMIN_EMAIL is not set: stateless mode log
 // password verified, so the actionable message never leaks account existence.
 var ErrPasswordLoginDisabledBySSO = errors.New("password sign-in is disabled while SSO is active: sign in with SSO instead")
 
+// ErrAccountPendingApproval is returned for an account whose enabled flag is
+// off: either an admin revoked its access, or SSO manual validation is on and
+// the account has not been approved yet. Like ErrPasswordLoginDisabledBySSO it
+// is only reached after the credentials verified, so it leaks nothing about
+// which accounts exist.
+var ErrAccountPendingApproval = errors.New("this account is waiting for an administrator to approve it")
+
 // dashboardSubject scopes every dashboard JWT to the dashboard itself. Both
 // validators below reject any other subject, which is what keeps the upload
 // tokens minted by localBucket — signed with the same JWT_SECRET — from being
@@ -158,11 +165,19 @@ var ErrAuthUnavailable = errors.New("could not verify the account against the da
 // principalForUser records the connection and builds the session principal.
 // Both a password login and a refresh prove the account is actively using the
 // dashboard. Best-effort: a failed touch must not fail the sign-in.
-func (a *DashboardAuthService) principalForUser(ctx context.Context, user store.User) *DashboardPrincipal {
+// principalForUser is the single choke point every database-backed sign-in
+// path goes through (password login, SSO callback, token refresh), which is
+// why the enabled check lives here: no path can acquire a principal without
+// passing it. On the refresh path this is also what makes disabling an account
+// effective, since a live session token is never re-read against the database.
+func (a *DashboardAuthService) principalForUser(ctx context.Context, user store.User) (*DashboardPrincipal, error) {
+	if !user.Enabled {
+		return nil, ErrAccountPendingApproval
+	}
 	if err := a.userRepo.TouchUserLastConnected(ctx, user.Id); err != nil {
 		log.Printf("failed to record last connection for user %s: %v", user.Id, err)
 	}
-	return &DashboardPrincipal{UserId: user.Id, Email: user.Email, IsAdmin: user.IsAdmin}
+	return &DashboardPrincipal{UserId: user.Id, Email: user.Email, IsAdmin: user.IsAdmin}, nil
 }
 
 func (a *DashboardAuthService) resolveLoginPrincipal(ctx context.Context, email string, password string) (*DashboardPrincipal, error) {
@@ -194,7 +209,7 @@ func (a *DashboardAuthService) resolveLoginPrincipal(ctx context.Context, email 
 	if a.ssoEnforced != nil && a.ssoEnforced(ctx) && !user.IsAdmin {
 		return nil, ErrPasswordLoginDisabledBySSO
 	}
-	return a.principalForUser(ctx, user), nil
+	return a.principalForUser(ctx, user)
 }
 
 // resolveRefreshPrincipal re-resolves the account behind a refresh token by
@@ -211,7 +226,7 @@ func (a *DashboardAuthService) resolveRefreshPrincipal(ctx context.Context, user
 		}
 		return nil, fmt.Errorf("%w: %v", ErrAuthUnavailable, err)
 	}
-	return a.principalForUser(ctx, user), nil
+	return a.principalForUser(ctx, user)
 }
 
 func (a *DashboardAuthService) LoginWithEmailPassword(ctx context.Context, email string, password string) (*DashboardSession, error) {
@@ -229,7 +244,11 @@ func (a *DashboardAuthService) IssueSession(ctx context.Context, user store.User
 	if a.userRepo == nil {
 		return nil, errors.New("sessions can only be issued for database-backed accounts")
 	}
-	return a.generateSessionPair(*a.principalForUser(ctx, user))
+	principal, err := a.principalForUser(ctx, user)
+	if err != nil {
+		return nil, err
+	}
+	return a.generateSessionPair(*principal)
 }
 
 // ValidateSession accepts only a dashboard session JWT — not a refresh token,

--- a/internal/services/dashboard_auth_service_test.go
+++ b/internal/services/dashboard_auth_service_test.go
@@ -12,7 +12,7 @@ import (
 // seededSSOUser mirrors what the enterprise SSO provisioning inserts: a
 // member account with the empty password-hash sentinel.
 func seededSSOUser(id string, email string) store.InsertUserParameters {
-	return store.InsertUserParameters{ID: id, Email: email, PasswordHash: "", IsAdmin: false}
+	return store.InsertUserParameters{ID: id, Email: email, PasswordHash: "", IsAdmin: false, Enabled: true}
 }
 
 // SSO-provisioned accounts carry an empty password hash: no password may ever
@@ -63,6 +63,47 @@ func TestIssueSessionMintsAValidPair(t *testing.T) {
 	statelessService := NewDashboardAuthService(nil)
 	_, err = statelessService.IssueSession(ctx, user)
 	assert.Error(t, err)
+}
+
+// Disabling an account must close every door, not just the login form. The
+// refresh path matters most: session tokens are validated from their claims
+// alone, so a revoked account keeps a working session until it refreshes.
+func TestDisabledAccountCannotSignInOrRefresh(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret")
+	repo := newFakeUserRepo()
+	userService := NewUserService(repo)
+	authService := NewDashboardAuthService(repo)
+	ctx := context.Background()
+
+	admin, err := userService.CreateUser(ctx, "admin@example.com", "Sup3rSecret!", true)
+	require.NoError(t, err)
+	member, err := userService.CreateUser(ctx, "member@example.com", "Sup3rSecret!", false)
+	require.NoError(t, err)
+
+	// A live session, obtained while the account was still enabled.
+	session, err := authService.LoginWithEmailPassword(ctx, "member@example.com", "Sup3rSecret!")
+	require.NoError(t, err)
+
+	require.NoError(t, userService.SetUserEnabled(ctx, admin.Id, member.Id, false))
+
+	// Password login: the credentials are right, the account is not usable.
+	_, err = authService.LoginWithEmailPassword(ctx, "member@example.com", "Sup3rSecret!")
+	assert.ErrorIs(t, err, ErrAccountPendingApproval)
+
+	// Refresh: the leftover refresh token cannot mint a new pair.
+	_, err = authService.RefreshSession(ctx, session.RefreshToken)
+	assert.ErrorIs(t, err, ErrAccountPendingApproval)
+
+	// SSO callback path: same refusal, so no flow can bypass the flag.
+	disabled, err := repo.GetUserByID(ctx, member.Id)
+	require.NoError(t, err)
+	_, err = authService.IssueSession(ctx, disabled)
+	assert.ErrorIs(t, err, ErrAccountPendingApproval)
+
+	// Re-approving restores access.
+	require.NoError(t, userService.SetUserEnabled(ctx, admin.Id, member.Id, true))
+	_, err = authService.LoginWithEmailPassword(ctx, "member@example.com", "Sup3rSecret!")
+	assert.NoError(t, err)
 }
 
 func TestSSOEnforcementOnPasswordLogin(t *testing.T) {

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -96,6 +96,13 @@ func (s *UserService) GetUserByID(ctx context.Context, id string) (store.User, e
 	return s.userRepo.GetUserByID(ctx, id)
 }
 
+func (s *UserService) GetMe(ctx context.Context, userId string, email string) (store.User, error) {
+	if s.userRepo == nil {
+		return store.User{Email: email, IsAdmin: true, Enabled: true}, nil
+	}
+	return s.userRepo.GetUserByID(ctx, userId)
+}
+
 func (s *UserService) CreateUser(ctx context.Context, email string, password string, isAdmin bool) (store.User, error) {
 	if err := s.requireControlPlane(); err != nil {
 		return store.User{}, err

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -18,12 +18,14 @@ type UserRepository interface {
 	GetUserByEmail(ctx context.Context, email string) (store.User, error)
 	GetUserByID(ctx context.Context, id string) (store.User, error)
 	GetUsers(ctx context.Context) ([]store.User, error)
-	// DeleteUserByID and UpdateUserIsAdmin enforce the "at least one admin"
-	// invariant atomically (store.ErrWouldLeaveNoAdmin): a check-then-write at
-	// this level would race with concurrent demotions/deletions.
+	// DeleteUserByID, UpdateUserIsAdmin and UpdateUserEnabled enforce the "at
+	// least one enabled admin" invariant atomically
+	// (store.ErrWouldLeaveNoAdmin): a check-then-write at this level would race
+	// with concurrent demotions/deletions/disables.
 	DeleteUserByID(ctx context.Context, id string) error
 	UpdateUserPassword(ctx context.Context, id string, passwordHash string) error
 	UpdateUserIsAdmin(ctx context.Context, id string, isAdmin bool) error
+	UpdateUserEnabled(ctx context.Context, id string, enabled bool) error
 	TouchUserLastConnected(ctx context.Context, id string) error
 }
 
@@ -32,7 +34,8 @@ var (
 	ErrUsersRequireControlPlane  = errors.New("user accounts are managed in the database: this deployment runs in stateless mode, where the only account comes from ADMIN_EMAIL and ADMIN_PASSWORD")
 	ErrCannotChangeOwnAdminFlag  = errors.New("you cannot change your own admin status")
 	ErrCannotDeleteOwnAccount    = errors.New("you cannot delete your own account")
-	ErrLastAdmin                 = errors.New("there must always be at least one admin")
+	ErrCannotDisableOwnAccount   = errors.New("you cannot disable your own account")
+	ErrLastAdmin                 = errors.New("there must always be at least one enabled admin")
 	ErrInvalidCurrentPassword    = errors.New("the current password is incorrect")
 	ErrUserCreationDisabledBySSO = errors.New("SSO is active: accounts are provisioned automatically on their first SSO sign-in")
 )
@@ -119,6 +122,9 @@ func (s *UserService) CreateUser(ctx context.Context, email string, password str
 		Email:        normalizedEmail,
 		PasswordHash: passwordHash,
 		IsAdmin:      isAdmin,
+		// An admin creating an account by hand is the approval: nothing to
+		// validate afterwards.
+		Enabled: true,
 	})
 }
 
@@ -148,6 +154,28 @@ func (s *UserService) SetUserAdmin(ctx context.Context, actorUserId string, targ
 		return ErrCannotChangeOwnAdminFlag
 	}
 	if err := s.userRepo.UpdateUserIsAdmin(ctx, targetUserId, isAdmin); err != nil {
+		if errors.Is(err, store.ErrWouldLeaveNoAdmin) {
+			return ErrLastAdmin
+		}
+		return err
+	}
+	return nil
+}
+
+// SetUserEnabled approves or revokes an account without deleting it. Disabling
+// takes effect on the account's next token refresh at the latest, since a live
+// session token is only re-checked against the database there.
+func (s *UserService) SetUserEnabled(ctx context.Context, actorUserId string, targetUserId string, enabled bool) error {
+	if err := s.requireControlPlane(); err != nil {
+		return err
+	}
+	// Same reasoning as SetUserAdmin: enabling an account you are signed in
+	// with is a no-op, so the only meaningful self-target is locking yourself
+	// out.
+	if actorUserId == targetUserId {
+		return ErrCannotDisableOwnAccount
+	}
+	if err := s.userRepo.UpdateUserEnabled(ctx, targetUserId, enabled); err != nil {
 		if errors.Is(err, store.ErrWouldLeaveNoAdmin) {
 			return ErrLastAdmin
 		}

--- a/internal/services/user_service_test.go
+++ b/internal/services/user_service_test.go
@@ -28,7 +28,7 @@ func (r *fakeUserRepo) InsertUser(_ context.Context, params store.InsertUserPara
 			return store.User{}, &store.ErrResourceAlreadyExists{Resource: "user", Identifier: email}
 		}
 	}
-	user := store.User{Id: params.ID, Email: email, PasswordHash: params.PasswordHash, IsAdmin: params.IsAdmin}
+	user := store.User{Id: params.ID, Email: email, PasswordHash: params.PasswordHash, IsAdmin: params.IsAdmin, Enabled: params.Enabled}
 	r.users[params.ID] = user
 	return user, nil
 }
@@ -94,6 +94,19 @@ func (r *fakeUserRepo) UpdateUserIsAdmin(_ context.Context, id string, isAdmin b
 	return nil
 }
 
+func (r *fakeUserRepo) UpdateUserEnabled(_ context.Context, id string, enabled bool) error {
+	user, ok := r.users[id]
+	if !ok {
+		return &store.ErrResourceNotFound{Resource: "user", Identifier: id}
+	}
+	if user.IsAdmin && user.Enabled && !enabled && r.adminCount() <= 1 {
+		return store.ErrWouldLeaveNoAdmin
+	}
+	user.Enabled = enabled
+	r.users[id] = user
+	return nil
+}
+
 func (r *fakeUserRepo) TouchUserLastConnected(_ context.Context, id string) error {
 	user, ok := r.users[id]
 	if !ok {
@@ -105,12 +118,13 @@ func (r *fakeUserRepo) TouchUserLastConnected(_ context.Context, id string) erro
 	return nil
 }
 
-// adminCount backs the same "at least one admin" guard the guarded SQL
-// queries enforce in the real store.
+// adminCount backs the same "at least one enabled admin" guard the guarded SQL
+// queries enforce in the real store. A disabled admin cannot sign in, so it is
+// no safety net and does not count.
 func (r *fakeUserRepo) adminCount() int64 {
 	var count int64
 	for _, user := range r.users {
-		if user.IsAdmin {
+		if user.IsAdmin && user.Enabled {
 			count++
 		}
 	}
@@ -166,6 +180,52 @@ func TestSetUserAdminGuardsOwnFlagAndLastAdmin(t *testing.T) {
 
 	// member is now the last admin: demoting them must be refused.
 	assert.ErrorIs(t, service.SetUserAdmin(ctx, admin.Id, member.Id, false), ErrLastAdmin)
+}
+
+func TestCreateUserLandsEnabled(t *testing.T) {
+	// An admin creating the account by hand is the approval; nothing should be
+	// left pending behind them.
+	_, _, admin, member := seedUserService(t)
+	assert.True(t, admin.Enabled)
+	assert.True(t, member.Enabled)
+}
+
+func TestSetUserEnabledGuardsSelfAndLastAdmin(t *testing.T) {
+	service, repo, admin, member := seedUserService(t)
+	ctx := context.Background()
+
+	// Locking yourself out of the dashboard is never a legitimate move.
+	assert.ErrorIs(t, service.SetUserEnabled(ctx, admin.Id, admin.Id, false), ErrCannotDisableOwnAccount)
+
+	// admin is the only enabled admin: disabling them (by anyone) is refused,
+	// exactly like deleting or demoting them.
+	assert.ErrorIs(t, service.SetUserEnabled(ctx, member.Id, admin.Id, false), ErrLastAdmin)
+
+	require.NoError(t, service.SetUserEnabled(ctx, admin.Id, member.Id, false))
+	disabled, err := repo.GetUserByID(ctx, member.Id)
+	require.NoError(t, err)
+	assert.False(t, disabled.Enabled)
+
+	require.NoError(t, service.SetUserEnabled(ctx, admin.Id, member.Id, true))
+	reEnabled, err := repo.GetUserByID(ctx, member.Id)
+	require.NoError(t, err)
+	assert.True(t, reEnabled.Enabled)
+}
+
+// A disabled admin cannot sign in, so it must not count as the admin that
+// keeps the dashboard reachable: without this, disabling one admin and then
+// deleting the other would leave nobody able to get back in.
+func TestDisabledAdminIsNoLongerASafetyNet(t *testing.T) {
+	service, _, admin, member := seedUserService(t)
+	ctx := context.Background()
+
+	require.NoError(t, service.SetUserAdmin(ctx, admin.Id, member.Id, true))
+	require.NoError(t, service.SetUserEnabled(ctx, admin.Id, member.Id, false))
+
+	// member is an admin again on paper, but a disabled one: admin is back to
+	// being the last usable admin and is protected as such.
+	assert.ErrorIs(t, service.SetUserAdmin(ctx, member.Id, admin.Id, false), ErrLastAdmin)
+	assert.ErrorIs(t, service.DeleteUser(ctx, member.Id, admin.Id), ErrLastAdmin)
 }
 
 func TestDeleteUserGuardsSelfAndLastAdmin(t *testing.T) {

--- a/internal/store/user_postgres.go
+++ b/internal/store/user_postgres.go
@@ -19,7 +19,11 @@ type User struct {
 	Email        string
 	PasswordHash string
 	IsAdmin      bool
-	CreatedAt    time.Time
+	// Enabled gates every sign-in path. Accounts are enabled on creation; an
+	// admin can revoke access without deleting the account, and SSO manual
+	// validation provisions new accounts disabled until an admin approves them.
+	Enabled   bool
+	CreatedAt time.Time
 	// Nil until the account's first successful sign-in.
 	LastConnectedAt *time.Time
 }
@@ -29,6 +33,7 @@ type InsertUserParameters struct {
 	Email        string
 	PasswordHash string
 	IsAdmin      bool
+	Enabled      bool
 }
 
 // NormalizeEmail is the single place an email is canonicalized before hitting
@@ -55,6 +60,7 @@ func (s *PostgresUserStore) InsertUser(ctx context.Context, params InsertUserPar
 		Email:        email,
 		PasswordHash: params.PasswordHash,
 		IsAdmin:      params.IsAdmin,
+		Enabled:      params.Enabled,
 	})
 	if err != nil {
 		if database.IsUniqueViolation(err) {
@@ -66,6 +72,7 @@ func (s *PostgresUserStore) InsertUser(ctx context.Context, params InsertUserPar
 		Id:        row.ID.String(),
 		Email:     row.Email,
 		IsAdmin:   row.IsAdmin,
+		Enabled:   row.Enabled,
 		CreatedAt: row.CreatedAt.Time,
 	}, nil
 }
@@ -104,6 +111,7 @@ func (s *PostgresUserStore) GetUsers(ctx context.Context) ([]User, error) {
 			Id:              row.ID.String(),
 			Email:           row.Email,
 			IsAdmin:         row.IsAdmin,
+			Enabled:         row.Enabled,
 			CreatedAt:       row.CreatedAt.Time,
 			LastConnectedAt: timestamptzToPtr(row.LastConnectedAt),
 		}
@@ -160,6 +168,25 @@ func (s *PostgresUserStore) UpdateUserIsAdmin(ctx context.Context, id string, is
 	return nil
 }
 
+func (s *PostgresUserStore) UpdateUserEnabled(ctx context.Context, id string, enabled bool) error {
+	commandTag, err := s.engine.Queries.UpdateUserEnabledByID(ctx, pgdb.UpdateUserEnabledByIDParams{
+		ID:      ToPgUUID(id),
+		Enabled: enabled,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update user enabled flag in database: %w", err)
+	}
+	if commandTag.RowsAffected() == 0 {
+		// The guarded query matches no row both for a missing user and for the
+		// last remaining enabled admin — look the row up to tell the two apart.
+		if _, lookupErr := s.GetUserByID(ctx, id); lookupErr != nil {
+			return lookupErr
+		}
+		return ErrWouldLeaveNoAdmin
+	}
+	return nil
+}
+
 func (s *PostgresUserStore) TouchUserLastConnected(ctx context.Context, id string) error {
 	if err := s.engine.Queries.TouchUserLastConnectedAt(ctx, ToPgUUID(id)); err != nil {
 		return fmt.Errorf("failed to touch user last connection in database: %w", err)
@@ -173,6 +200,7 @@ func userFromRow(row pgdb.User) User {
 		Email:           row.Email,
 		PasswordHash:    row.PasswordHash,
 		IsAdmin:         row.IsAdmin,
+		Enabled:         row.Enabled,
 		CreatedAt:       row.CreatedAt.Time,
 		LastConnectedAt: timestamptzToPtr(row.LastConnectedAt),
 	}

--- a/test/dashboard_test.go
+++ b/test/dashboard_test.go
@@ -6,14 +6,15 @@ import (
 	infrastructure "expo-open-ota/internal/router"
 	"expo-open-ota/internal/services"
 	"expo-open-ota/internal/types"
-	"github.com/jarcoal/httpmock"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLoginDashboardNotEnabled(t *testing.T) {
@@ -117,7 +118,7 @@ func TestGetMeStateless(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+login().Token)
 	router.ServeHTTP(respRec, req)
 	assert.Equal(t, http.StatusOK, respRec.Code)
-	assert.Equal(t, `{"id":"","email":"admin@expo-open-ota.dev","isAdmin":true}`, strings.TrimSpace(respRec.Body.String()))
+	assert.Equal(t, `{"id":"","email":"admin@expo-open-ota.dev","isAdmin":true,"enabled":true}`, strings.TrimSpace(respRec.Body.String()))
 }
 
 // User management is a control-plane feature: in stateless mode the routes


### PR DESCRIPTION
Add an enabled field to the user table, and a setting on the SSO config to require manual approval for newly created SSO users.