### PR TITLE
feat/rbac

### DIFF
--- a/.github/img/cover.svg
+++ b/.github/img/cover.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Expo Open OTA v3">
+  <defs>
+    <linearGradient id="mercure" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0083b4"/>
+      <stop offset="100%" stop-color="#d95892"/>
+    </linearGradient>
+    <radialGradient id="glowPink" cx="85%" cy="10%" r="60%">
+      <stop offset="0%" stop-color="#d95892" stop-opacity="0.32"/>
+      <stop offset="100%" stop-color="#d95892" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glowBlue" cx="8%" cy="95%" r="65%">
+      <stop offset="0%" stop-color="#0083b4" stop-opacity="0.38"/>
+      <stop offset="100%" stop-color="#0083b4" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="planet" cx="35%" cy="30%" r="80%">
+      <stop offset="0%" stop-color="#442591"/>
+      <stop offset="100%" stop-color="#190053"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1200" height="630" fill="#120031"/>
+  <rect width="1200" height="630" fill="url(#glowPink)"/>
+  <rect width="1200" height="630" fill="url(#glowBlue)"/>
+
+  <!-- stars -->
+  <g fill="#ffffff">
+    <circle cx="110" cy="90" r="2" opacity="0.8"/>
+    <circle cx="260" cy="180" r="1.5" opacity="0.5"/>
+    <circle cx="420" cy="70" r="2" opacity="0.6"/>
+    <circle cx="640" cy="140" r="1.5" opacity="0.4"/>
+    <circle cx="820" cy="60" r="2" opacity="0.7"/>
+    <circle cx="1020" cy="200" r="1.5" opacity="0.5"/>
+    <circle cx="1120" cy="330" r="2" opacity="0.6"/>
+    <circle cx="180" cy="420" r="1.5" opacity="0.5"/>
+    <circle cx="90" cy="560" r="2" opacity="0.6"/>
+    <circle cx="520" cy="560" r="1.5" opacity="0.4"/>
+    <circle cx="700" cy="500" r="2" opacity="0.5"/>
+    <circle cx="950" cy="540" r="1.5" opacity="0.6"/>
+    <circle cx="360" cy="300" r="1.5" opacity="0.35"/>
+  </g>
+
+  <!-- planet with orbit -->
+  <g transform="translate(950 430)">
+    <ellipse rx="190" ry="58" fill="none" stroke="url(#mercure)" stroke-width="6" stroke-opacity="0.85" transform="rotate(-18)"/>
+    <circle r="110" fill="url(#planet)"/>
+    <circle r="110" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="2"/>
+    <circle cx="-175" cy="45" r="10" fill="#ffdb5c" transform="rotate(-18)"/>
+  </g>
+
+  <!-- copy -->
+  <g font-family="'Quicksand','Trebuchet MS','Segoe UI',sans-serif">
+    <text x="90" y="215" font-size="34" font-weight="600" letter-spacing="14" fill="#ffffff" fill-opacity="0.75">EXPO OPEN OTA</text>
+    <text x="78" y="400" font-size="190" font-weight="700" fill="url(#mercure)">v3</text>
+    <text x="90" y="480" font-size="30" font-weight="500" fill="#ffffff" fill-opacity="0.65">Self-hosted over-the-air updates for Expo apps,</text>
+    <text x="90" y="522" font-size="30" font-weight="500" fill="#ffffff" fill-opacity="0.65">now multi-app, with a control plane.</text>
+  </g>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src=".github/img/social_card.png" alt="Expo Open OTA" />
+  <img src=".github/img/cover.svg" alt="Expo Open OTA" />
 </p>
 
 <h3 align="center">Self-hosted over-the-air updates for Expo apps, built for production at scale.</h3>

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -15,6 +15,7 @@ import { Users } from '@/pages/Users';
 import { Account } from '@/pages/Account';
 import { License } from '@/ee/pages/License';
 import { Sso } from '@/ee/pages/Sso';
+import { Roles } from '@/ee/pages/Roles';
 import { SettingsProvider } from '@/lib/SettingsContext';
 import { CurrentUserProvider } from '@/lib/CurrentUserContext';
 import { PermissionsProvider } from '@/ee/lib/PermissionsContext';
@@ -53,6 +54,7 @@ export const App = () => {
                       <Route path="/app-info" element={withLayout(<AppInfo />)} />
                       <Route path="/tokens" element={withLayout(<ApiTokens />)} />
                       <Route path="/users" element={withLayout(<Users />)} />
+                      <Route path="/roles" element={withLayout(<Roles />)} />
                       <Route path="/sso" element={withLayout(<Sso />)} />
                       <Route path="/license" element={withLayout(<License />)} />
                       <Route path="/account" element={withLayout(<Account />)} />

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -19,9 +19,16 @@ import { Roles } from '@/ee/pages/Roles';
 import { SettingsProvider } from '@/lib/SettingsContext';
 import { CurrentUserProvider } from '@/lib/CurrentUserContext';
 import { PermissionsProvider } from '@/ee/lib/PermissionsContext';
+import { RequiresApp } from '@/components/RequiresApp';
 
 function withLayout(children: ReactNode) {
   return <Layout>{children}</Layout>;
+}
+
+// App-scoped pages have nothing to render without a visible app: RequiresApp
+// swaps them for the "No app available" empty state.
+function withApp(children: ReactNode) {
+  return <RequiresApp>{children}</RequiresApp>;
 }
 
 export const App = () => {
@@ -48,11 +55,11 @@ export const App = () => {
                   <PermissionsProvider>
                     <SelectedAppProvider>
                     <Routes>
-                      <Route path="/" element={withLayout(<Updates />)} />
+                      <Route path="/" element={withLayout(withApp(<Updates />))} />
                       <Route path="/settings" element={withLayout(<Settings />)} />
-                      <Route path="/channels" element={withLayout(<Channels />)} />
-                      <Route path="/app-info" element={withLayout(<AppInfo />)} />
-                      <Route path="/tokens" element={withLayout(<ApiTokens />)} />
+                      <Route path="/channels" element={withLayout(withApp(<Channels />))} />
+                      <Route path="/app-info" element={withLayout(withApp(<AppInfo />))} />
+                      <Route path="/tokens" element={withLayout(withApp(<ApiTokens />))} />
                       <Route path="/users" element={withLayout(<Users />)} />
                       <Route path="/roles" element={withLayout(<Roles />)} />
                       <Route path="/sso" element={withLayout(<Sso />)} />

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -17,6 +17,7 @@ import { License } from '@/ee/pages/License';
 import { Sso } from '@/ee/pages/Sso';
 import { SettingsProvider } from '@/lib/SettingsContext';
 import { CurrentUserProvider } from '@/lib/CurrentUserContext';
+import { PermissionsProvider } from '@/ee/lib/PermissionsContext';
 
 function withLayout(children: ReactNode) {
   return <Layout>{children}</Layout>;
@@ -43,7 +44,8 @@ export const App = () => {
             isLoggedIn ? (
               <SettingsProvider>
                 <CurrentUserProvider>
-                  <SelectedAppProvider>
+                  <PermissionsProvider>
+                    <SelectedAppProvider>
                     <Routes>
                       <Route path="/" element={withLayout(<Updates />)} />
                       <Route path="/settings" element={withLayout(<Settings />)} />
@@ -56,7 +58,8 @@ export const App = () => {
                       <Route path="/account" element={withLayout(<Account />)} />
                       <Route path="/logout" element={withLayout(<Logout />)} />
                     </Routes>
-                  </SelectedAppProvider>
+                    </SelectedAppProvider>
+                  </PermissionsProvider>
                 </CurrentUserProvider>
               </SettingsProvider>
             ) : null

--- a/apps/dashboard/src/components/Combobox/index.tsx
+++ b/apps/dashboard/src/components/Combobox/index.tsx
@@ -26,6 +26,8 @@ interface ComboboxProps {
   onChange: (value: string) => void;
   loading?: boolean;
   label?: string;
+  // Disables the trigger entirely (e.g. while the surrounding form saves).
+  disabled?: boolean;
   // Optional action pinned under the options (e.g. "New Application"). Stays
   // visible whatever the search input, since it is not one of the options.
   action?: { label: string; icon?: React.ReactNode; onSelect: () => void };
@@ -36,7 +38,7 @@ interface ComboboxProps {
 
 export function Combobox(props: ComboboxProps) {
   const [open, setOpen] = React.useState(false);
-  const { options, value, onChange, loading, label, action, className } = props;
+  const { options, value, onChange, loading, label, disabled, action, className } = props;
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -44,6 +46,7 @@ export function Combobox(props: ComboboxProps) {
           variant="outline"
           role="combobox"
           aria-expanded={open}
+          disabled={disabled}
           className={cn('w-max justify-between font-normal', className)}>
           <span className="truncate">
             {value ? options.find(opt => opt.value === value)?.label : label || 'Select option'}

--- a/apps/dashboard/src/components/Combobox/index.tsx
+++ b/apps/dashboard/src/components/Combobox/index.tsx
@@ -37,15 +37,21 @@ interface ComboboxProps {
 }
 
 export function Combobox(props: ComboboxProps) {
-  const [open, setOpen] = React.useState(false);
   const { options, value, onChange, loading, label, disabled, action, className } = props;
+  const [open, setOpen] = React.useState(false);
+  // Disabling only blocks the trigger: a popover already open when disabled
+  // flips to true (e.g. the surrounding form starts saving) would stay
+  // interactive, so close it.
+  React.useEffect(() => {
+    if (disabled) setOpen(false);
+  }, [disabled]);
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
           variant="outline"
           role="combobox"
-          aria-expanded={open}
+          aria-expanded={disabled ? false : open}
           disabled={disabled}
           className={cn('w-max justify-between font-normal', className)}>
           <span className="truncate">

--- a/apps/dashboard/src/components/RequiresApp.tsx
+++ b/apps/dashboard/src/components/RequiresApp.tsx
@@ -1,0 +1,62 @@
+import { ReactNode, useState } from 'react';
+import { PackageOpen, Plus } from 'lucide-react';
+import { useSelectedApp } from '@/lib/SelectedAppContext';
+import { useCurrentUser } from '@/lib/CurrentUserContext';
+import { useSettings } from '@/lib/SettingsContext';
+import { usePermissions } from '@/ee/lib/PermissionsContext';
+import { Button } from '@/components/ui/button';
+import { CreateAppModal } from '@/components/app-creation-modal';
+
+// Wraps the app-scoped pages (updates, channels, app info, tokens): when the
+// account can see no app at all, the page is replaced by an explicit empty
+// state instead of empty tables that read like a bug. Admins get the create
+// path right there; members learn who to ask.
+export const RequiresApp = ({ children }: { children: ReactNode }) => {
+  const { CONTROL_PLANE_ENABLED } = useSettings();
+  const { apps, isLoading, refreshApps, setSelectedAppId } = useSelectedApp();
+  const { isAdmin } = useCurrentUser();
+  const { enabled: rbacEnabled } = usePermissions();
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+
+  // While the list loads the pages render their own skeletons; the empty
+  // state only takes over once we know there is truly nothing to show.
+  if (isLoading || apps.length > 0) {
+    return <>{children}</>;
+  }
+
+  const canCreateApp = CONTROL_PLANE_ENABLED && isAdmin;
+  const description = !CONTROL_PLANE_ENABLED
+    ? 'No apps are configured on this server. Check the server configuration.'
+    : canCreateApp
+      ? 'Create your first app to start shipping over-the-air updates.'
+      : rbacEnabled
+        ? 'You do not have access to any app yet. Ask an admin to grant you access.'
+        : 'No apps yet. Ask an admin to create one.';
+
+  return (
+    <div className="flex min-h-[60vh] w-full items-center justify-center">
+      <div className="flex max-w-md flex-col items-center gap-3 rounded-2xl border border-dashed bg-muted/20 px-10 py-12 text-center">
+        <span className="flex h-11 w-11 items-center justify-center rounded-full border bg-background text-muted-foreground">
+          <PackageOpen className="h-5 w-5" strokeWidth={1.75} />
+        </span>
+        <h2 className="text-base font-semibold">No app available</h2>
+        <p className="text-sm text-muted-foreground">{description}</p>
+        {canCreateApp && (
+          <Button size="sm" className="mt-2" onClick={() => setIsCreateModalOpen(true)}>
+            <Plus className="h-4 w-4" /> Create app
+          </Button>
+        )}
+      </div>
+      {canCreateApp && (
+        <CreateAppModal
+          isOpen={isCreateModalOpen}
+          onClose={() => setIsCreateModalOpen(false)}
+          onAppCreated={async appId => {
+            await refreshApps();
+            setSelectedAppId(appId);
+          }}
+        />
+      )}
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/RequiresApp.tsx
+++ b/apps/dashboard/src/components/RequiresApp.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useState } from 'react';
 import { PackageOpen, Plus } from 'lucide-react';
+import { ApiError } from '@/components/APIError';
 import { useSelectedApp } from '@/lib/SelectedAppContext';
 import { useCurrentUser } from '@/lib/CurrentUserContext';
 import { useSettings } from '@/lib/SettingsContext';
@@ -13,7 +14,7 @@ import { CreateAppModal } from '@/components/app-creation-modal';
 // path right there; members learn who to ask.
 export const RequiresApp = ({ children }: { children: ReactNode }) => {
   const { CONTROL_PLANE_ENABLED } = useSettings();
-  const { apps, isLoading, refreshApps, setSelectedAppId } = useSelectedApp();
+  const { apps, isLoading, error, refreshApps, setSelectedAppId } = useSelectedApp();
   const { isAdmin } = useCurrentUser();
   const { enabled: rbacEnabled } = usePermissions();
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
@@ -22,6 +23,16 @@ export const RequiresApp = ({ children }: { children: ReactNode }) => {
   // state only takes over once we know there is truly nothing to show.
   if (isLoading || apps.length > 0) {
     return <>{children}</>;
+  }
+
+  // A failed app list is not an empty one: show the error instead of a
+  // misleading "no app available".
+  if (error) {
+    return (
+      <div className="w-full pt-8">
+        <ApiError error={error} />
+      </div>
+    );
   }
 
   const canCreateApp = CONTROL_PLANE_ENABLED && isAdmin;

--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Plus,
   Radio,
   Settings,
+  ShieldCheck,
   Users,
 } from 'lucide-react';
 import clsx from 'clsx';
@@ -196,6 +197,9 @@ export function AppSidebar() {
                     ) : undefined
                   }>
                   Users
+                </NavLink>
+                <NavLink to="/roles" icon={ShieldCheck} badge={<EnterpriseNavBadge />}>
+                  Roles
                 </NavLink>
                 <NavLink to="/sso" icon={Fingerprint} badge={<EnterpriseNavBadge />}>
                   SSO

--- a/apps/dashboard/src/components/user-creation-modal.tsx
+++ b/apps/dashboard/src/components/user-creation-modal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { api, describeApiError } from '@/lib/api';
 import { useToast } from '@/hooks/use-toast';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   Dialog,
   DialogContent,
@@ -14,6 +15,8 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PasswordRulesChecklist } from '@/components/ui/password-rules-checklist';
 import { isPasswordValid } from '@/lib/password-policy';
+import { usePermissions } from '@/ee/lib/PermissionsContext';
+import { DraftGrant, GrantsEditor } from '@/ee/components/GrantsEditor';
 
 type CreateUserModalProps = {
   isOpen: boolean;
@@ -23,15 +26,22 @@ type CreateUserModalProps = {
 
 export const CreateUserModal = ({ isOpen, onClose, onUserCreated }: CreateUserModalProps) => {
   const { toast } = useToast();
+  const queryClient = useQueryClient();
+  // While enterprise roles are enforced, a member created without a grant
+  // sees an empty dashboard, so the modal offers the role assignment
+  // directly. Without a license the modal keeps its community shape.
+  const { enabled: rbacEnabled } = usePermissions();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isAdmin, setIsAdmin] = useState(false);
+  const [grants, setGrants] = useState<DraftGrant[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleClose = () => {
     setEmail('');
     setPassword('');
     setIsAdmin(false);
+    setGrants([]);
     onClose();
   };
 
@@ -43,10 +53,30 @@ export const CreateUserModal = ({ isOpen, onClose, onUserCreated }: CreateUserMo
     setIsSubmitting(true);
     try {
       const user = await api.createUser({ email: email.trim(), password, isAdmin });
+      // The grants ride a second call; the account already exists if it
+      // fails, so say exactly that instead of a generic creation error.
+      if (!isAdmin && rbacEnabled && grants.length > 0) {
+        try {
+          await api.setUserGrants(user.id, grants);
+          queryClient.invalidateQueries({ queryKey: ['userGrantsSummary'] });
+        } catch (grantError) {
+          toast({
+            ...describeApiError(
+              grantError,
+              `"${user.email}" was created but assigning their roles failed. Open Roles on their row to retry.`
+            ),
+            variant: 'destructive',
+          });
+          onUserCreated?.();
+          handleClose();
+          return;
+        }
+      }
       toast({
         title: 'User created',
         description: `"${user.email}" can now sign in to the dashboard.`,
       });
+      queryClient.invalidateQueries({ queryKey: ['userGrantsSummary'] });
       onUserCreated?.();
       handleClose();
     } catch (error) {
@@ -58,7 +88,10 @@ export const CreateUserModal = ({ isOpen, onClose, onUserCreated }: CreateUserMo
 
   return (
     <Dialog open={isOpen} onOpenChange={open => !open && handleClose()}>
-      <DialogContent className="sm:max-w-[420px]">
+      <DialogContent
+        className={
+          rbacEnabled ? 'max-h-[85vh] overflow-y-auto sm:max-w-[560px]' : 'sm:max-w-[420px]'
+        }>
         <form onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle className="text-lg">Create user</DialogTitle>
@@ -109,6 +142,16 @@ export const CreateUserModal = ({ isOpen, onClose, onUserCreated }: CreateUserMo
               />
               <span>Admin account</span>
             </label>
+            {rbacEnabled && !isAdmin && (
+              <div className="space-y-2 border-t pt-4">
+                <p className="text-xs font-medium text-foreground">App access</p>
+                <p className="text-xs text-muted-foreground">
+                  Members only see the apps you grant them. Without any grant this account will see
+                  an empty dashboard.
+                </p>
+                <GrantsEditor draft={grants} onChange={setGrants} disabled={isSubmitting} />
+              </div>
+            )}
           </div>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={handleClose} disabled={isSubmitting}>

--- a/apps/dashboard/src/ee/components/GrantsEditor.tsx
+++ b/apps/dashboard/src/ee/components/GrantsEditor.tsx
@@ -134,6 +134,7 @@ export const GrantsEditor = ({
             <p className="text-xs font-medium text-muted-foreground">Role on this app</p>
             <Combobox
               options={roleOptions}
+              disabled={disabled}
               value={grant.roleId ?? NO_ROLE_VALUE}
               onChange={value =>
                 updateGrant(grant.appId, {
@@ -195,6 +196,7 @@ export const GrantsEditor = ({
           <p className="text-xs font-medium text-muted-foreground">Grant access to</p>
           <Combobox
             options={availableApps.map(app => ({ value: app.id, label: app.name || app.id }))}
+            disabled={disabled}
             value=""
             onChange={appId => {
               if (appId) {

--- a/apps/dashboard/src/ee/components/GrantsEditor.tsx
+++ b/apps/dashboard/src/ee/components/GrantsEditor.tsx
@@ -1,0 +1,223 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Plus, Trash2 } from 'lucide-react';
+import { api } from '@/lib/api';
+import { useSelectedApp } from '@/lib/SelectedAppContext';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Combobox } from '@/components/Combobox';
+import { PERMISSION_GROUPS } from '@/ee/lib/permissionCatalog';
+import { RoleFormDialog } from '@/ee/components/RoleFormDialog';
+
+export type DraftGrant = {
+  appId: string;
+  roleId: string | null;
+  extraPermissions: string[];
+};
+
+// Per-app access editor shared by the user Roles panel and the creation
+// modal. The primary flow is "pick a role per app"; direct permissions are
+// deliberately tucked behind a per-app "custom permissions" toggle so they
+// read as the advanced path, not as the way roles are assigned.
+export const GrantsEditor = ({
+  draft,
+  onChange,
+  disabled,
+}: {
+  draft: DraftGrant[];
+  onChange: (next: DraftGrant[]) => void;
+  disabled?: boolean;
+}) => {
+  const { apps } = useSelectedApp();
+  const queryClient = useQueryClient();
+  const rolesQuery = useQuery({
+    queryKey: ['roles'],
+    queryFn: () => api.getRoles(),
+  });
+
+  // The inline "New role" flow: which app card asked for it, so the created
+  // role lands selected on that grant. 'none' marks the empty-state button,
+  // which has no grant to select the role on.
+  const [roleDialogForApp, setRoleDialogForApp] = useState<string | null>(null);
+
+  // Cards whose custom section was opened by hand; cards carrying saved
+  // extras start open so nothing granted is ever hidden.
+  const [customizedApps, setCustomizedApps] = useState<Set<string>>(new Set());
+  const isCustomized = (grant: DraftGrant) =>
+    customizedApps.has(grant.appId) || grant.extraPermissions.length > 0;
+
+  const appName = (appId: string) => {
+    const app = apps.find(candidate => candidate.id === appId);
+    return app?.name || appId;
+  };
+  const grantedAppIds = new Set(draft.map(grant => grant.appId));
+  const availableApps = apps.filter(app => !grantedAppIds.has(app.id));
+
+  // The Combobox renders its `label` prop for an empty value, so "no role"
+  // needs a real sentinel value to display as a proper selection.
+  const NO_ROLE_VALUE = 'none';
+  const roleOptions = [
+    { value: NO_ROLE_VALUE, label: 'No role (read-only)' },
+    ...(rolesQuery.data ?? []).map(role => ({ value: role.id, label: role.name })),
+  ];
+
+  const updateGrant = (appId: string, patch: Partial<DraftGrant>) => {
+    onChange(draft.map(grant => (grant.appId === appId ? { ...grant, ...patch } : grant)));
+  };
+
+  const setCustomized = (appId: string, next: boolean) => {
+    setCustomizedApps(previous => {
+      const draftSet = new Set(previous);
+      if (next) {
+        draftSet.add(appId);
+      } else {
+        draftSet.delete(appId);
+      }
+      return draftSet;
+    });
+    if (!next) {
+      // Switching the custom section off means "role only": drop the extras
+      // instead of keeping them active but invisible.
+      updateGrant(appId, { extraPermissions: [] });
+    }
+  };
+
+  const toggleExtra = (appId: string, permission: string, next: boolean) => {
+    const grant = draft.find(candidate => candidate.appId === appId);
+    if (!grant) return;
+    const extras = new Set(grant.extraPermissions);
+    if (next) {
+      extras.add(permission);
+    } else {
+      extras.delete(permission);
+    }
+    updateGrant(appId, { extraPermissions: Array.from(extras) });
+  };
+
+  return (
+    <div className="space-y-4">
+      {(rolesQuery.data ?? []).length === 0 && !rolesQuery.isLoading && (
+        <div className="flex items-center justify-between gap-3 rounded-lg border bg-muted/30 px-3 py-2.5 text-xs text-muted-foreground">
+          <span>No roles yet. Create one, e.g. Release manager, then assign it here.</span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={disabled}
+            onClick={() => setRoleDialogForApp('none')}
+            className="h-7 shrink-0 gap-1">
+            <Plus className="h-3.5 w-3.5" /> Create role
+          </Button>
+        </div>
+      )}
+
+      {draft.map(grant => (
+        <div key={grant.appId} className="rounded-xl border p-4">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-sm font-medium">{appName(grant.appId)}</p>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={disabled}
+              onClick={() => onChange(draft.filter(g => g.appId !== grant.appId))}
+              className="h-8 w-8 p-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+              title="Remove access to this app">
+              <Trash2 />
+            </Button>
+          </div>
+
+          <div className="mt-3 space-y-1.5">
+            <p className="text-xs font-medium text-muted-foreground">Role on this app</p>
+            <Combobox
+              options={roleOptions}
+              value={grant.roleId ?? NO_ROLE_VALUE}
+              onChange={value =>
+                updateGrant(grant.appId, {
+                  // Re-selecting the current option makes the Combobox emit
+                  // '': both spellings mean "no role".
+                  roleId: value === NO_ROLE_VALUE || value === '' ? null : value,
+                })
+              }
+              loading={rolesQuery.isLoading}
+              label="role"
+              className="w-full"
+              action={{
+                label: 'New role',
+                icon: <Plus className="h-3.5 w-3.5" />,
+                onSelect: () => setRoleDialogForApp(grant.appId),
+              }}
+            />
+          </div>
+
+          <div className="mt-3.5 border-t pt-3">
+            <label className="flex cursor-pointer items-center justify-between gap-3 text-sm">
+              <span className="text-muted-foreground">
+                Custom permissions for this app
+                <span className="block text-xs text-muted-foreground/70">
+                  Granted on top of the role, for one-off needs.
+                </span>
+              </span>
+              <Switch
+                checked={isCustomized(grant)}
+                disabled={disabled}
+                onCheckedChange={next => setCustomized(grant.appId, next)}
+                aria-label="Custom permissions for this app"
+              />
+            </label>
+            {isCustomized(grant) && (
+              <div className="mt-3 grid grid-cols-1 gap-x-4 gap-y-2 sm:grid-cols-2">
+                {PERMISSION_GROUPS.flatMap(group => group.permissions).map(permission => (
+                  <label
+                    key={permission.value}
+                    className="flex cursor-pointer items-center justify-between gap-2 text-sm"
+                    title={permission.description}>
+                    <span className="truncate">{permission.label}</span>
+                    <Switch
+                      checked={grant.extraPermissions.includes(permission.value)}
+                      disabled={disabled}
+                      onCheckedChange={next => toggleExtra(grant.appId, permission.value, next)}
+                      aria-label={permission.label}
+                    />
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      ))}
+
+      {availableApps.length > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-xs font-medium text-muted-foreground">Grant access to</p>
+          <Combobox
+            options={availableApps.map(app => ({ value: app.id, label: app.name || app.id }))}
+            value=""
+            onChange={appId => {
+              if (appId) {
+                onChange([...draft, { appId, roleId: null, extraPermissions: [] }]);
+              }
+            }}
+            label="Select an app…"
+            className="w-full"
+          />
+        </div>
+      )}
+
+      <RoleFormDialog
+        open={roleDialogForApp !== null}
+        role={null}
+        onClose={() => setRoleDialogForApp(null)}
+        onSaved={created => {
+          queryClient.invalidateQueries({ queryKey: ['roles'] });
+          if (created && roleDialogForApp && roleDialogForApp !== 'none') {
+            updateGrant(roleDialogForApp, { roleId: created.id });
+          }
+        }}
+      />
+    </div>
+  );
+};

--- a/apps/dashboard/src/ee/components/RoleFormDialog.tsx
+++ b/apps/dashboard/src/ee/components/RoleFormDialog.tsx
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+import { useEffect, useState } from 'react';
+import { api, ApiProblemError, RoleRecord } from '@/lib/api';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useToast } from '@/hooks/use-toast';
+import { PERMISSION_GROUPS } from '@/ee/lib/permissionCatalog';
+
+// Create/edit form for one role: a name and the permission catalog as
+// toggles. `role` null means create; the dialog resets its draft every time
+// it opens so a cancelled edit never leaks into the next one.
+export const RoleFormDialog = ({
+  open,
+  role,
+  onClose,
+  onSaved,
+}: {
+  open: boolean;
+  role: RoleRecord | null;
+  onClose: () => void;
+  onSaved: () => void;
+}) => {
+  const { toast } = useToast();
+  const [name, setName] = useState('');
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setName(role?.name ?? '');
+      setSelected(new Set(role?.permissions ?? []));
+    }
+  }, [open, role]);
+
+  const togglePermission = (permission: string, next: boolean) => {
+    setSelected(previous => {
+      const draft = new Set(previous);
+      if (next) {
+        draft.add(permission);
+      } else {
+        draft.delete(permission);
+      }
+      return draft;
+    });
+  };
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      toast({ title: 'Name required', description: 'Give the role a name.', variant: 'destructive' });
+      return;
+    }
+    setIsSaving(true);
+    try {
+      const payload = { name: name.trim(), permissions: Array.from(selected) };
+      if (role) {
+        await api.updateRole(role.id, payload);
+        toast({ title: 'Role updated', description: `"${payload.name}" was saved.` });
+      } else {
+        await api.createRole(payload);
+        toast({ title: 'Role created', description: `"${payload.name}" is ready to assign.` });
+      }
+      onSaved();
+      onClose();
+    } catch (error) {
+      let errorTitle = role ? 'Update failed' : 'Creation failed';
+      let errorMessage = 'Could not save the role.';
+      if (error instanceof ApiProblemError) {
+        errorTitle = error.title;
+        errorMessage = error.detail;
+      } else if (error instanceof Error) {
+        errorMessage = error.message;
+      }
+      toast({ title: errorTitle, description: errorMessage, variant: 'destructive' });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-[560px]">
+        <DialogHeader>
+          <DialogTitle>{role ? 'Edit role' : 'New role'}</DialogTitle>
+          <DialogDescription>
+            A role is a reusable set of permissions. Assign it to a user on an app from the Users
+            page.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5">
+          <div className="space-y-1.5">
+            <Label htmlFor="role-name">Name</Label>
+            <Input
+              id="role-name"
+              value={name}
+              onChange={event => setName(event.target.value)}
+              placeholder="e.g. Release manager"
+              autoComplete="off"
+            />
+          </div>
+
+          {PERMISSION_GROUPS.map(group => (
+            <div key={group.label}>
+              <p className="mb-2 text-sm font-medium">{group.label}</p>
+              <div className="space-y-2.5 rounded-xl border p-3.5">
+                {group.permissions.map(permission => (
+                  <div key={permission.value} className="flex items-start justify-between gap-4">
+                    <div>
+                      <p className="text-sm">{permission.label}</p>
+                      <p className="text-xs text-muted-foreground">{permission.description}</p>
+                    </div>
+                    <Switch
+                      checked={selected.has(permission.value)}
+                      onCheckedChange={next => togglePermission(permission.value, next)}
+                      aria-label={permission.label}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <DialogFooter className="mt-2 gap-2 border-t pt-3 sm:gap-0">
+          <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSave} disabled={isSaving}>
+            {isSaving ? 'Saving…' : role ? 'Save role' : 'Create role'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/dashboard/src/ee/components/RoleFormDialog.tsx
+++ b/apps/dashboard/src/ee/components/RoleFormDialog.tsx
@@ -21,7 +21,9 @@ import { PERMISSION_GROUPS } from '@/ee/lib/permissionCatalog';
 
 // Create/edit form for one role: a name and the permission catalog as
 // toggles. `role` null means create; the dialog resets its draft every time
-// it opens so a cancelled edit never leaks into the next one.
+// it opens so a cancelled edit never leaks into the next one. onSaved
+// receives the created role (creation only) so callers can select it
+// immediately, e.g. the grants editor's inline "New role" flow.
 export const RoleFormDialog = ({
   open,
   role,
@@ -31,7 +33,7 @@ export const RoleFormDialog = ({
   open: boolean;
   role: RoleRecord | null;
   onClose: () => void;
-  onSaved: () => void;
+  onSaved: (created?: RoleRecord) => void;
 }) => {
   const { toast } = useToast();
   const [name, setName] = useState('');
@@ -68,11 +70,12 @@ export const RoleFormDialog = ({
       if (role) {
         await api.updateRole(role.id, payload);
         toast({ title: 'Role updated', description: `"${payload.name}" was saved.` });
+        onSaved();
       } else {
-        await api.createRole(payload);
+        const created = await api.createRole(payload);
         toast({ title: 'Role created', description: `"${payload.name}" is ready to assign.` });
+        onSaved(created);
       }
-      onSaved();
       onClose();
     } catch (error) {
       let errorTitle = role ? 'Update failed' : 'Creation failed';

--- a/apps/dashboard/src/ee/components/UserRolesSheet.tsx
+++ b/apps/dashboard/src/ee/components/UserRolesSheet.tsx
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+import { useEffect, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { TriangleAlert } from 'lucide-react';
+import { api, UserRecord, describeApiError } from '@/lib/api';
+import { useToast } from '@/hooks/use-toast';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { EnterpriseFeatureGate } from '@/ee/components/EnterpriseFeatureGate';
+import { DraftGrant, GrantsEditor } from '@/ee/components/GrantsEditor';
+
+// The single "Roles" panel of a user row: the admin flag, and for members the
+// per-app roles. The admin switch is a community feature and stays outside
+// the license gate; the per-app editor is enterprise and sits behind it.
+// Everything applies on Save, in one place.
+export const UserRolesSheet = ({
+  user,
+  onClose,
+}: {
+  user: UserRecord | null;
+  onClose: () => void;
+}) => {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const [isAdminDraft, setIsAdminDraft] = useState(false);
+  const [draft, setDraft] = useState<DraftGrant[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const grantsQuery = useQuery({
+    queryKey: ['userGrants', user?.id],
+    queryFn: () => api.getUserGrants(user!.id),
+    enabled: !!user,
+  });
+
+  useEffect(() => {
+    if (user) {
+      setIsAdminDraft(user.isAdmin);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (user && grantsQuery.data) {
+      setDraft(
+        grantsQuery.data.map(grant => ({
+          appId: grant.appId,
+          roleId: grant.roleId,
+          extraPermissions: grant.extraPermissions,
+        }))
+      );
+    }
+  }, [user, grantsQuery.data]);
+
+  const handleSave = async () => {
+    if (!user) return;
+    setIsSaving(true);
+    try {
+      if (isAdminDraft !== user.isAdmin) {
+        await api.updateUserAdmin(user.id, isAdminDraft);
+      }
+      // Grants only matter for members; an admin's dormant grants are left
+      // untouched so demoting them later restores their previous scope.
+      if (!isAdminDraft) {
+        await api.setUserGrants(user.id, draft);
+      }
+      toast({
+        title: 'Roles saved',
+        description: isAdminDraft
+          ? `"${user.email}" is an admin with full access.`
+          : draft.length === 0
+            ? `"${user.email}" has no app access.`
+            : `"${user.email}" has access to ${draft.length} app${draft.length > 1 ? 's' : ''}.`,
+      });
+      queryClient.invalidateQueries({ queryKey: ['users'] });
+      queryClient.invalidateQueries({ queryKey: ['userGrants', user.id] });
+      queryClient.invalidateQueries({ queryKey: ['userGrantsSummary'] });
+      onClose();
+    } catch (error) {
+      toast({ ...describeApiError(error, 'Could not save roles'), variant: 'destructive' });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Sheet open={!!user} onOpenChange={open => !open && onClose()}>
+      <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-lg">
+        <SheetHeader>
+          <SheetTitle>Roles</SheetTitle>
+          <SheetDescription>What “{user?.email}” can see and do.</SheetDescription>
+        </SheetHeader>
+
+        <div className="mt-6 space-y-5">
+          <label className="flex cursor-pointer items-center justify-between gap-3 rounded-xl border p-4 text-sm">
+            <span>
+              <span className="font-medium">Administrator</span>
+              <span className="block text-xs text-muted-foreground">
+                Full access to every app; manages users, roles and server settings.
+              </span>
+            </span>
+            <Switch
+              checked={isAdminDraft}
+              disabled={isSaving}
+              onCheckedChange={setIsAdminDraft}
+              aria-label="Administrator"
+            />
+          </label>
+
+          {isAdminDraft ? (
+            <p className="rounded-lg border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+              Admins bypass roles entirely, so there is nothing else to configure.
+            </p>
+          ) : (
+            <EnterpriseFeatureGate>
+              {grantsQuery.isLoading ? (
+                <div className="space-y-3">
+                  <Skeleton className="h-12 w-full" />
+                  <Skeleton className="h-4 w-1/2" />
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  {draft.length === 0 && (
+                    <div className="flex items-start gap-2.5 rounded-xl border border-amber-300/60 bg-amber-50 px-4 py-3 text-xs text-amber-800">
+                      <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                      <span>
+                        This member has no app access: they will see an empty dashboard. Grant them
+                        an app below, with a role.
+                      </span>
+                    </div>
+                  )}
+                  <GrantsEditor draft={draft} onChange={setDraft} disabled={isSaving} />
+                </div>
+              )}
+            </EnterpriseFeatureGate>
+          )}
+
+          <div className="flex justify-end gap-2 border-t pt-4">
+            <Button variant="outline" onClick={onClose} disabled={isSaving}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={isSaving || (!isAdminDraft && grantsQuery.isLoading)}>
+              {isSaving ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+};

--- a/apps/dashboard/src/ee/components/UserRolesSheet.tsx
+++ b/apps/dashboard/src/ee/components/UserRolesSheet.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { TriangleAlert } from 'lucide-react';
 import { api, UserRecord, describeApiError } from '@/lib/api';
+import { ApiError } from '@/components/APIError';
 import { useToast } from '@/hooks/use-toast';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
@@ -48,6 +49,10 @@ export const UserRolesSheet = ({
     if (user) {
       setIsAdminDraft(user.isAdmin);
     }
+    // Changing the target (or closing) must never carry the previous
+    // member's draft over: the sheet stays mounted across opens, and a
+    // failed fetch would otherwise show, and save, the last user's grants.
+    setDraft([]);
   }, [user]);
 
   useEffect(() => {
@@ -128,6 +133,15 @@ export const UserRolesSheet = ({
                   <Skeleton className="h-12 w-full" />
                   <Skeleton className="h-4 w-1/2" />
                 </div>
+              ) : grantsQuery.isError ? (
+                // A failed fetch must never render as "no grants": with an
+                // empty draft, Save would wipe the member's real grants.
+                <div className="space-y-3">
+                  <ApiError error={grantsQuery.error} />
+                  <Button variant="outline" size="sm" onClick={() => grantsQuery.refetch()}>
+                    Try again
+                  </Button>
+                </div>
               ) : (
                 <div className="space-y-4">
                   {draft.length === 0 && (
@@ -149,7 +163,11 @@ export const UserRolesSheet = ({
             <Button variant="outline" onClick={onClose} disabled={isSaving}>
               Cancel
             </Button>
-            <Button onClick={handleSave} disabled={isSaving || (!isAdminDraft && grantsQuery.isLoading)}>
+            <Button
+              onClick={handleSave}
+              // isSuccess, not !isLoading: saving grants over a failed fetch
+              // would replace the member's set with the empty draft.
+              disabled={isSaving || (!isAdminDraft && !grantsQuery.isSuccess)}>
               {isSaving ? 'Saving…' : 'Save'}
             </Button>
           </div>

--- a/apps/dashboard/src/ee/lib/PermissionsContext.tsx
+++ b/apps/dashboard/src/ee/lib/PermissionsContext.tsx
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+import { createContext, useContext, useMemo, ReactNode } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import { useCurrentUser } from '@/lib/CurrentUserContext';
+import { useSelectedApp } from '@/lib/SelectedAppContext';
+
+// Mirrors the server catalog (ee/rbac/permissions.go). An unknown string
+// would simply never match, so drift fails closed.
+export type Permission =
+  | 'app:delete'
+  | 'app:rename'
+  | 'certificate:read'
+  | 'branch:create'
+  | 'branch:delete'
+  | 'branch:protect'
+  | 'channel:create'
+  | 'channel:delete'
+  | 'channel:edit-branch'
+  | 'channel-rollout:manage'
+  | 'update-rollout:manage'
+  | 'apikeys:manage';
+
+type PermissionsContextValue = {
+  // enabled reports whether fine-grained roles are enforced right now
+  // (control plane + valid enterprise license).
+  enabled: boolean;
+  isAdmin: boolean;
+  // can answers "may the current account do this on this app". Admins can do
+  // everything; without enforcement members can do nothing (the community
+  // read-only rule); enforced members follow their grants. Display gating
+  // only: the server re-checks every mutation.
+  can: (appId: string | null | undefined, permission: Permission) => boolean;
+};
+
+const PermissionsContext = createContext<PermissionsContextValue | null>(null);
+
+export function PermissionsProvider({ children }: { children: ReactNode }) {
+  // isAdmin from /api/me keeps the UI correct while the permission map is
+  // still loading (an admin never flickers, a member starts read-only and
+  // gains buttons when their grants arrive).
+  const { isAdmin: sessionIsAdmin } = useCurrentUser();
+  const { data } = useQuery({
+    queryKey: ['me', 'permissions'],
+    queryFn: () => api.getMyPermissions(),
+  });
+
+  const value = useMemo<PermissionsContextValue>(() => {
+    const isAdmin = data ? data.isAdmin : sessionIsAdmin;
+    const enabled = data?.enabled ?? false;
+    const apps = data?.apps ?? null;
+    return {
+      enabled,
+      isAdmin,
+      can: (appId, permission) => {
+        if (isAdmin) {
+          return true;
+        }
+        if (!enabled || !appId) {
+          return false;
+        }
+        return apps?.[appId]?.includes(permission) ?? false;
+      },
+    };
+  }, [data, sessionIsAdmin]);
+
+  return <PermissionsContext.Provider value={value}>{children}</PermissionsContext.Provider>;
+}
+
+export function usePermissions(): PermissionsContextValue {
+  const context = useContext(PermissionsContext);
+  if (!context) {
+    throw new Error('usePermissions must be used within a PermissionsProvider');
+  }
+  return context;
+}
+
+// useAppPermission is the one-liner for the common case: "may I do this on
+// the app currently selected in the dashboard".
+export function useAppPermission(permission: Permission): boolean {
+  const { selectedAppId } = useSelectedApp();
+  const { can } = usePermissions();
+  return can(selectedAppId, permission);
+}

--- a/apps/dashboard/src/ee/lib/permissionCatalog.ts
+++ b/apps/dashboard/src/ee/lib/permissionCatalog.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+import { Permission } from '@/ee/lib/PermissionsContext';
+
+// Display metadata for the permission catalog, grouped the way the role and
+// grant editors lay their toggles out. The values mirror ee/rbac/permissions.go.
+export type PermissionOption = {
+  value: Permission;
+  label: string;
+  description: string;
+};
+
+export type PermissionGroup = {
+  label: string;
+  permissions: PermissionOption[];
+};
+
+export const PERMISSION_GROUPS: PermissionGroup[] = [
+  {
+    label: 'App',
+    permissions: [
+      {
+        value: 'app:rename',
+        label: 'Rename the app',
+        description: 'Change the display name of the app.',
+      },
+      {
+        value: 'app:delete',
+        label: 'Delete the app',
+        description: 'Remove the app with all of its branches, channels and updates.',
+      },
+      {
+        value: 'certificate:read',
+        label: 'Download the signing certificate',
+        description: 'Key material used to verify update signatures.',
+      },
+    ],
+  },
+  {
+    label: 'Branches',
+    permissions: [
+      {
+        value: 'branch:create',
+        label: 'Create branches',
+        description: 'Add new update branches to the app.',
+      },
+      {
+        value: 'branch:delete',
+        label: 'Delete branches',
+        description: 'Protected branches always refuse deletion.',
+      },
+      {
+        value: 'branch:protect',
+        label: 'Protect branches',
+        description: 'Toggle branch protection on and off.',
+      },
+    ],
+  },
+  {
+    label: 'Channels',
+    permissions: [
+      {
+        value: 'channel:create',
+        label: 'Create channels',
+        description: 'Add new release channels to the app.',
+      },
+      {
+        value: 'channel:delete',
+        label: 'Delete channels',
+        description: 'Builds configured with a deleted channel stop receiving updates.',
+      },
+      {
+        value: 'channel:edit-branch',
+        label: 'Change the channel branch',
+        description: 'Point a release channel at a different branch.',
+      },
+    ],
+  },
+  {
+    label: 'Rollouts',
+    permissions: [
+      {
+        value: 'channel-rollout:manage',
+        label: 'Manage channel rollouts',
+        description: 'Start, adjust, promote or revert a progressive branch rollout.',
+      },
+      {
+        value: 'update-rollout:manage',
+        label: 'Manage update rollouts',
+        description: 'Set or revert the rollout percentage of a single update.',
+      },
+    ],
+  },
+  {
+    label: 'API tokens',
+    permissions: [
+      {
+        value: 'apikeys:manage',
+        label: 'Manage API tokens',
+        description: 'Create and revoke publishing tokens and edit their restrictions.',
+      },
+    ],
+  },
+];

--- a/apps/dashboard/src/ee/pages/Roles/index.tsx
+++ b/apps/dashboard/src/ee/pages/Roles/index.tsx
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Plus, Pencil, Trash2 } from 'lucide-react';
+import { api, ApiProblemError, RoleRecord } from '@/lib/api';
+import { useSettings } from '@/lib/SettingsContext';
+import { useCurrentUser } from '@/lib/CurrentUserContext';
+import { PageHeader } from '@/components/PageHeader';
+import { ApiError } from '@/components/APIError';
+import { DataTable } from '@/components/DataTable';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { TimestampCell } from '@/components/ui/timestamp-cell';
+import { DeleteDialog } from '@/components/ui/delete-dialog';
+import { useToast } from '@/hooks/use-toast';
+import { EnterpriseFeatureGate } from '@/ee/components/EnterpriseFeatureGate';
+import { RoleFormDialog } from '@/ee/components/RoleFormDialog';
+import { PERMISSION_GROUPS } from '@/ee/lib/permissionCatalog';
+
+const PERMISSION_LABELS = new Map(
+  PERMISSION_GROUPS.flatMap(group =>
+    group.permissions.map(permission => [permission.value as string, permission.label])
+  )
+);
+
+// The Roles page of the Access & Security sidebar group: named permission
+// bundles for enterprise user roles. Follows the SSO page conventions: the
+// content stays visible behind the frosted enterprise gate without a license.
+export const Roles = () => {
+  const { CONTROL_PLANE_ENABLED } = useSettings();
+  const { isAdmin } = useCurrentUser();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const [formState, setFormState] = useState<{ open: boolean; role: RoleRecord | null }>({
+    open: false,
+    role: null,
+  });
+  const [roleToDelete, setRoleToDelete] = useState<RoleRecord | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const rolesQuery = useQuery({
+    queryKey: ['roles'],
+    queryFn: () => api.getRoles(),
+    enabled: CONTROL_PLANE_ENABLED && isAdmin,
+  });
+
+  const refreshRoles = () => queryClient.invalidateQueries({ queryKey: ['roles'] });
+
+  const handleExecuteDeletion = async () => {
+    if (!roleToDelete) return;
+    setIsDeleting(true);
+    try {
+      await api.deleteRole(roleToDelete.id);
+      toast({ title: 'Role deleted', description: `"${roleToDelete.name}" was removed.` });
+      setRoleToDelete(null);
+      refreshRoles();
+    } catch (error) {
+      // The server refuses deleting a role that is still assigned (409) and
+      // says so; surface its message.
+      let errorMessage = 'Could not delete the role.';
+      if (error instanceof ApiProblemError) {
+        errorMessage = error.detail;
+      } else if (error instanceof Error) {
+        errorMessage = error.message;
+      }
+      toast({ title: 'Deletion failed', description: errorMessage, variant: 'destructive' });
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  if (!CONTROL_PLANE_ENABLED) {
+    return (
+      <div className="w-full">
+        <PageHeader title="Roles" description="Reusable permission sets for your team." />
+        <div className="rounded-xl border border-dashed bg-muted/30 p-8 text-center text-sm text-muted-foreground">
+          User roles live in the database, so they require control-plane (DB) mode. Stateless
+          deployments have a single admin account.
+        </div>
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return (
+      <div className="w-full">
+        <PageHeader title="Roles" description="Reusable permission sets for your team." />
+        <div className="rounded-xl border border-dashed bg-muted/30 p-8 text-center text-sm text-muted-foreground">
+          Only admins can manage roles. Ask an admin if you need access.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full">
+      <PageHeader
+        title="Roles"
+        description="A role is a reusable set of permissions, like Release manager. Assign one to a user on an app from the Users page; admins bypass roles entirely."
+      />
+      <EnterpriseFeatureGate>
+        <div className="space-y-4">
+          {!!rolesQuery.error && <ApiError error={rolesQuery.error} />}
+
+          <div className="flex justify-end">
+            <Button size="sm" onClick={() => setFormState({ open: true, role: null })}>
+              <Plus className="h-4 w-4" /> New role
+            </Button>
+          </div>
+
+          <DataTable
+            loading={rolesQuery.isLoading}
+            columns={[
+              {
+                header: 'Name',
+                accessorKey: 'name',
+                cell: ({ row }) => <span className="font-medium">{row.original.name}</span>,
+              },
+              {
+                header: 'Permissions',
+                id: 'permissions',
+                cell: ({ row }) => {
+                  const permissions = row.original.permissions;
+                  if (permissions.length === 0) {
+                    return <span className="text-muted-foreground/60">None (read-only)</span>;
+                  }
+                  return (
+                    <div className="flex max-w-md flex-wrap gap-1">
+                      {permissions.map(permission => (
+                        <Badge key={permission} variant="outline" className="font-normal">
+                          {PERMISSION_LABELS.get(permission) ?? permission}
+                        </Badge>
+                      ))}
+                    </div>
+                  );
+                },
+              },
+              {
+                header: 'Created',
+                accessorKey: 'createdAt',
+                cell: ({ row }) => <TimestampCell dateString={row.original.createdAt ?? ''} />,
+              },
+              {
+                header: '',
+                id: 'actions',
+                cell: ({ row }) => (
+                  <div className="flex justify-end gap-1 pr-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setFormState({ open: true, role: row.original })}
+                      className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground"
+                      title="Edit role">
+                      <Pencil className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setRoleToDelete(row.original)}
+                      className="h-8 w-8 p-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                      title="Delete role">
+                      <Trash2 />
+                    </Button>
+                  </div>
+                ),
+              },
+            ]}
+            data={rolesQuery.data ?? []}
+            emptyMessage="No roles yet. Create one, like Release manager, then assign it from the Users page."
+          />
+        </div>
+      </EnterpriseFeatureGate>
+
+      <RoleFormDialog
+        open={formState.open}
+        role={formState.role}
+        onClose={() => setFormState({ open: false, role: null })}
+        onSaved={refreshRoles}
+      />
+
+      <DeleteDialog
+        isOpen={!!roleToDelete}
+        onClose={() => setRoleToDelete(null)}
+        onConfirm={handleExecuteDeletion}
+        isDeleting={isDeleting}
+        title="Delete role"
+        resourceName={roleToDelete?.name}
+        descriptionText="Users holding this role through a grant keep their other permissions. A role still assigned to someone cannot be deleted."
+        confirmButtonText="Delete role"
+        isDeletingButtonText="Deleting…"
+      />
+    </div>
+  );
+};

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -393,6 +393,20 @@ export class ApiClient {
     });
   }
 
+  // The current account's permission map (enterprise user roles, ee/rbac).
+  // enabled=false means fine-grained roles are not enforced and the UI falls
+  // back to the community rule: isAdmin decides everything. apps is null for
+  // admins and when disabled.
+  public async getMyPermissions() {
+    return this.request<{
+      enabled: boolean;
+      isAdmin: boolean;
+      apps: Record<string, string[]> | null;
+    }>(`/api/me/permissions`, {
+      method: 'GET',
+    });
+  }
+
   public async changeMyPassword(payload: { currentPassword: string; newPassword: string }) {
     return this.request<void>(`/api/me/password`, {
       method: 'PUT',

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -182,6 +182,16 @@ export type UserRecord = {
   lastConnectedAt?: string;
 };
 
+// A named permission bundle (enterprise user roles, ee/rbac). Roles are
+// global; they apply to an app only through a user's grant.
+export type RoleRecord = {
+  id: string;
+  name: string;
+  permissions: string[];
+  createdAt?: string;
+  updatedAt?: string;
+};
+
 // The deployment's Enterprise Edition license status (/api/license,
 // control-plane only). `valid` is the single source of truth for "enterprise
 // features are on": `hasKey` can be true with `valid` false when the stored
@@ -447,6 +457,35 @@ export class ApiClient {
 
   public async deleteUser(userId: string) {
     return this.request<void>(`/api/users/${encodeURIComponent(userId)}`, {
+      method: 'DELETE',
+    });
+  }
+
+  // Enterprise user roles (admin only; writes are license-gated server-side).
+  public async getRoles() {
+    return this.request<RoleRecord[]>(`/api/roles`, {
+      method: 'GET',
+    });
+  }
+
+  public async createRole(payload: { name: string; permissions: string[] }) {
+    return this.request<RoleRecord>(`/api/roles`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  }
+
+  public async updateRole(roleId: string, payload: { name: string; permissions: string[] }) {
+    return this.request<void>(`/api/roles/${encodeURIComponent(roleId)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  }
+
+  public async deleteRole(roleId: string) {
+    return this.request<void>(`/api/roles/${encodeURIComponent(roleId)}`, {
       method: 'DELETE',
     });
   }

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -192,6 +192,17 @@ export type RoleRecord = {
   updatedAt?: string;
 };
 
+// One member's access to one app: an optional role plus direct extra
+// permissions. effectivePermissions is the server-computed union the
+// enforcement actually uses.
+export type GrantRecord = {
+  appId: string;
+  roleId: string | null;
+  roleName: string | null;
+  extraPermissions: string[];
+  effectivePermissions: string[];
+};
+
 // The deployment's Enterprise Edition license status (/api/license,
 // control-plane only). `valid` is the single source of truth for "enterprise
 // features are on": `hasKey` can be true with `valid` false when the stored
@@ -487,6 +498,32 @@ export class ApiClient {
   public async deleteRole(roleId: string) {
     return this.request<void>(`/api/roles/${encodeURIComponent(roleId)}`, {
       method: 'DELETE',
+    });
+  }
+
+  public async getUserGrants(userId: string) {
+    return this.request<GrantRecord[]>(`/api/users/${encodeURIComponent(userId)}/grants`, {
+      method: 'GET',
+    });
+  }
+
+  // Per-user grant counts ({userId: count}); users absent from the map hold
+  // no grants. Backs the "no app access" warning on the Users page.
+  public async getUserGrantsSummary() {
+    return this.request<Record<string, number>>(`/api/users/grants/summary`, {
+      method: 'GET',
+    });
+  }
+
+  // Replaces the member's whole grant set in one transaction server-side.
+  public async setUserGrants(
+    userId: string,
+    grants: { appId: string; roleId: string | null; extraPermissions: string[] }[]
+  ) {
+    return this.request<void>(`/api/users/${encodeURIComponent(userId)}/grants`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(grants),
     });
   }
 

--- a/apps/dashboard/src/pages/ApiTokens/index.tsx
+++ b/apps/dashboard/src/pages/ApiTokens/index.tsx
@@ -12,13 +12,13 @@ import { DataTable } from '@/components/DataTable';
 import { TimestampCell } from '@/components/ui/timestamp-cell';
 import { DeleteDialog } from '@/components/ui/delete-dialog';
 import { AdminOnlyNote } from '@/components/ui/admin-only-note';
-import { useCurrentUser } from '@/lib/CurrentUserContext';
+import { useAppPermission } from '@/ee/lib/PermissionsContext';
 import { ApiKeyRestrictionsSheet } from '@/ee/components/ApiKeyRestrictionsSheet';
 
 export const ApiTokens = () => {
   const { CONTROL_PLANE_ENABLED } = useSettings();
-  // Member accounts are read-only: minting and revoking tokens is admin-only.
-  const { isAdmin } = useCurrentUser();
+  // Display gating only: the server re-checks the permission on its routes.
+  const canManageApiKeys = useAppPermission('apikeys:manage');
   const { selectedAppId } = useSelectedApp();
   const { toast } = useToast();
   const queryClient = useQueryClient();
@@ -134,13 +134,13 @@ export const ApiTokens = () => {
       />
 
       <div className="space-y-4">
-        {!isAdmin && (
+        {!canManageApiKeys && (
           <AdminOnlyNote>
-            You are signed in with a member account, which is read-only. Ask an admin to create or
-            revoke tokens.
+            You do not have permission to manage this app's tokens. Ask an admin to grant you
+            access.
           </AdminOnlyNote>
         )}
-        {isAdmin && (
+        {canManageApiKeys && (
           <div className="flex justify-end">
             <ResourceCreateForm
               id="token-name"
@@ -226,7 +226,7 @@ export const ApiTokens = () => {
                 ) : (
                   <span className="text-sm text-muted-foreground/60">None</span>
                 );
-                if (!isAdmin) {
+                if (!canManageApiKeys) {
                   return state;
                 }
                 return (
@@ -244,7 +244,7 @@ export const ApiTokens = () => {
                 );
               },
             },
-            ...(isAdmin
+            ...(canManageApiKeys
               ? [
                   {
                     header: '',

--- a/apps/dashboard/src/pages/AppInfo/index.tsx
+++ b/apps/dashboard/src/pages/AppInfo/index.tsx
@@ -11,13 +11,14 @@ import { DeleteDialog } from '@/components/ui/delete-dialog';
 import { KeystoreCard } from './components/KeystoreCard';
 import { AdminOnlyNote } from '@/components/ui/admin-only-note';
 import { useSettings } from '@/lib/SettingsContext';
-import { useCurrentUser } from '@/lib/CurrentUserContext';
+import { useAppPermission } from '@/ee/lib/PermissionsContext';
 
 export const AppInfo = () => {
   const { CONTROL_PLANE_ENABLED } = useSettings();
-  // Renaming and deleting an app are admin actions (the server enforces it),
-  // so hide the controls from everyone else.
-  const { isAdmin } = useCurrentUser();
+  // Display gating only: the server re-checks each permission on its route.
+  const canRenameApp = useAppPermission('app:rename');
+  const canDeleteApp = useAppPermission('app:delete');
+  const canReadCertificate = useAppPermission('certificate:read');
   const { selectedAppId, refreshApps } = useSelectedApp();
   const { toast } = useToast();
   const queryClient = useQueryClient();
@@ -179,7 +180,7 @@ export const AppInfo = () => {
           ) : (
             <span className="flex items-center gap-2">
               {appData?.name || selectedAppId}
-              {CONTROL_PLANE_ENABLED && isAdmin && (
+              {CONTROL_PLANE_ENABLED && canRenameApp && (
                 <Button
                   variant="ghost"
                   size="icon"
@@ -200,8 +201,8 @@ export const AppInfo = () => {
           </span>
         }
         actions={
-          // Key material: the server only serves it to admins.
-          isDownloadAvailable && isAdmin ? (
+          // Key material: the server only serves it with certificate:read.
+          isDownloadAvailable && canReadCertificate ? (
             <Button variant="outline" size="sm" onClick={handleDownloadCertificate}>
               <Download className="h-4 w-4" />
               Download certificate
@@ -211,16 +212,16 @@ export const AppInfo = () => {
       />
 
       <div className="max-w-2xl space-y-6">
-        {CONTROL_PLANE_ENABLED && !isAdmin && (
+        {CONTROL_PLANE_ENABLED && !canRenameApp && !canDeleteApp && !canReadCertificate && (
           <AdminOnlyNote>
-            You are signed in with a member account, which is read-only. Only admins can rename or
-            delete the app and download its signing certificate.
+            You do not have permission to rename or delete this app or download its signing
+            certificate. Ask an admin to grant you access.
           </AdminOnlyNote>
         )}
 
         <KeystoreCard isLoading={appDetailsQuery.isLoading} appData={appData} />
 
-        {CONTROL_PLANE_ENABLED && isAdmin && (
+        {CONTROL_PLANE_ENABLED && canDeleteApp && (
           <div className="overflow-hidden rounded-xl border border-destructive/30">
             <div className="flex flex-wrap items-center justify-between gap-4 p-5">
               <div>
@@ -241,7 +242,7 @@ export const AppInfo = () => {
         )}
       </div>
 
-      {CONTROL_PLANE_ENABLED && isAdmin && (
+      {CONTROL_PLANE_ENABLED && canDeleteApp && (
         <DeleteDialog
           isOpen={showDeleteAppDialog}
           onClose={() => setShowDeleteAppDialog(false)}

--- a/apps/dashboard/src/pages/Channels/index.tsx
+++ b/apps/dashboard/src/pages/Channels/index.tsx
@@ -17,7 +17,7 @@ import { TimestampCell } from '@/components/ui/timestamp-cell';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Trash2, Plus, Split, Lock } from 'lucide-react';
 import { useSettings } from '@/lib/SettingsContext';
-import { useCurrentUser } from '@/lib/CurrentUserContext';
+import { useAppPermission } from '@/ee/lib/PermissionsContext';
 import { RolloutBar } from '@/components/rollout/RolloutBar';
 import { StartRolloutDialog } from '@/pages/Channels/components/StartRolloutDialog';
 import { ManageRolloutDialog } from '@/pages/Channels/components/ManageRolloutDialog';
@@ -31,7 +31,11 @@ interface TableColumnConfig {
 
 export const Channels = () => {
   const { CONTROL_PLANE_ENABLED } = useSettings();
-  const { isAdmin } = useCurrentUser();
+  // Display gating only: the server re-checks each permission on its route.
+  const canCreateChannel = useAppPermission('channel:create');
+  const canDeleteChannel = useAppPermission('channel:delete');
+  const canEditChannelBranch = useAppPermission('channel:edit-branch');
+  const canManageRollout = useAppPermission('channel-rollout:manage');
   const { selectedAppId } = useSelectedApp();
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: ['channels', selectedAppId],
@@ -222,7 +226,7 @@ export const Channels = () => {
               </TooltipProvider>
             );
           }
-          return isAdmin ? (
+          return canEditChannelBranch ? (
             <SelectBranch
               currentBranch={row.original.branchId || ''}
               loading={isLoading || loading}
@@ -247,7 +251,7 @@ export const Channels = () => {
                       <span className="text-xs text-muted-foreground">
                         to {channel.rollout.rolloutBranchName}
                       </span>
-                      {isAdmin && (
+                      {canManageRollout && (
                         <button
                           type="button"
                           onClick={() => setRolloutAction({ type: 'manage', channel })}
@@ -262,7 +266,7 @@ export const Channels = () => {
                 if (!channel.branchId) {
                   return <span className="text-muted-foreground/60">None</span>;
                 }
-                if (isAdmin) {
+                if (canManageRollout) {
                   return (
                     <Button
                       variant="ghost"
@@ -284,8 +288,8 @@ export const Channels = () => {
             } satisfies TableColumnConfig,
           ]
         : []),
-      // Deleting a channel is an admin action (the server enforces it).
-      ...(CONTROL_PLANE_ENABLED && isAdmin
+      // Deleting a channel needs its permission (the server enforces it).
+      ...(CONTROL_PLANE_ENABLED && canDeleteChannel
         ? [
             {
               header: '',
@@ -306,7 +310,15 @@ export const Channels = () => {
           ]
         : []),
     ];
-  }, [CONTROL_PLANE_ENABLED, isAdmin, isLoading, loading, onBranchChange]);
+  }, [
+    CONTROL_PLANE_ENABLED,
+    canDeleteChannel,
+    canEditChannelBranch,
+    canManageRollout,
+    isLoading,
+    loading,
+    onBranchChange,
+  ]);
 
   return (
     <div className="w-full">
@@ -335,13 +347,17 @@ export const Channels = () => {
       {!!error && <ApiError error={error} />}
 
       <div className="space-y-4">
-        {CONTROL_PLANE_ENABLED && !isAdmin && (
-          <AdminOnlyNote>
-            You are signed in with a member account, which is read-only. Ask an admin to create or
-            delete channels, change which branch a channel serves, or manage progressive rollouts.
-          </AdminOnlyNote>
-        )}
-        {CONTROL_PLANE_ENABLED && isAdmin && (
+        {CONTROL_PLANE_ENABLED &&
+          !canCreateChannel &&
+          !canDeleteChannel &&
+          !canEditChannelBranch &&
+          !canManageRollout && (
+            <AdminOnlyNote>
+              You do not have permission to manage channels on this app. Ask an admin to grant you
+              access.
+            </AdminOnlyNote>
+          )}
+        {CONTROL_PLANE_ENABLED && canCreateChannel && (
           <Card>
             <CardContent className="p-5">
               <form
@@ -394,7 +410,7 @@ export const Channels = () => {
         />
       </div>
 
-      {CONTROL_PLANE_ENABLED && isAdmin && (
+      {CONTROL_PLANE_ENABLED && canDeleteChannel && (
         <DeleteDialog
           isOpen={!!channelToDelete}
           onClose={() => setChannelToDelete(null)}
@@ -408,7 +424,7 @@ export const Channels = () => {
         />
       )}
 
-      {CONTROL_PLANE_ENABLED && isAdmin && (
+      {CONTROL_PLANE_ENABLED && canManageRollout && (
         <>
           <StartRolloutDialog
             channel={rolloutAction?.type === 'start' ? rolloutActionChannel : null}

--- a/apps/dashboard/src/pages/Updates/components/BranchesTable/index.tsx
+++ b/apps/dashboard/src/pages/Updates/components/BranchesTable/index.tsx
@@ -239,8 +239,16 @@ export const BranchesTable = () => {
               header: '',
               id: 'actions',
               cell: ({ row }) => {
+                const isProtected = row.original.protected;
                 return (
-                  <div className="text-right">
+                  <div
+                    className="text-right"
+                    title={
+                      isProtected
+                        ? 'Protected branches cannot be deleted. Remove the protection first.'
+                        : undefined
+                    }
+                  >
                     <Button
                       variant="ghost"
                       size="sm"
@@ -248,8 +256,9 @@ export const BranchesTable = () => {
                         e.stopPropagation();
                         setBranchToDelete(row.original);
                       }}
+                      disabled={isProtected}
                       className="h-8 w-8 p-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-                      title="Delete branch"
+                      title={isProtected ? undefined : 'Delete branch'}
                     >
                       <Trash2 />
                     </Button>
@@ -328,7 +337,8 @@ export const BranchesTable = () => {
                 "{branchToProtect?.branchName}"
               </strong>{' '}
               is protected, only API tokens explicitly allowed on protected branches can publish,
-              roll back or republish on it. Tokens handed to developers will be blocked.
+              roll back or republish on it. Tokens handed to developers will be blocked, and the
+              branch cannot be deleted until the protection is lifted.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="mt-4 gap-2 border-t pt-3 sm:gap-0">

--- a/apps/dashboard/src/pages/Updates/components/BranchesTable/index.tsx
+++ b/apps/dashboard/src/pages/Updates/components/BranchesTable/index.tsx
@@ -22,7 +22,7 @@ import { ResourceCreateForm } from '@/components/ui/resource-create-form';
 import { DeleteDialog } from '@/components/ui/delete-dialog';
 import { AdminOnlyNote } from '@/components/ui/admin-only-note';
 import { useSettings } from '@/lib/SettingsContext';
-import { useCurrentUser } from '@/lib/CurrentUserContext';
+import { useAppPermission } from '@/ee/lib/PermissionsContext';
 import { EnterpriseExplainerDialog } from '@/ee/components/EnterpriseExplainerDialog';
 
 interface TableColumnConfig {
@@ -36,8 +36,11 @@ interface TableColumnConfig {
 
 export const BranchesTable = () => {
   const { CONTROL_PLANE_ENABLED } = useSettings();
-  // Member accounts are read-only; every mutation is admin-only server-side.
-  const { isAdmin } = useCurrentUser();
+  // Display gating only: the server re-checks each of these permissions on
+  // its route (admins always pass, members follow their enterprise grants).
+  const canCreateBranch = useAppPermission('branch:create');
+  const canDeleteBranch = useAppPermission('branch:delete');
+  const canProtectBranch = useAppPermission('branch:protect');
   const [, setSearchParams] = useSearchParams();
   const { selectedAppId } = useSelectedApp();
   const queryClient = useQueryClient();
@@ -213,9 +216,9 @@ export const BranchesTable = () => {
                     {isProtected ? 'Protected' : 'Unprotected'}
                   </span>
                 );
-                // Members see the state read-only; the server gates the write
-                // to admins anyway.
-                if (!isAdmin) {
+                // Without the permission the state is read-only; the server
+                // gates the write anyway.
+                if (!canProtectBranch) {
                   return label;
                 }
                 return (
@@ -233,7 +236,7 @@ export const BranchesTable = () => {
             } satisfies TableColumnConfig,
           ]
         : []),
-      ...(CONTROL_PLANE_ENABLED && isAdmin
+      ...(CONTROL_PLANE_ENABLED && canDeleteBranch
         ? [
             {
               header: '',
@@ -269,19 +272,25 @@ export const BranchesTable = () => {
           ]
         : []),
     ];
-  }, [CONTROL_PLANE_ENABLED, isAdmin, branchBeingToggled, handleToggleProtection]);
+  }, [
+    CONTROL_PLANE_ENABLED,
+    canDeleteBranch,
+    canProtectBranch,
+    branchBeingToggled,
+    handleToggleProtection,
+  ]);
 
   return (
     <div className="w-full flex-1 space-y-4">
       {!!error && <ApiError error={error} />}
 
-      {CONTROL_PLANE_ENABLED && !isAdmin && (
+      {CONTROL_PLANE_ENABLED && !canCreateBranch && !canDeleteBranch && !canProtectBranch && (
         <AdminOnlyNote>
-          You are signed in with a member account, which is read-only. Ask an admin to create or
-          delete branches.
+          You do not have permission to manage branches on this app. Ask an admin to grant you
+          access.
         </AdminOnlyNote>
       )}
-      {CONTROL_PLANE_ENABLED && isAdmin && (
+      {CONTROL_PLANE_ENABLED && canCreateBranch && (
         <div className="flex justify-end">
           <ResourceCreateForm
             id="branch-name"
@@ -305,7 +314,7 @@ export const BranchesTable = () => {
         onRowClick={row => setSearchParams({ branch: row.branchName })}
       />
 
-      {CONTROL_PLANE_ENABLED && isAdmin && (
+      {CONTROL_PLANE_ENABLED && canDeleteBranch && (
         <DeleteDialog
           isOpen={!!branchToDelete}
           onClose={() => setBranchToDelete(null)}

--- a/apps/dashboard/src/pages/Updates/components/UpdateRolloutCard.tsx
+++ b/apps/dashboard/src/pages/Updates/components/UpdateRolloutCard.tsx
@@ -17,8 +17,9 @@ import {
 } from '@/components/ui/dialog';
 import { RolloutBar } from '@/components/rollout/RolloutBar';
 
-// Renders the active per-update rollout for a (branch, runtime version) with
-// its admin controls: progress forward, finish, or revert. `updates` holds one
+// Renders the active per-update rollout for a (branch, runtime version). The
+// controls (progress forward, finish, or revert) only show when the account
+// holds the update-rollout permission (canManageRollout). `updates` holds one
 // row per platform, all sharing the same update id and percentage.
 export const UpdateRolloutCard = ({
   branch,

--- a/apps/dashboard/src/pages/Updates/components/UpdateRolloutCard.tsx
+++ b/apps/dashboard/src/pages/Updates/components/UpdateRolloutCard.tsx
@@ -24,12 +24,12 @@ export const UpdateRolloutCard = ({
   branch,
   runtimeVersion,
   updates,
-  isAdmin,
+  canManageRollout,
 }: {
   branch: string;
   runtimeVersion: string;
   updates: UpdateRolloutInfo[];
-  isAdmin: boolean;
+  canManageRollout: boolean;
 }) => {
   const { selectedAppId } = useSelectedApp();
   const { toast } = useToast();
@@ -143,7 +143,7 @@ export const UpdateRolloutCard = ({
             <RolloutBar value={percentage} />
           </div>
 
-          {isAdmin && (
+          {canManageRollout && (
             <div className="flex flex-wrap items-center gap-2">
               {canIncrease && (
                 <div className="flex items-center gap-1.5">

--- a/apps/dashboard/src/pages/Updates/components/UpdatesTable/index.tsx
+++ b/apps/dashboard/src/pages/Updates/components/UpdatesTable/index.tsx
@@ -9,7 +9,7 @@ import { UpdateDetailsRef, UpdateDetailsSheet } from '@/components/UpdateDetails
 import { useRef } from 'react';
 import { useSelectedApp } from '@/lib/SelectedAppContext';
 import { useSettings } from '@/lib/SettingsContext';
-import { useCurrentUser } from '@/lib/CurrentUserContext';
+import { useAppPermission } from '@/ee/lib/PermissionsContext';
 import { TimestampCell } from '@/components/ui/timestamp-cell';
 import { UpdatesBreadcrumb } from '@/pages/Updates/components/UpdatesBreadcrumb';
 import { UpdateRolloutCard } from '@/pages/Updates/components/UpdateRolloutCard';
@@ -24,7 +24,7 @@ export const UpdatesTable = ({
   const sheetRef = useRef<UpdateDetailsRef>(null);
   const { selectedAppId } = useSelectedApp();
   const { CONTROL_PLANE_ENABLED } = useSettings();
-  const { isAdmin } = useCurrentUser();
+  const canManageUpdateRollout = useAppPermission('update-rollout:manage');
   const { data, isLoading, error } = useQuery({
     queryKey: ['updates', selectedAppId, branch, runtimeVersion],
     queryFn: () => api.getUpdates(branch, runtimeVersion),
@@ -51,7 +51,7 @@ export const UpdatesTable = ({
           branch={branch}
           runtimeVersion={runtimeVersion}
           updates={activeRollout}
-          isAdmin={isAdmin}
+          canManageRollout={canManageUpdateRollout}
         />
       )}
       <UpdateDetailsSheet ref={sheetRef} branch={branch} runtimeVersion={runtimeVersion} />

--- a/apps/dashboard/src/pages/Users/index.tsx
+++ b/apps/dashboard/src/pages/Users/index.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { KeyRound, Plus, Shield, ShieldOff, Trash2 } from 'lucide-react';
+import { KeyRound, Plus, Trash2, UserCog } from 'lucide-react';
 import { api, UserRecord, describeApiError } from '@/lib/api';
+import { UserRolesSheet } from '@/ee/components/UserRolesSheet';
+import { usePermissions } from '@/ee/lib/PermissionsContext';
 import { useSettings } from '@/lib/SettingsContext';
 import { useCurrentUser } from '@/lib/CurrentUserContext';
 import { useToast } from '@/hooks/use-toast';
@@ -21,35 +23,28 @@ export const Users = () => {
   const queryClient = useQueryClient();
 
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [userForRoles, setUserForRoles] = useState<UserRecord | null>(null);
   const [userToDelete, setUserToDelete] = useState<UserRecord | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
-  const [togglingUserId, setTogglingUserId] = useState<string | null>(null);
   const [togglingEnabledId, setTogglingEnabledId] = useState<string | null>(null);
+
+  // While fine-grained roles are enforced, a member without a single grant
+  // sees an empty dashboard; the summary lets the table warn about them.
+  const { enabled: rbacEnabled } = usePermissions();
 
   const usersQuery = useQuery({
     queryKey: ['users'],
     queryFn: () => api.getUsers(),
     enabled: CONTROL_PLANE_ENABLED && isAdmin,
   });
+  const grantsSummaryQuery = useQuery({
+    queryKey: ['userGrantsSummary'],
+    queryFn: () => api.getUserGrantsSummary(),
+    enabled: CONTROL_PLANE_ENABLED && isAdmin && rbacEnabled,
+  });
 
   const notifyError = (error: unknown, fallbackTitle: string) =>
     toast({ ...describeApiError(error, fallbackTitle), variant: 'destructive' });
-
-  const handleToggleAdmin = async (user: UserRecord) => {
-    setTogglingUserId(user.id);
-    try {
-      await api.updateUserAdmin(user.id, !user.isAdmin);
-      queryClient.invalidateQueries({ queryKey: ['users'] });
-      toast({
-        title: user.isAdmin ? 'Admin removed' : 'Admin granted',
-        description: `"${user.email}" is ${user.isAdmin ? 'no longer' : 'now'} an admin.`,
-      });
-    } catch (error) {
-      notifyError(error, 'Error updating user');
-    } finally {
-      setTogglingUserId(null);
-    }
-  };
 
   const handleToggleEnabled = async (user: UserRecord) => {
     setTogglingEnabledId(user.id);
@@ -153,12 +148,30 @@ export const Users = () => {
             {
               header: 'Role',
               accessorKey: 'isAdmin',
-              cell: ({ row }) =>
-                row.original.isAdmin ? (
-                  <Badge>Admin</Badge>
-                ) : (
-                  <Badge variant="secondary">Member</Badge>
-                ),
+              cell: ({ row }) => {
+                if (row.original.isAdmin) {
+                  return <Badge>Admin</Badge>;
+                }
+                // Only meaningful while roles are enforced: without a license
+                // members keep the community read-only access to every app.
+                const hasNoAccess =
+                  rbacEnabled &&
+                  grantsSummaryQuery.data &&
+                  !(grantsSummaryQuery.data[row.original.id] > 0);
+                return (
+                  <span className="flex items-center gap-1.5">
+                    <Badge variant="secondary">Member</Badge>
+                    {hasNoAccess && (
+                      <Badge
+                        variant="outline"
+                        className="border-amber-300/80 bg-amber-50 font-normal text-amber-800"
+                        title="This member holds no grant: they see an empty dashboard. Open Roles to give them access.">
+                        No app access
+                      </Badge>
+                    )}
+                  </span>
+                );
+              },
             },
             {
               header: 'Access',
@@ -216,13 +229,13 @@ export const Users = () => {
                 return (
                   <div className="flex items-center justify-end gap-1">
                     <Button
-                      variant="ghost"
+                      variant="outline"
                       size="sm"
-                      onClick={() => handleToggleAdmin(row.original)}
-                      disabled={togglingUserId === row.original.id}
-                      className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground"
-                      title={row.original.isAdmin ? 'Remove admin' : 'Make admin'}>
-                      {row.original.isAdmin ? <ShieldOff /> : <Shield />}
+                      onClick={() => setUserForRoles(row.original)}
+                      className="h-8 gap-1.5 text-muted-foreground hover:text-foreground"
+                      title="Admin status and per-app roles">
+                      <UserCog className="h-3.5 w-3.5" />
+                      Roles
                     </Button>
                     <Button
                       variant="ghost"
@@ -247,6 +260,8 @@ export const Users = () => {
         onClose={() => setIsCreateModalOpen(false)}
         onUserCreated={() => queryClient.invalidateQueries({ queryKey: ['users'] })}
       />
+
+      <UserRolesSheet user={userForRoles} onClose={() => setUserForRoles(null)} />
 
       <DeleteDialog
         isOpen={!!userToDelete}

--- a/ee/rbac/handler.go
+++ b/ee/rbac/handler.go
@@ -20,13 +20,10 @@ import (
 // dashboard gates its UI with.
 type RBACHandler struct {
 	service *RBACService
-	// userLookup resolves the target user of the grants endpoints (404 on an
-	// unknown id) and the caller of /me/permissions. Nil in stateless mode.
-	userLookup UserLookup
 }
 
-func NewRBACHandler(service *RBACService, userLookup UserLookup) *RBACHandler {
-	return &RBACHandler{service: service, userLookup: userLookup}
+func NewRBACHandler(service *RBACService) *RBACHandler {
+	return &RBACHandler{service: service}
 }
 
 type RoleResponse struct {
@@ -159,11 +156,11 @@ func (h *RBACHandler) DeleteRoleHandler(w http.ResponseWriter, r *http.Request) 
 // permissionless user.
 func (h *RBACHandler) resolveTargetUser(w http.ResponseWriter, r *http.Request) (string, bool) {
 	userId := mux.Vars(r)["USER_ID"]
-	if h.userLookup == nil {
+	if h.service.userLookup == nil {
 		handlers.RenderError(w, http.StatusBadRequest, ErrRequiresControlPlane.Error())
 		return "", false
 	}
-	if _, err := h.userLookup.GetUserByID(r.Context(), userId); err != nil {
+	if _, err := h.service.userLookup.GetUserByID(r.Context(), userId); err != nil {
 		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
 			handlers.RenderError(w, http.StatusNotFound, notFoundErr.Error())
 		} else {
@@ -232,7 +229,7 @@ type MyPermissionsResponse struct {
 // GetMyPermissionsHandler is display support only: the server re-checks every
 // mutation through the middlewares regardless of what the UI shows.
 func (h *RBACHandler) GetMyPermissionsHandler(w http.ResponseWriter, r *http.Request) {
-	subject, ok := resolveSubject(w, r, h.userLookup)
+	subject, ok := h.service.resolveSubject(w, r)
 	if !ok {
 		return
 	}

--- a/ee/rbac/handler.go
+++ b/ee/rbac/handler.go
@@ -217,6 +217,17 @@ func (h *RBACHandler) SetUserGrantsHandler(w http.ResponseWriter, r *http.Reques
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// GetGrantSummaryHandler answers the per-user grant counts as a plain
+// {userId: count} map; users absent from the map hold no grants.
+func (h *RBACHandler) GetGrantSummaryHandler(w http.ResponseWriter, r *http.Request) {
+	counts, err := h.service.GrantCountsByUser(r.Context())
+	if err != nil {
+		renderRBACServiceError(w, err)
+		return
+	}
+	renderJSON(w, http.StatusOK, counts)
+}
+
 // MyPermissionsResponse tells the dashboard what to show the current account.
 // Enabled=false means fine-grained roles are not enforced (community rules:
 // isAdmin decides everything). For an admin, or when disabled, Apps is null.

--- a/ee/rbac/handler.go
+++ b/ee/rbac/handler.go
@@ -1,0 +1,252 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package rbac
+
+import (
+	"encoding/json"
+	"errors"
+	"expo-open-ota/internal/handlers"
+	"expo-open-ota/internal/store"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+// RBACHandler serves the management API: role CRUD and per-user grants
+// (admin-only routes), plus the current account's permission map the
+// dashboard gates its UI with.
+type RBACHandler struct {
+	service *RBACService
+	// userLookup resolves the target user of the grants endpoints (404 on an
+	// unknown id) and the caller of /me/permissions. Nil in stateless mode.
+	userLookup UserLookup
+}
+
+func NewRBACHandler(service *RBACService, userLookup UserLookup) *RBACHandler {
+	return &RBACHandler{service: service, userLookup: userLookup}
+}
+
+type RoleResponse struct {
+	Id          string   `json:"id"`
+	Name        string   `json:"name"`
+	Permissions []string `json:"permissions"`
+	CreatedAt   string   `json:"createdAt,omitempty"`
+	UpdatedAt   string   `json:"updatedAt,omitempty"`
+}
+
+func roleResponseFrom(role Role) RoleResponse {
+	response := RoleResponse{
+		Id:          role.ID,
+		Name:        role.Name,
+		Permissions: fromPermissions(role.Permissions),
+	}
+	if !role.CreatedAt.IsZero() {
+		response.CreatedAt = role.CreatedAt.UTC().Format(time.RFC3339)
+	}
+	if !role.UpdatedAt.IsZero() {
+		response.UpdatedAt = role.UpdatedAt.UTC().Format(time.RFC3339)
+	}
+	return response
+}
+
+// GrantResponse is one row of a member's access list. EffectivePermissions is
+// precomputed server-side (role ∪ extras) so every consumer displays the same
+// truth the enforcement uses.
+type GrantResponse struct {
+	AppId                string   `json:"appId"`
+	RoleId               *string  `json:"roleId"`
+	RoleName             *string  `json:"roleName"`
+	ExtraPermissions     []string `json:"extraPermissions"`
+	EffectivePermissions []string `json:"effectivePermissions"`
+}
+
+func grantResponseFrom(grant AppGrant) GrantResponse {
+	return GrantResponse{
+		AppId:                grant.AppID,
+		RoleId:               grant.RoleID,
+		RoleName:             grant.RoleName,
+		ExtraPermissions:     fromPermissions(grant.ExtraPermissions),
+		EffectivePermissions: fromPermissions(grant.Effective()),
+	}
+}
+
+func renderJSON(w http.ResponseWriter, status int, payload interface{}) {
+	marshaledResponse, _ := json.Marshal(payload)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	w.Write(marshaledResponse)
+}
+
+func renderRBACServiceError(w http.ResponseWriter, err error) {
+	validationErr := (*ValidationError)(nil)
+	alreadyExistsErr := (*store.ErrResourceAlreadyExists)(nil)
+	switch {
+	case errors.Is(err, ErrRequiresControlPlane):
+		handlers.RenderError(w, http.StatusBadRequest, err.Error())
+	case errors.Is(err, ErrRequiresValidLicense):
+		handlers.RenderError(w, http.StatusForbidden, err.Error())
+	case errors.Is(err, ErrRoleNotFound):
+		handlers.RenderError(w, http.StatusNotFound, err.Error())
+	case errors.Is(err, ErrRoleInUse):
+		handlers.RenderError(w, http.StatusConflict, err.Error())
+	case errors.As(err, &alreadyExistsErr):
+		handlers.RenderError(w, http.StatusConflict, alreadyExistsErr.Error())
+	case errors.As(err, &validationErr):
+		handlers.RenderError(w, http.StatusBadRequest, validationErr.Error())
+	default:
+		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred.")
+	}
+}
+
+func (h *RBACHandler) ListRolesHandler(w http.ResponseWriter, r *http.Request) {
+	roles, err := h.service.ListRoles(r.Context())
+	if err != nil {
+		renderRBACServiceError(w, err)
+		return
+	}
+	response := make([]RoleResponse, len(roles))
+	for i, role := range roles {
+		response[i] = roleResponseFrom(role)
+	}
+	renderJSON(w, http.StatusOK, response)
+}
+
+type rolePayload struct {
+	Name        string   `json:"name"`
+	Permissions []string `json:"permissions"`
+}
+
+func (h *RBACHandler) CreateRoleHandler(w http.ResponseWriter, r *http.Request) {
+	var requestBody rolePayload
+	if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+		handlers.RenderError(w, http.StatusBadRequest, "Invalid request body: "+err.Error())
+		return
+	}
+	role, err := h.service.CreateRole(r.Context(), requestBody.Name, toPermissions(requestBody.Permissions))
+	if err != nil {
+		renderRBACServiceError(w, err)
+		return
+	}
+	renderJSON(w, http.StatusCreated, roleResponseFrom(role))
+}
+
+func (h *RBACHandler) UpdateRoleHandler(w http.ResponseWriter, r *http.Request) {
+	var requestBody rolePayload
+	if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+		handlers.RenderError(w, http.StatusBadRequest, "Invalid request body: "+err.Error())
+		return
+	}
+	if err := h.service.UpdateRole(r.Context(), mux.Vars(r)["ROLE_ID"], requestBody.Name, toPermissions(requestBody.Permissions)); err != nil {
+		renderRBACServiceError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *RBACHandler) DeleteRoleHandler(w http.ResponseWriter, r *http.Request) {
+	if err := h.service.DeleteRole(r.Context(), mux.Vars(r)["ROLE_ID"]); err != nil {
+		renderRBACServiceError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// resolveTargetUser 404s grant requests aimed at an account that does not
+// exist, instead of answering an empty grant list that reads like a real,
+// permissionless user.
+func (h *RBACHandler) resolveTargetUser(w http.ResponseWriter, r *http.Request) (string, bool) {
+	userId := mux.Vars(r)["USER_ID"]
+	if h.userLookup == nil {
+		handlers.RenderError(w, http.StatusBadRequest, ErrRequiresControlPlane.Error())
+		return "", false
+	}
+	if _, err := h.userLookup.GetUserByID(r.Context(), userId); err != nil {
+		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
+			handlers.RenderError(w, http.StatusNotFound, notFoundErr.Error())
+		} else {
+			handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred.")
+		}
+		return "", false
+	}
+	return userId, true
+}
+
+func (h *RBACHandler) GetUserGrantsHandler(w http.ResponseWriter, r *http.Request) {
+	userId, ok := h.resolveTargetUser(w, r)
+	if !ok {
+		return
+	}
+	grants, err := h.service.GetUserGrants(r.Context(), userId)
+	if err != nil {
+		renderRBACServiceError(w, err)
+		return
+	}
+	response := make([]GrantResponse, len(grants))
+	for i, grant := range grants {
+		response[i] = grantResponseFrom(grant)
+	}
+	renderJSON(w, http.StatusOK, response)
+}
+
+func (h *RBACHandler) SetUserGrantsHandler(w http.ResponseWriter, r *http.Request) {
+	userId, ok := h.resolveTargetUser(w, r)
+	if !ok {
+		return
+	}
+	var requestBody []struct {
+		AppId            string   `json:"appId"`
+		RoleId           *string  `json:"roleId"`
+		ExtraPermissions []string `json:"extraPermissions"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+		handlers.RenderError(w, http.StatusBadRequest, "Invalid request body: "+err.Error())
+		return
+	}
+	grants := make([]GrantInput, len(requestBody))
+	for i, grant := range requestBody {
+		grants[i] = GrantInput{
+			AppID:            grant.AppId,
+			RoleID:           grant.RoleId,
+			ExtraPermissions: toPermissions(grant.ExtraPermissions),
+		}
+	}
+	if err := h.service.SetUserGrants(r.Context(), userId, grants); err != nil {
+		renderRBACServiceError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// MyPermissionsResponse tells the dashboard what to show the current account.
+// Enabled=false means fine-grained roles are not enforced (community rules:
+// isAdmin decides everything). For an admin, or when disabled, Apps is null.
+type MyPermissionsResponse struct {
+	Enabled bool                `json:"enabled"`
+	IsAdmin bool                `json:"isAdmin"`
+	Apps    map[string][]string `json:"apps"`
+}
+
+// GetMyPermissionsHandler is display support only: the server re-checks every
+// mutation through the middlewares regardless of what the UI shows.
+func (h *RBACHandler) GetMyPermissionsHandler(w http.ResponseWriter, r *http.Request) {
+	subject, ok := resolveSubject(w, r, h.userLookup)
+	if !ok {
+		return
+	}
+	response := MyPermissionsResponse{Enabled: h.service.Enabled(), IsAdmin: subject.IsAdmin}
+	if response.Enabled && !subject.IsAdmin {
+		byApp, err := h.service.EffectivePermissionsByApp(r.Context(), subject.UserID)
+		if err != nil {
+			renderRBACServiceError(w, err)
+			return
+		}
+		response.Apps = make(map[string][]string, len(byApp))
+		for appId, perms := range byApp {
+			response.Apps[appId] = fromPermissions(perms)
+		}
+	}
+	renderJSON(w, http.StatusOK, response)
+}

--- a/ee/rbac/handler_test.go
+++ b/ee/rbac/handler_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package rbac
+
+import (
+	"encoding/json"
+	"expo-open-ota/internal/middleware"
+	"expo-open-ota/internal/services"
+	"expo-open-ota/internal/store"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+// newHandlerRig registers every RBAC route the way the real router does
+// (minus the admin gate, which has its own tests) and returns a request
+// runner. The principal, when set, rides the context like the auth middleware
+// would place it.
+func newHandlerRig(handler *RBACHandler) func(t *testing.T, method, path, body string, principal *services.DashboardPrincipal) *httptest.ResponseRecorder {
+	router := mux.NewRouter()
+	router.HandleFunc("/roles", handler.ListRolesHandler).Methods(http.MethodGet)
+	router.HandleFunc("/roles", handler.CreateRoleHandler).Methods(http.MethodPost)
+	router.HandleFunc("/roles/{ROLE_ID}", handler.UpdateRoleHandler).Methods(http.MethodPut)
+	router.HandleFunc("/roles/{ROLE_ID}", handler.DeleteRoleHandler).Methods(http.MethodDelete)
+	router.HandleFunc("/users/{USER_ID}/grants", handler.GetUserGrantsHandler).Methods(http.MethodGet)
+	router.HandleFunc("/users/{USER_ID}/grants", handler.SetUserGrantsHandler).Methods(http.MethodPut)
+	router.HandleFunc("/me/permissions", handler.GetMyPermissionsHandler).Methods(http.MethodGet)
+	return func(t *testing.T, method, path, body string, principal *services.DashboardPrincipal) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(method, path, strings.NewReader(body))
+		if principal != nil {
+			req = req.WithContext(middleware.WithPrincipal(req.Context(), principal))
+		}
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		return recorder
+	}
+}
+
+func TestRoleHandlersContract(t *testing.T) {
+	repo := newFakeRepo()
+	run := newHandlerRig(NewRBACHandler(licensedService(repo), &fakeUserLookup{}))
+
+	// Create: 201 with the canonical shape.
+	recorder := run(t, http.MethodPost, "/roles", `{"name":"Release manager","permissions":["channel-rollout:manage"]}`, nil)
+	require.Equal(t, http.StatusCreated, recorder.Code)
+	var created RoleResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &created))
+	require.NotEmpty(t, created.Id)
+	require.Equal(t, "Release manager", created.Name)
+	require.Equal(t, []string{"channel-rollout:manage"}, created.Permissions)
+
+	// An unknown permission string never reaches the repository.
+	recorder = run(t, http.MethodPost, "/roles", `{"name":"Bad","permissions":["nope"]}`, nil)
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "nope")
+
+	// List carries the created role.
+	recorder = run(t, http.MethodGet, "/roles", "", nil)
+	require.Equal(t, http.StatusOK, recorder.Code)
+	var listed []RoleResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &listed))
+	require.Len(t, listed, 1)
+
+	// Update and delete answer 204; a ghost role 404s.
+	recorder = run(t, http.MethodPut, "/roles/"+created.Id, `{"name":"Ops","permissions":[]}`, nil)
+	require.Equal(t, http.StatusNoContent, recorder.Code)
+	recorder = run(t, http.MethodDelete, "/roles/"+created.Id, "", nil)
+	require.Equal(t, http.StatusNoContent, recorder.Code)
+	recorder = run(t, http.MethodDelete, "/roles/"+created.Id, "", nil)
+	require.Equal(t, http.StatusNotFound, recorder.Code)
+}
+
+func TestGrantHandlersContract(t *testing.T) {
+	repo := newFakeRepo()
+	roleID := "role-1"
+	repo.grants["member-1"] = []AppGrant{{
+		AppID:            "app-1",
+		RoleID:           &roleID,
+		RolePermissions:  []Permission{PermBranchProtect},
+		ExtraPermissions: []Permission{PermCertificateRead},
+	}}
+	lookup := &fakeUserLookup{users: map[string]store.User{"member-1": {Id: "member-1"}}}
+	run := newHandlerRig(NewRBACHandler(licensedService(repo), lookup))
+
+	// The read resolves the role and precomputes the effective union.
+	recorder := run(t, http.MethodGet, "/users/member-1/grants", "", nil)
+	require.Equal(t, http.StatusOK, recorder.Code)
+	var grants []GrantResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &grants))
+	require.Len(t, grants, 1)
+	require.Equal(t, "app-1", grants[0].AppId)
+	require.Equal(t, []string{"certificate:read"}, grants[0].ExtraPermissions)
+	require.Equal(t, []string{"certificate:read", "branch:protect"}, grants[0].EffectivePermissions)
+
+	// Writes land in the repository as a wholesale replacement.
+	recorder = run(t, http.MethodPut, "/users/member-1/grants",
+		`[{"appId":"app-2","roleId":"role-9","extraPermissions":["branch:create"]}]`, nil)
+	require.Equal(t, http.StatusNoContent, recorder.Code)
+	require.Len(t, repo.replaced["member-1"], 1)
+	require.Equal(t, "app-2", repo.replaced["member-1"][0].AppID)
+
+	// A grants request for an account that does not exist is a 404, not an
+	// empty list that reads like a real permissionless user.
+	recorder = run(t, http.MethodGet, "/users/ghost/grants", "", nil)
+	require.Equal(t, http.StatusNotFound, recorder.Code)
+	recorder = run(t, http.MethodPut, "/users/ghost/grants", `[]`, nil)
+	require.Equal(t, http.StatusNotFound, recorder.Code)
+
+	// Unknown permission strings are refused at the door.
+	recorder = run(t, http.MethodPut, "/users/member-1/grants", `[{"appId":"app-1","extraPermissions":["nope"]}]`, nil)
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+}
+
+func TestMyPermissionsHandler(t *testing.T) {
+	repo := newFakeRepo()
+	repo.grants["member-1"] = []AppGrant{{AppID: "app-1", ExtraPermissions: []Permission{PermBranchCreate}}}
+	lookup := &fakeUserLookup{users: map[string]store.User{
+		"member-1": {Id: "member-1"},
+		"admin-1":  {Id: "admin-1", IsAdmin: true},
+	}}
+
+	decode := func(recorder *httptest.ResponseRecorder) MyPermissionsResponse {
+		var response MyPermissionsResponse
+		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+		return response
+	}
+
+	// Enforced member: the per-app map, straight from the grants.
+	run := newHandlerRig(NewRBACHandler(licensedService(repo), lookup))
+	recorder := run(t, http.MethodGet, "/me/permissions", "", &services.DashboardPrincipal{UserId: "member-1"})
+	require.Equal(t, http.StatusOK, recorder.Code)
+	response := decode(recorder)
+	require.True(t, response.Enabled)
+	require.False(t, response.IsAdmin)
+	require.Equal(t, map[string][]string{"app-1": {"branch:create"}}, response.Apps)
+
+	// Admin: flagged as such, no map needed.
+	recorder = run(t, http.MethodGet, "/me/permissions", "", &services.DashboardPrincipal{UserId: "admin-1"})
+	response = decode(recorder)
+	require.True(t, response.IsAdmin)
+	require.Nil(t, response.Apps)
+
+	// No license: enabled=false tells the UI to fall back to community rules.
+	run = newHandlerRig(NewRBACHandler(unlicensedService(repo), lookup))
+	recorder = run(t, http.MethodGet, "/me/permissions", "", &services.DashboardPrincipal{UserId: "member-1"})
+	response = decode(recorder)
+	require.False(t, response.Enabled)
+	require.Nil(t, response.Apps)
+
+	// No session at all: refused.
+	recorder = run(t, http.MethodGet, "/me/permissions", "", nil)
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+}

--- a/ee/rbac/handler_test.go
+++ b/ee/rbac/handler_test.go
@@ -45,7 +45,7 @@ func newHandlerRig(handler *RBACHandler) func(t *testing.T, method, path, body s
 
 func TestRoleHandlersContract(t *testing.T) {
 	repo := newFakeRepo()
-	run := newHandlerRig(NewRBACHandler(licensedService(repo), &fakeUserLookup{}))
+	run := newHandlerRig(NewRBACHandler(withLookup(licensedService(repo), &fakeUserLookup{})))
 
 	// Create: 201 with the canonical shape.
 	recorder := run(t, http.MethodPost, "/roles", `{"name":"Release manager","permissions":["channel-rollout:manage"]}`, nil)
@@ -87,7 +87,7 @@ func TestGrantHandlersContract(t *testing.T) {
 		ExtraPermissions: []Permission{PermCertificateRead},
 	}}
 	lookup := &fakeUserLookup{users: map[string]store.User{"member-1": {Id: "member-1"}}}
-	run := newHandlerRig(NewRBACHandler(licensedService(repo), lookup))
+	run := newHandlerRig(NewRBACHandler(withLookup(licensedService(repo), lookup)))
 
 	// The read resolves the role and precomputes the effective union.
 	recorder := run(t, http.MethodGet, "/users/member-1/grants", "", nil)
@@ -133,7 +133,7 @@ func TestMyPermissionsHandler(t *testing.T) {
 	}
 
 	// Enforced member: the per-app map, straight from the grants.
-	run := newHandlerRig(NewRBACHandler(licensedService(repo), lookup))
+	run := newHandlerRig(NewRBACHandler(withLookup(licensedService(repo), lookup)))
 	recorder := run(t, http.MethodGet, "/me/permissions", "", &services.DashboardPrincipal{UserId: "member-1"})
 	require.Equal(t, http.StatusOK, recorder.Code)
 	response := decode(recorder)
@@ -148,7 +148,7 @@ func TestMyPermissionsHandler(t *testing.T) {
 	require.Nil(t, response.Apps)
 
 	// No license: enabled=false tells the UI to fall back to community rules.
-	run = newHandlerRig(NewRBACHandler(unlicensedService(repo), lookup))
+	run = newHandlerRig(NewRBACHandler(withLookup(unlicensedService(repo), lookup)))
 	recorder = run(t, http.MethodGet, "/me/permissions", "", &services.DashboardPrincipal{UserId: "member-1"})
 	response = decode(recorder)
 	require.False(t, response.Enabled)

--- a/ee/rbac/handler_test.go
+++ b/ee/rbac/handler_test.go
@@ -5,6 +5,7 @@
 package rbac
 
 import (
+	"context"
 	"encoding/json"
 	"expo-open-ota/internal/middleware"
 	"expo-open-ota/internal/services"
@@ -33,10 +34,11 @@ func newHandlerRig(handler *RBACHandler) func(t *testing.T, method, path, body s
 	router.HandleFunc("/me/permissions", handler.GetMyPermissionsHandler).Methods(http.MethodGet)
 	return func(t *testing.T, method, path, body string, principal *services.DashboardPrincipal) *httptest.ResponseRecorder {
 		t.Helper()
-		req := httptest.NewRequest(method, path, strings.NewReader(body))
+		ctx := context.Background()
 		if principal != nil {
-			req = req.WithContext(middleware.WithPrincipal(req.Context(), principal))
+			ctx = middleware.WithPrincipal(ctx, principal)
 		}
+		req := httptest.NewRequestWithContext(ctx, method, path, strings.NewReader(body))
 		recorder := httptest.NewRecorder()
 		router.ServeHTTP(recorder, req)
 		return recorder

--- a/ee/rbac/middleware.go
+++ b/ee/rbac/middleware.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package rbac
+
+import (
+	"context"
+	"errors"
+	"expo-open-ota/internal/handlers"
+	"expo-open-ota/internal/middleware"
+	"expo-open-ota/internal/store"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// UserLookup is the one read the middlewares need from the users store.
+// services.UserRepository satisfies it; keeping it narrow lets tests fake a
+// single method instead of the whole repository. Nil in stateless mode, where
+// the session claim is authoritative (the single ADMIN_EMAIL account).
+type UserLookup interface {
+	GetUserByID(ctx context.Context, id string) (store.User, error)
+}
+
+// resolveSubject authenticates the request as a dashboard account and
+// resolves its admin flag from a fresh users-table read, exactly like the
+// community admin gate: a session token lives 2 hours, and a revoked admin
+// (or deleted user) must lose access immediately, not at the next refresh.
+// On failure it writes the response and returns ok=false.
+func resolveSubject(w http.ResponseWriter, r *http.Request, userLookup UserLookup) (Subject, bool) {
+	principal := middleware.PrincipalFromContext(r.Context())
+	if principal == nil {
+		handlers.RenderError(w, http.StatusForbidden, "This action requires a dashboard session")
+		return Subject{}, false
+	}
+	if userLookup == nil {
+		// Stateless mode: the single ADMIN_EMAIL account is always an admin
+		return Subject{UserID: principal.UserId, IsAdmin: principal.IsAdmin}, true
+	}
+	user, err := userLookup.GetUserByID(r.Context(), principal.UserId)
+	if err != nil {
+		// Only a missing row means the account is gone; an infrastructure
+		// failure must not read as a dead session.
+		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
+			handlers.RenderError(w, http.StatusUnauthorized, "Invalid token")
+		} else {
+			handlers.RenderError(w, http.StatusInternalServerError, "Could not verify the account")
+		}
+		return Subject{}, false
+	}
+	return Subject{UserID: principal.UserId, IsAdmin: user.IsAdmin}, true
+}
+
+// RequirePermission guards one app-scoped dashboard mutation: admins pass,
+// members need the permission on the route's APP_ID. It replaces the
+// community adminOnly gate on these routes, and degrades to exactly its
+// behavior when roles are not enforced (no control plane, no valid license):
+// members get the same 403 an admin-only route gives them today.
+func RequirePermission(service *RBACService, userLookup UserLookup, perm Permission) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			subject, ok := resolveSubject(w, r, userLookup)
+			if !ok {
+				return
+			}
+			appId := mux.Vars(r)["APP_ID"]
+			if appId == "" {
+				handlers.RenderError(w, http.StatusBadRequest, "invalid app id")
+				return
+			}
+			if err := service.Authorize(r.Context(), subject, appId, perm); err != nil {
+				renderAuthorizeError(w, err)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func renderAuthorizeError(w http.ResponseWriter, err error) {
+	deniedErr := (*ErrPermissionDenied)(nil)
+	switch {
+	case errors.Is(err, ErrRequiresControlPlane), errors.Is(err, ErrRequiresValidLicense):
+		// Community fallback: members are read-only, same refusal as the
+		// admin-only gate so an expired license reads identically to today.
+		handlers.RenderError(w, http.StatusForbidden, "This action requires an admin account")
+	case errors.Is(err, ErrNoAppAccess):
+		// Same body as the app resolver's 404: an app the member has no
+		// grant on does not exist for them.
+		handlers.RenderError(w, http.StatusNotFound, "app not found")
+	case errors.As(err, &deniedErr):
+		handlers.RenderError(w, http.StatusForbidden, deniedErr.Error())
+	default:
+		handlers.RenderError(w, http.StatusInternalServerError, "Could not verify permissions")
+	}
+}
+
+// RequireAppVisible guards the app-scoped dashboard reads: while roles are
+// enforced, members only see the apps they hold a grant on — anything else
+// 404s like an app that does not exist. Admins and the community fallback see
+// everything. CLI credentials pass through on the explicit marker the auth
+// middleware stamped after validating their app scope — asserted, not
+// inferred from a missing principal, so a wiring mistake fails closed.
+func RequireAppVisible(service *RBACService, userLookup UserLookup) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if middleware.PrincipalFromContext(r.Context()) == nil {
+				if middleware.CliAuthAppFromContext(r.Context()) != "" {
+					next.ServeHTTP(w, r)
+					return
+				}
+				handlers.RenderError(w, http.StatusForbidden, "This action requires a dashboard session")
+				return
+			}
+			subject, ok := resolveSubject(w, r, userLookup)
+			if !ok {
+				return
+			}
+			visible, err := service.CanSeeApp(r.Context(), subject, mux.Vars(r)["APP_ID"])
+			if err != nil {
+				handlers.RenderError(w, http.StatusInternalServerError, "Could not verify permissions")
+				return
+			}
+			if !visible {
+				handlers.RenderError(w, http.StatusNotFound, "app not found")
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/ee/rbac/middleware.go
+++ b/ee/rbac/middleware.go
@@ -28,17 +28,17 @@ type UserLookup interface {
 // community admin gate: a session token lives 2 hours, and a revoked admin
 // (or deleted user) must lose access immediately, not at the next refresh.
 // On failure it writes the response and returns ok=false.
-func resolveSubject(w http.ResponseWriter, r *http.Request, userLookup UserLookup) (Subject, bool) {
+func (s *RBACService) resolveSubject(w http.ResponseWriter, r *http.Request) (Subject, bool) {
 	principal := middleware.PrincipalFromContext(r.Context())
 	if principal == nil {
 		handlers.RenderError(w, http.StatusForbidden, "This action requires a dashboard session")
 		return Subject{}, false
 	}
-	if userLookup == nil {
+	if s.userLookup == nil {
 		// Stateless mode: the single ADMIN_EMAIL account is always an admin
 		return Subject{UserID: principal.UserId, IsAdmin: principal.IsAdmin}, true
 	}
-	user, err := userLookup.GetUserByID(r.Context(), principal.UserId)
+	user, err := s.userLookup.GetUserByID(r.Context(), principal.UserId)
 	if err != nil {
 		// Only a missing row means the account is gone; an infrastructure
 		// failure must not read as a dead session.
@@ -57,10 +57,10 @@ func resolveSubject(w http.ResponseWriter, r *http.Request, userLookup UserLooku
 // community adminOnly gate on these routes, and degrades to exactly its
 // behavior when roles are not enforced (no control plane, no valid license):
 // members get the same 403 an admin-only route gives them today.
-func RequirePermission(service *RBACService, userLookup UserLookup, perm Permission) mux.MiddlewareFunc {
+func RequirePermission(service *RBACService, perm Permission) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			subject, ok := resolveSubject(w, r, userLookup)
+			subject, ok := service.resolveSubject(w, r)
 			if !ok {
 				return
 			}
@@ -102,7 +102,7 @@ func renderAuthorizeError(w http.ResponseWriter, err error) {
 // everything. CLI credentials pass through on the explicit marker the auth
 // middleware stamped after validating their app scope — asserted, not
 // inferred from a missing principal, so a wiring mistake fails closed.
-func RequireAppVisible(service *RBACService, userLookup UserLookup) mux.MiddlewareFunc {
+func RequireAppVisible(service *RBACService) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if middleware.PrincipalFromContext(r.Context()) == nil {
@@ -113,7 +113,7 @@ func RequireAppVisible(service *RBACService, userLookup UserLookup) mux.Middlewa
 				handlers.RenderError(w, http.StatusForbidden, "This action requires a dashboard session")
 				return
 			}
-			subject, ok := resolveSubject(w, r, userLookup)
+			subject, ok := service.resolveSubject(w, r)
 			if !ok {
 				return
 			}

--- a/ee/rbac/middleware_test.go
+++ b/ee/rbac/middleware_test.go
@@ -68,7 +68,7 @@ func performCliAppRequest(t *testing.T, mw mux.MiddlewareFunc) *httptest.Respons
 }
 
 func TestRequirePermissionRequiresDashboardSession(t *testing.T) {
-	mw := RequirePermission(licensedService(newFakeRepo()), nil, PermBranchCreate)
+	mw := RequirePermission(licensedService(newFakeRepo()), PermBranchCreate)
 	recorder := performAppRequest(t, mw, nil)
 	require.Equal(t, http.StatusForbidden, recorder.Code)
 	require.Contains(t, recorder.Body.String(), "dashboard session")
@@ -81,8 +81,8 @@ func TestRequirePermissionStatelessTrustsClaim(t *testing.T) {
 	admin := &services.DashboardPrincipal{UserId: "admin-1", IsAdmin: true}
 	member := &services.DashboardPrincipal{UserId: "member-1", IsAdmin: false}
 
-	require.Equal(t, http.StatusOK, performAppRequest(t, RequirePermission(service, nil, PermBranchCreate), admin).Code)
-	recorder := performAppRequest(t, RequirePermission(service, nil, PermBranchCreate), member)
+	require.Equal(t, http.StatusOK, performAppRequest(t, RequirePermission(service, PermBranchCreate), admin).Code)
+	recorder := performAppRequest(t, RequirePermission(service, PermBranchCreate), member)
 	require.Equal(t, http.StatusForbidden, recorder.Code)
 	require.Contains(t, recorder.Body.String(), "requires an admin account")
 }
@@ -93,7 +93,7 @@ func TestRequirePermissionCommunityFallbackWithoutLicense(t *testing.T) {
 	repo := newFakeRepo()
 	repo.grants["member-1"] = []AppGrant{{AppID: "app-1", ExtraPermissions: []Permission{PermBranchCreate}}}
 	lookup := &fakeUserLookup{users: map[string]store.User{"member-1": {Id: "member-1"}}}
-	mw := RequirePermission(unlicensedService(repo), lookup, PermBranchCreate)
+	mw := RequirePermission(withLookup(unlicensedService(repo), lookup), PermBranchCreate)
 
 	recorder := performAppRequest(t, mw, &services.DashboardPrincipal{UserId: "member-1"})
 	require.Equal(t, http.StatusForbidden, recorder.Code)
@@ -103,44 +103,43 @@ func TestRequirePermissionCommunityFallbackWithoutLicense(t *testing.T) {
 func TestRequirePermissionEnforcedMember(t *testing.T) {
 	repo := newFakeRepo()
 	repo.grants["member-1"] = []AppGrant{{AppID: "app-1", ExtraPermissions: []Permission{PermBranchCreate}}}
-	service := licensedService(repo)
 	lookup := &fakeUserLookup{users: map[string]store.User{"member-1": {Id: "member-1"}}}
+	service := withLookup(licensedService(repo), lookup)
 	member := &services.DashboardPrincipal{UserId: "member-1"}
 
 	// Granted permission passes.
 	require.Equal(t, http.StatusOK,
-		performAppRequest(t, RequirePermission(service, lookup, PermBranchCreate), member).Code)
+		performAppRequest(t, RequirePermission(service, PermBranchCreate), member).Code)
 
 	// Granted app, missing permission: 403 naming it.
-	recorder := performAppRequest(t, RequirePermission(service, lookup, PermBranchDelete), member)
+	recorder := performAppRequest(t, RequirePermission(service, PermBranchDelete), member)
 	require.Equal(t, http.StatusForbidden, recorder.Code)
 	require.Contains(t, recorder.Body.String(), string(PermBranchDelete))
 
 	// No grant on the app at all: it does not exist for this member.
 	repo.grants["member-1"] = nil
-	recorder = performAppRequest(t, RequirePermission(service, lookup, PermBranchCreate), member)
+	recorder = performAppRequest(t, RequirePermission(service, PermBranchCreate), member)
 	require.Equal(t, http.StatusNotFound, recorder.Code)
 	require.Contains(t, recorder.Body.String(), "app not found")
 }
 
 func TestRequirePermissionReadsAdminFlagFresh(t *testing.T) {
-	service := licensedService(newFakeRepo())
-
 	// The JWT claims admin but the row says member (revoked since the token
 	// was minted): the fresh read wins, and with no grant the app 404s.
 	lookup := &fakeUserLookup{users: map[string]store.User{"user-1": {Id: "user-1", IsAdmin: false}}}
+	service := withLookup(licensedService(newFakeRepo()), lookup)
 	staleAdmin := &services.DashboardPrincipal{UserId: "user-1", IsAdmin: true}
 	require.Equal(t, http.StatusNotFound,
-		performAppRequest(t, RequirePermission(service, lookup, PermBranchCreate), staleAdmin).Code)
+		performAppRequest(t, RequirePermission(service, PermBranchCreate), staleAdmin).Code)
 
 	// The reverse promotion applies immediately too.
 	lookup.users["user-1"] = store.User{Id: "user-1", IsAdmin: true}
 	freshAdmin := &services.DashboardPrincipal{UserId: "user-1", IsAdmin: false}
 	require.Equal(t, http.StatusOK,
-		performAppRequest(t, RequirePermission(service, lookup, PermBranchCreate), freshAdmin).Code)
+		performAppRequest(t, RequirePermission(service, PermBranchCreate), freshAdmin).Code)
 
 	// A deleted account is a dead session, not a 403.
-	recorder := performAppRequest(t, RequirePermission(service, lookup, PermBranchCreate),
+	recorder := performAppRequest(t, RequirePermission(service, PermBranchCreate),
 		&services.DashboardPrincipal{UserId: "ghost"})
 	require.Equal(t, http.StatusUnauthorized, recorder.Code)
 }
@@ -153,7 +152,7 @@ func TestRequireAppVisible(t *testing.T) {
 		"admin-1":  {Id: "admin-1", IsAdmin: true},
 	}}
 
-	enforced := RequireAppVisible(licensedService(repo), lookup)
+	enforced := RequireAppVisible(withLookup(licensedService(repo), lookup))
 
 	// A validated CLI credential passes on the auth middleware's explicit
 	// marker; a request with neither principal nor marker fails closed.
@@ -174,5 +173,5 @@ func TestRequireAppVisible(t *testing.T) {
 
 	// Community fallback: everything stays visible.
 	require.Equal(t, http.StatusOK,
-		performAppRequest(t, RequireAppVisible(unlicensedService(repo), lookup), member).Code)
+		performAppRequest(t, RequireAppVisible(withLookup(unlicensedService(repo), lookup)), member).Code)
 }

--- a/ee/rbac/middleware_test.go
+++ b/ee/rbac/middleware_test.go
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package rbac
+
+import (
+	"context"
+	"expo-open-ota/internal/middleware"
+	"expo-open-ota/internal/services"
+	"expo-open-ota/internal/store"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeUserLookup struct {
+	users map[string]store.User
+}
+
+func (f *fakeUserLookup) GetUserByID(_ context.Context, id string) (store.User, error) {
+	user, ok := f.users[id]
+	if !ok {
+		return store.User{}, &store.ErrResourceNotFound{Resource: "user", Identifier: id}
+	}
+	return user, nil
+}
+
+// performAppRequest sends a request through the middleware on an app-scoped
+// route; the inner handler answers "200 handler executed", so that response
+// means the middleware let the request through and anything else is its
+// refusal.
+func performAppRequest(t *testing.T, mw mux.MiddlewareFunc, principal *services.DashboardPrincipal) *httptest.ResponseRecorder {
+	t.Helper()
+	router := mux.NewRouter()
+	router.Handle("/api/apps/{APP_ID}/branches",
+		mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("handler executed"))
+		}))).Methods(http.MethodPost)
+	req := httptest.NewRequest(http.MethodPost, "/api/apps/app-1/branches", nil)
+	if principal != nil {
+		req = req.WithContext(middleware.WithPrincipal(req.Context(), principal))
+	}
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	return recorder
+}
+
+// performCliAppRequest simulates a request the auth middleware validated as
+// an app-scoped CLI credential: no principal, the CLI marker on the context.
+func performCliAppRequest(t *testing.T, mw mux.MiddlewareFunc) *httptest.ResponseRecorder {
+	t.Helper()
+	router := mux.NewRouter()
+	router.Handle("/api/apps/{APP_ID}/branches",
+		mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("handler executed"))
+		}))).Methods(http.MethodPost)
+	req := httptest.NewRequest(http.MethodPost, "/api/apps/app-1/branches", nil)
+	req = req.WithContext(middleware.WithCliAuth(req.Context(), "app-1"))
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	return recorder
+}
+
+func TestRequirePermissionRequiresDashboardSession(t *testing.T) {
+	mw := RequirePermission(licensedService(newFakeRepo()), nil, PermBranchCreate)
+	recorder := performAppRequest(t, mw, nil)
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "dashboard session")
+}
+
+func TestRequirePermissionStatelessTrustsClaim(t *testing.T) {
+	// No user lookup (stateless mode): the claim decides, and members are
+	// read-only exactly like today.
+	service := unlicensedService(nil)
+	admin := &services.DashboardPrincipal{UserId: "admin-1", IsAdmin: true}
+	member := &services.DashboardPrincipal{UserId: "member-1", IsAdmin: false}
+
+	require.Equal(t, http.StatusOK, performAppRequest(t, RequirePermission(service, nil, PermBranchCreate), admin).Code)
+	recorder := performAppRequest(t, RequirePermission(service, nil, PermBranchCreate), member)
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "requires an admin account")
+}
+
+func TestRequirePermissionCommunityFallbackWithoutLicense(t *testing.T) {
+	// Control plane, grants in place, but no license: the grant must not
+	// widen anything, the member gets the community admin-only refusal.
+	repo := newFakeRepo()
+	repo.grants["member-1"] = []AppGrant{{AppID: "app-1", ExtraPermissions: []Permission{PermBranchCreate}}}
+	lookup := &fakeUserLookup{users: map[string]store.User{"member-1": {Id: "member-1"}}}
+	mw := RequirePermission(unlicensedService(repo), lookup, PermBranchCreate)
+
+	recorder := performAppRequest(t, mw, &services.DashboardPrincipal{UserId: "member-1"})
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "requires an admin account")
+}
+
+func TestRequirePermissionEnforcedMember(t *testing.T) {
+	repo := newFakeRepo()
+	repo.grants["member-1"] = []AppGrant{{AppID: "app-1", ExtraPermissions: []Permission{PermBranchCreate}}}
+	service := licensedService(repo)
+	lookup := &fakeUserLookup{users: map[string]store.User{"member-1": {Id: "member-1"}}}
+	member := &services.DashboardPrincipal{UserId: "member-1"}
+
+	// Granted permission passes.
+	require.Equal(t, http.StatusOK,
+		performAppRequest(t, RequirePermission(service, lookup, PermBranchCreate), member).Code)
+
+	// Granted app, missing permission: 403 naming it.
+	recorder := performAppRequest(t, RequirePermission(service, lookup, PermBranchDelete), member)
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+	require.Contains(t, recorder.Body.String(), string(PermBranchDelete))
+
+	// No grant on the app at all: it does not exist for this member.
+	repo.grants["member-1"] = nil
+	recorder = performAppRequest(t, RequirePermission(service, lookup, PermBranchCreate), member)
+	require.Equal(t, http.StatusNotFound, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "app not found")
+}
+
+func TestRequirePermissionReadsAdminFlagFresh(t *testing.T) {
+	service := licensedService(newFakeRepo())
+
+	// The JWT claims admin but the row says member (revoked since the token
+	// was minted): the fresh read wins, and with no grant the app 404s.
+	lookup := &fakeUserLookup{users: map[string]store.User{"user-1": {Id: "user-1", IsAdmin: false}}}
+	staleAdmin := &services.DashboardPrincipal{UserId: "user-1", IsAdmin: true}
+	require.Equal(t, http.StatusNotFound,
+		performAppRequest(t, RequirePermission(service, lookup, PermBranchCreate), staleAdmin).Code)
+
+	// The reverse promotion applies immediately too.
+	lookup.users["user-1"] = store.User{Id: "user-1", IsAdmin: true}
+	freshAdmin := &services.DashboardPrincipal{UserId: "user-1", IsAdmin: false}
+	require.Equal(t, http.StatusOK,
+		performAppRequest(t, RequirePermission(service, lookup, PermBranchCreate), freshAdmin).Code)
+
+	// A deleted account is a dead session, not a 403.
+	recorder := performAppRequest(t, RequirePermission(service, lookup, PermBranchCreate),
+		&services.DashboardPrincipal{UserId: "ghost"})
+	require.Equal(t, http.StatusUnauthorized, recorder.Code)
+}
+
+func TestRequireAppVisible(t *testing.T) {
+	repo := newFakeRepo()
+	repo.grants["member-1"] = []AppGrant{{AppID: "app-1"}}
+	lookup := &fakeUserLookup{users: map[string]store.User{
+		"member-1": {Id: "member-1"},
+		"admin-1":  {Id: "admin-1", IsAdmin: true},
+	}}
+
+	enforced := RequireAppVisible(licensedService(repo), lookup)
+
+	// A validated CLI credential passes on the auth middleware's explicit
+	// marker; a request with neither principal nor marker fails closed.
+	require.Equal(t, http.StatusOK, performCliAppRequest(t, enforced).Code)
+	require.Equal(t, http.StatusForbidden, performAppRequest(t, enforced, nil).Code)
+
+	// A granted member sees the app, an admin always does.
+	member := &services.DashboardPrincipal{UserId: "member-1"}
+	require.Equal(t, http.StatusOK, performAppRequest(t, enforced, member).Code)
+	require.Equal(t, http.StatusOK,
+		performAppRequest(t, enforced, &services.DashboardPrincipal{UserId: "admin-1"}).Code)
+
+	// A grant on another app does not help: this one does not exist for them.
+	repo.grants["member-1"] = []AppGrant{{AppID: "app-2"}}
+	recorder := performAppRequest(t, enforced, member)
+	require.Equal(t, http.StatusNotFound, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "app not found")
+
+	// Community fallback: everything stays visible.
+	require.Equal(t, http.StatusOK,
+		performAppRequest(t, RequireAppVisible(unlicensedService(repo), lookup), member).Code)
+}

--- a/ee/rbac/permissions.go
+++ b/ee/rbac/permissions.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package rbac
+
+// Permission is one dashboard action a member can be granted on an app.
+// Admins never need one: the admin flag bypasses the whole permission model.
+// The strings are stored as-is in roles.permissions and
+// user_app_grants.extra_permissions, so renaming one is a data migration.
+type Permission string
+
+const (
+	PermAppDelete       Permission = "app:delete"
+	PermAppRename       Permission = "app:rename"
+	PermCertificateRead Permission = "certificate:read"
+	PermBranchCreate    Permission = "branch:create"
+	PermBranchDelete    Permission = "branch:delete"
+	// PermBranchProtect toggles branch protection on and off. Deliberately
+	// separate from PermBranchDelete: protecting production is routine,
+	// deleting branches is not.
+	PermBranchProtect     Permission = "branch:protect"
+	PermChannelCreate     Permission = "channel:create"
+	PermChannelDelete     Permission = "channel:delete"
+	PermChannelEditBranch Permission = "channel:edit-branch"
+	// PermChannelRolloutManage covers the whole lifecycle of a channel
+	// rollout (start, adjust the percentage, promote or revert): being able
+	// to move a rollout forward and being able to back it out are the same
+	// level of trust.
+	PermChannelRolloutManage Permission = "channel-rollout:manage"
+	// PermUpdateRolloutManage is the per-update sibling: set the rollout
+	// percentage of a single update or revert it.
+	PermUpdateRolloutManage Permission = "update-rollout:manage"
+	// PermApiKeysManage mints and revokes the app's publishing tokens and
+	// edits their enterprise restrictions (IP allowlists, protected-branch
+	// access).
+	PermApiKeysManage Permission = "apikeys:manage"
+)
+
+// AllPermissions is the catalog, in the order the dashboard displays it.
+var AllPermissions = []Permission{
+	PermAppDelete,
+	PermAppRename,
+	PermCertificateRead,
+	PermBranchCreate,
+	PermBranchDelete,
+	PermBranchProtect,
+	PermChannelCreate,
+	PermChannelDelete,
+	PermChannelEditBranch,
+	PermChannelRolloutManage,
+	PermUpdateRolloutManage,
+	PermApiKeysManage,
+}
+
+var permissionSet = func() map[Permission]struct{} {
+	set := make(map[Permission]struct{}, len(AllPermissions))
+	for _, p := range AllPermissions {
+		set[p] = struct{}{}
+	}
+	return set
+}()
+
+// IsValidPermission reports whether the string is part of the catalog. Every
+// write path validates through it so an unknown string can never reach the
+// database, where it would silently grant nothing.
+func IsValidPermission(p string) bool {
+	_, ok := permissionSet[Permission(p)]
+	return ok
+}

--- a/ee/rbac/service.go
+++ b/ee/rbac/service.go
@@ -1,0 +1,315 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package rbac
+
+import (
+	"context"
+	"errors"
+	"expo-open-ota/ee/licensing"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Role is a named, reusable permission bundle. Roles are global: which apps
+// one applies to is decided per user in the grants.
+type Role struct {
+	ID          string
+	Name        string
+	Permissions []Permission
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// AppGrant is one member's access to one app: an optional role plus direct
+// extra permissions. A grant with neither still matters — it makes the app
+// visible to the member (read access).
+type AppGrant struct {
+	AppID string
+	// RoleID/RoleName/RolePermissions are nil/empty when the grant carries no
+	// role, only direct permissions.
+	RoleID           *string
+	RoleName         *string
+	RolePermissions  []Permission
+	ExtraPermissions []Permission
+}
+
+// Effective is the union of the role's permissions and the direct ones,
+// deduplicated, in catalog order so every surface lists them identically.
+func (g AppGrant) Effective() []Permission {
+	granted := make(map[Permission]struct{}, len(g.RolePermissions)+len(g.ExtraPermissions))
+	for _, p := range g.RolePermissions {
+		granted[p] = struct{}{}
+	}
+	for _, p := range g.ExtraPermissions {
+		granted[p] = struct{}{}
+	}
+	effective := make([]Permission, 0, len(granted))
+	for _, p := range AllPermissions { // Not interating over the map so the order is catalog order, not random.
+		if _, ok := granted[p]; ok {
+			effective = append(effective, p)
+		}
+	}
+	return effective
+}
+
+// Has reports whether the grant carries the permission, through its role or
+// directly.
+func (g AppGrant) Has(perm Permission) bool {
+	return slices.Contains(g.RolePermissions, perm) || slices.Contains(g.ExtraPermissions, perm)
+}
+
+// GrantInput is the write shape of one grant, as the admin edits it.
+type GrantInput struct {
+	AppID            string
+	RoleID           *string
+	ExtraPermissions []Permission
+}
+
+// RBACRepository persists roles and grants. GetUserAppGrant and
+// ListAccessibleAppIDs are the enforcement reads on the dashboard request
+// path; a nil grant means the member has no access to the app at all.
+type RBACRepository interface {
+	ListRoles(ctx context.Context) ([]Role, error)
+	GetRoleByID(ctx context.Context, id string) (Role, error)
+	InsertRole(ctx context.Context, role Role) (Role, error)
+	UpdateRole(ctx context.Context, id string, name string, permissions []Permission) error
+	DeleteRole(ctx context.Context, id string) error
+	ListUserGrants(ctx context.Context, userID string) ([]AppGrant, error)
+	GetUserAppGrant(ctx context.Context, userID string, appID string) (*AppGrant, error)
+	ReplaceUserGrants(ctx context.Context, userID string, grants []GrantInput) error
+	ListAccessibleAppIDs(ctx context.Context, userID string) ([]string, error)
+}
+
+var (
+	ErrRequiresControlPlane = errors.New("user roles are managed in the database: this deployment runs in stateless mode, which is community edition only")
+	ErrRequiresValidLicense = errors.New("user roles require an active enterprise license")
+	ErrRoleNotFound         = errors.New("role not found")
+	// ErrRoleInUse mirrors the ON DELETE RESTRICT on user_app_grants.role_id.
+	ErrRoleInUse = errors.New("this role is still assigned to at least one user: unassign it everywhere first")
+	// ErrNoAppAccess is the member-without-a-grant outcome. Its message reads
+	// like the app resolver's 404 on purpose: an app the member has no grant
+	// on must not even appear to exist.
+	ErrNoAppAccess = errors.New("app not found")
+)
+
+// ErrPermissionDenied names the permission a granted member is missing, so
+// the 403 tells them what to ask their admin for.
+type ErrPermissionDenied struct {
+	Permission Permission
+}
+
+func (e *ErrPermissionDenied) Error() string {
+	return fmt.Sprintf("this action requires the %q permission on this app", string(e.Permission))
+}
+
+// ValidationError marks admin input the service refused (bad role name,
+// unknown permission string, duplicate app in a grants payload).
+type ValidationError struct {
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	return e.Message
+}
+
+// RBACService owns the management and the enforcement of user roles and
+// per-app grants. Mutations are license-gated (no valid license, no changes);
+// reads are not, so the dashboard can always show what exists. Enforcement is
+// only consulted while Enabled() is true — without a license the community
+// rules apply unchanged (members are read-only, every app visible).
+type RBACService struct {
+	repo RBACRepository
+	// licenseValid is the live licensing state; a field so same-package tests
+	// can pin it without minting signed keys.
+	licenseValid func() bool
+}
+
+// NewRBACService accepts a nil repository (stateless mode); every method then
+// answers ErrRequiresControlPlane and Enabled() stays false.
+func NewRBACService(repo RBACRepository) *RBACService {
+	return &RBACService{repo: repo, licenseValid: licensing.IsEnterprise}
+}
+
+// Enabled reports whether fine-grained roles are being enforced right now.
+// When false, callers fall back to the community model: is_admin decides
+// everything, grants stay dormant in the database.
+func (s *RBACService) Enabled() bool {
+	return s.repo != nil && s.licenseValid()
+}
+
+func (s *RBACService) requireWritable() error {
+	if s.repo == nil {
+		return ErrRequiresControlPlane
+	}
+	if !s.licenseValid() {
+		return ErrRequiresValidLicense
+	}
+	return nil
+}
+
+func validatePermissions(perms []Permission) error {
+	for _, p := range perms {
+		if !IsValidPermission(string(p)) {
+			return &ValidationError{Message: fmt.Sprintf("unknown permission %q", string(p))}
+		}
+	}
+	return nil
+}
+
+func normalizeRoleName(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", &ValidationError{Message: "role name cannot be empty"}
+	}
+	if len(name) > 255 {
+		return "", &ValidationError{Message: "role name cannot exceed 255 characters"}
+	}
+	return name, nil
+}
+
+func (s *RBACService) ListRoles(ctx context.Context) ([]Role, error) {
+	if s.repo == nil {
+		return nil, ErrRequiresControlPlane
+	}
+	return s.repo.ListRoles(ctx)
+}
+
+func (s *RBACService) CreateRole(ctx context.Context, name string, permissions []Permission) (Role, error) {
+	if err := s.requireWritable(); err != nil {
+		return Role{}, err
+	}
+	name, err := normalizeRoleName(name)
+	if err != nil {
+		return Role{}, err
+	}
+	if err := validatePermissions(permissions); err != nil {
+		return Role{}, err
+	}
+	return s.repo.InsertRole(ctx, Role{
+		ID:          uuid.NewString(),
+		Name:        name,
+		Permissions: permissions,
+	})
+}
+
+func (s *RBACService) UpdateRole(ctx context.Context, id string, name string, permissions []Permission) error {
+	if err := s.requireWritable(); err != nil {
+		return err
+	}
+	name, err := normalizeRoleName(name)
+	if err != nil {
+		return err
+	}
+	if err := validatePermissions(permissions); err != nil {
+		return err
+	}
+	return s.repo.UpdateRole(ctx, id, name, permissions)
+}
+
+func (s *RBACService) DeleteRole(ctx context.Context, id string) error {
+	if err := s.requireWritable(); err != nil {
+		return err
+	}
+	return s.repo.DeleteRole(ctx, id)
+}
+
+func (s *RBACService) GetUserGrants(ctx context.Context, userID string) ([]AppGrant, error) {
+	if s.repo == nil {
+		return nil, ErrRequiresControlPlane
+	}
+	return s.repo.ListUserGrants(ctx, userID)
+}
+
+// SetUserGrants replaces every grant of one member in a single transaction.
+func (s *RBACService) SetUserGrants(ctx context.Context, userID string, grants []GrantInput) error {
+	if err := s.requireWritable(); err != nil {
+		return err
+	}
+	seenApps := make(map[string]struct{}, len(grants))
+	for _, grant := range grants {
+		if _, dup := seenApps[grant.AppID]; dup {
+			return &ValidationError{Message: fmt.Sprintf("app %q appears twice in the grants", grant.AppID)}
+		}
+		seenApps[grant.AppID] = struct{}{}
+		if err := validatePermissions(grant.ExtraPermissions); err != nil {
+			return err
+		}
+	}
+	return s.repo.ReplaceUserGrants(ctx, userID, grants)
+}
+
+// AuthorizeMember decides one member mutation on one app. Admins never reach
+// it — the middleware bypasses them first. The distinction between its two
+// refusals is deliberate: no grant at all reads as a 404 (the app does not
+// exist for this member), a missing permission on a granted app reads as a
+// 403 naming the permission.
+func (s *RBACService) AuthorizeMember(ctx context.Context, userID string, appID string, perm Permission) error {
+	if s.repo == nil {
+		return ErrRequiresControlPlane
+	}
+	if !s.licenseValid() {
+		return ErrRequiresValidLicense
+	}
+	grant, err := s.repo.GetUserAppGrant(ctx, userID, appID)
+	if err != nil {
+		return err
+	}
+	if grant == nil {
+		return ErrNoAppAccess
+	}
+	if !grant.Has(perm) {
+		return &ErrPermissionDenied{Permission: perm}
+	}
+	return nil
+}
+
+// MemberCanSeeApp is the read-path sibling of AuthorizeMember: any grant on
+// the app, whatever its permissions, makes the app visible.
+func (s *RBACService) MemberCanSeeApp(ctx context.Context, userID string, appID string) (bool, error) {
+	if !s.Enabled() {
+		return true, nil
+	}
+	grant, err := s.repo.GetUserAppGrant(ctx, userID, appID)
+	if err != nil {
+		return false, err
+	}
+	return grant != nil, nil
+}
+
+// MemberVisibleApps returns the member's app scope for list filtering.
+// restricted=false means the community fallback is active and every app is
+// visible; when true, only the returned ids (possibly none) are.
+func (s *RBACService) MemberVisibleApps(ctx context.Context, userID string) (restricted bool, appIDs []string, err error) {
+	if !s.Enabled() {
+		return false, nil, nil
+	}
+	ids, err := s.repo.ListAccessibleAppIDs(ctx, userID)
+	if err != nil {
+		return true, nil, err
+	}
+	return true, ids, nil
+}
+
+// EffectivePermissionsByApp is the dashboard's permission map: for each
+// granted app, the member's effective permissions. Served to the UI so it can
+// hide what the server would refuse anyway.
+func (s *RBACService) EffectivePermissionsByApp(ctx context.Context, userID string) (map[string][]Permission, error) {
+	if s.repo == nil {
+		return nil, ErrRequiresControlPlane
+	}
+	grants, err := s.repo.ListUserGrants(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	byApp := make(map[string][]Permission, len(grants))
+	for _, grant := range grants {
+		byApp[grant.AppID] = grant.Effective()
+	}
+	return byApp, nil
+}

--- a/ee/rbac/service.go
+++ b/ee/rbac/service.go
@@ -97,6 +97,7 @@ type RBACRepository interface {
 	GetUserAppGrant(ctx context.Context, userID string, appID string) (*AppGrant, error)
 	ReplaceUserGrants(ctx context.Context, userID string, grants []GrantInput) error
 	ListAccessibleAppIDs(ctx context.Context, userID string) ([]string, error)
+	GrantCountsByUser(ctx context.Context) (map[string]int64, error)
 }
 
 var (
@@ -241,6 +242,15 @@ func (s *RBACService) GetUserGrants(ctx context.Context, userID string) ([]AppGr
 		return nil, ErrRequiresControlPlane
 	}
 	return s.repo.ListUserGrants(ctx, userID)
+}
+
+// GrantCountsByUser backs the Users page warning: a member with zero grants
+// sees an empty dashboard, and an admin should notice that at a glance.
+func (s *RBACService) GrantCountsByUser(ctx context.Context) (map[string]int64, error) {
+	if s.repo == nil {
+		return nil, ErrRequiresControlPlane
+	}
+	return s.repo.GrantCountsByUser(ctx)
 }
 
 // SetUserGrants replaces every grant of one member in a single transaction.

--- a/ee/rbac/service.go
+++ b/ee/rbac/service.go
@@ -71,6 +71,17 @@ type GrantInput struct {
 	ExtraPermissions []Permission
 }
 
+// Subject is the authenticated account an authorization decision is made for.
+// IsAdmin must come from a fresh users-table read (the middleware does one on
+// every guarded request, exactly like the community admin gate), never from
+// the JWT claim alone: a revoked admin loses everything immediately, not at
+// token expiry. Every entry point below handles the admin bypass itself so no
+// call site can forget it.
+type Subject struct {
+	UserID  string
+	IsAdmin bool
+}
+
 // RBACRepository persists roles and grants. GetUserAppGrant and
 // ListAccessibleAppIDs are the enforcement reads on the dashboard request
 // path; a nil grant means the member has no access to the app at all.
@@ -244,19 +255,22 @@ func (s *RBACService) SetUserGrants(ctx context.Context, userID string, grants [
 	return s.repo.ReplaceUserGrants(ctx, userID, grants)
 }
 
-// AuthorizeMember decides one member mutation on one app. Admins never reach
-// it — the middleware bypasses them first. The distinction between its two
-// refusals is deliberate: no grant at all reads as a 404 (the app does not
-// exist for this member), a missing permission on a granted app reads as a
-// 403 naming the permission.
-func (s *RBACService) AuthorizeMember(ctx context.Context, userID string, appID string, perm Permission) error {
+// Authorize decides one dashboard mutation on one app. Admins are allowed
+// unconditionally. For members, the distinction between the two refusals is
+// deliberate: no grant at all reads as a 404 (the app does not exist for this
+// member), a missing permission on a granted app reads as a 403 naming the
+// permission.
+func (s *RBACService) Authorize(ctx context.Context, subject Subject, appID string, perm Permission) error {
+	if subject.IsAdmin {
+		return nil
+	}
 	if s.repo == nil {
 		return ErrRequiresControlPlane
 	}
 	if !s.licenseValid() {
 		return ErrRequiresValidLicense
 	}
-	grant, err := s.repo.GetUserAppGrant(ctx, userID, appID)
+	grant, err := s.repo.GetUserAppGrant(ctx, subject.UserID, appID)
 	if err != nil {
 		return err
 	}
@@ -269,27 +283,28 @@ func (s *RBACService) AuthorizeMember(ctx context.Context, userID string, appID 
 	return nil
 }
 
-// MemberCanSeeApp is the read-path sibling of AuthorizeMember: any grant on
-// the app, whatever its permissions, makes the app visible.
-func (s *RBACService) MemberCanSeeApp(ctx context.Context, userID string, appID string) (bool, error) {
-	if !s.Enabled() {
+// CanSeeApp is the read-path sibling of Authorize: any grant on the app,
+// whatever its permissions, makes the app visible to a member. Admins see
+// everything.
+func (s *RBACService) CanSeeApp(ctx context.Context, subject Subject, appID string) (bool, error) {
+	if subject.IsAdmin || !s.Enabled() {
 		return true, nil
 	}
-	grant, err := s.repo.GetUserAppGrant(ctx, userID, appID)
+	grant, err := s.repo.GetUserAppGrant(ctx, subject.UserID, appID)
 	if err != nil {
 		return false, err
 	}
 	return grant != nil, nil
 }
 
-// MemberVisibleApps returns the member's app scope for list filtering.
-// restricted=false means the community fallback is active and every app is
-// visible; when true, only the returned ids (possibly none) are.
-func (s *RBACService) MemberVisibleApps(ctx context.Context, userID string) (restricted bool, appIDs []string, err error) {
-	if !s.Enabled() {
+// VisibleApps returns the subject's app scope for list filtering.
+// restricted=false means every app is visible (admin, or community fallback);
+// when true, only the returned ids (possibly none) are.
+func (s *RBACService) VisibleApps(ctx context.Context, subject Subject) (restricted bool, appIDs []string, err error) {
+	if subject.IsAdmin || !s.Enabled() {
 		return false, nil, nil
 	}
-	ids, err := s.repo.ListAccessibleAppIDs(ctx, userID)
+	ids, err := s.repo.ListAccessibleAppIDs(ctx, subject.UserID)
 	if err != nil {
 		return true, nil, err
 	}

--- a/ee/rbac/service.go
+++ b/ee/rbac/service.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"errors"
 	"expo-open-ota/ee/licensing"
+	"expo-open-ota/internal/services"
+	"expo-open-ota/internal/store"
 	"fmt"
 	"slices"
 	"strings"
@@ -136,6 +138,10 @@ func (e *ValidationError) Error() string {
 // rules apply unchanged (members are read-only, every app visible).
 type RBACService struct {
 	repo RBACRepository
+	// userLookup resolves the fresh admin flag behind every authorization
+	// decision and the target of the grants endpoints. Nil in stateless mode,
+	// where the session claim is authoritative.
+	userLookup UserLookup
 	// licenseValid is the live licensing state; a field so same-package tests
 	// can pin it without minting signed keys.
 	licenseValid func() bool
@@ -143,8 +149,8 @@ type RBACService struct {
 
 // NewRBACService accepts a nil repository (stateless mode); every method then
 // answers ErrRequiresControlPlane and Enabled() stays false.
-func NewRBACService(repo RBACRepository) *RBACService {
-	return &RBACService{repo: repo, licenseValid: licensing.IsEnterprise}
+func NewRBACService(repo RBACRepository, userLookup UserLookup) *RBACService {
+	return &RBACService{repo: repo, userLookup: userLookup, licenseValid: licensing.IsEnterprise}
 }
 
 // Enabled reports whether fine-grained roles are being enforced right now.
@@ -309,6 +315,39 @@ func (s *RBACService) VisibleApps(ctx context.Context, subject Subject) (restric
 		return true, nil, err
 	}
 	return true, ids, nil
+}
+
+// VisibleAppsForPrincipal adapts VisibleApps for the community read handlers
+// (app list, settings), which know the request principal but not the rbac
+// Subject. It resolves the fresh admin flag itself and answers
+// restricted=false whenever nothing must be filtered (admin, CLI, community
+// fallback). A principal whose account no longer exists gets an empty scope
+// rather than an error: a dead session should see nothing, not break the
+// endpoint.
+func (s *RBACService) VisibleAppsForPrincipal(ctx context.Context, principal *services.DashboardPrincipal) (restricted bool, visible map[string]bool, err error) {
+	if principal == nil || !s.Enabled() {
+		return false, nil, nil
+	}
+	subject := Subject{UserID: principal.UserId, IsAdmin: principal.IsAdmin}
+	if s.userLookup != nil {
+		user, err := s.userLookup.GetUserByID(ctx, principal.UserId)
+		if err != nil {
+			if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
+				return true, map[string]bool{}, nil
+			}
+			return false, nil, err
+		}
+		subject.IsAdmin = user.IsAdmin
+	}
+	restricted, ids, err := s.VisibleApps(ctx, subject)
+	if err != nil || !restricted {
+		return restricted, nil, err
+	}
+	visible = make(map[string]bool, len(ids))
+	for _, id := range ids {
+		visible[id] = true
+	}
+	return true, visible, nil
 }
 
 // EffectivePermissionsByApp is the dashboard's permission map: for each

--- a/ee/rbac/service_test.go
+++ b/ee/rbac/service_test.go
@@ -184,7 +184,7 @@ func TestSetUserGrantsValidatesInput(t *testing.T) {
 	require.Equal(t, grants, repo.replaced["user-1"])
 }
 
-func TestAuthorizeMember(t *testing.T) {
+func TestAuthorize(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeRepo()
 	roleID := "role-1"
@@ -195,28 +195,46 @@ func TestAuthorizeMember(t *testing.T) {
 		ExtraPermissions: []Permission{PermBranchCreate},
 	}}
 	service := licensedService(repo)
+	member := Subject{UserID: "user-1"}
 
 	// Through the role and through the direct grant.
-	require.NoError(t, service.AuthorizeMember(ctx, "user-1", "app-1", PermChannelRolloutManage))
-	require.NoError(t, service.AuthorizeMember(ctx, "user-1", "app-1", PermBranchCreate))
+	require.NoError(t, service.Authorize(ctx, member, "app-1", PermChannelRolloutManage))
+	require.NoError(t, service.Authorize(ctx, member, "app-1", PermBranchCreate))
 
 	// Granted app, missing permission: a 403 naming the permission.
-	err := service.AuthorizeMember(ctx, "user-1", "app-1", PermAppDelete)
+	err := service.Authorize(ctx, member, "app-1", PermAppDelete)
 	deniedErr := (*ErrPermissionDenied)(nil)
 	require.True(t, errors.As(err, &deniedErr), "expected ErrPermissionDenied, got %v", err)
 	require.Equal(t, PermAppDelete, deniedErr.Permission)
 
 	// No grant on the app: it does not exist for this member.
-	require.ErrorIs(t, service.AuthorizeMember(ctx, "user-1", "app-2", PermBranchCreate), ErrNoAppAccess)
-	require.ErrorIs(t, service.AuthorizeMember(ctx, "user-2", "app-1", PermBranchCreate), ErrNoAppAccess)
+	require.ErrorIs(t, service.Authorize(ctx, member, "app-2", PermBranchCreate), ErrNoAppAccess)
+	require.ErrorIs(t, service.Authorize(ctx, Subject{UserID: "user-2"}, "app-1", PermBranchCreate), ErrNoAppAccess)
 }
 
-func TestAuthorizeMemberFallsBackWithoutLicense(t *testing.T) {
+func TestAuthorizeAdminBypassesEverything(t *testing.T) {
+	ctx := context.Background()
+	admin := Subject{UserID: "admin-1", IsAdmin: true}
+
+	// No grant row, no license, not even a control plane: an admin is always
+	// allowed and always sees everything.
+	for _, service := range []*RBACService{licensedService(newFakeRepo()), unlicensedService(newFakeRepo()), unlicensedService(nil)} {
+		require.NoError(t, service.Authorize(ctx, admin, "any-app", PermAppDelete))
+		visible, err := service.CanSeeApp(ctx, admin, "any-app")
+		require.NoError(t, err)
+		require.True(t, visible)
+		restricted, _, err := service.VisibleApps(ctx, admin)
+		require.NoError(t, err)
+		require.False(t, restricted)
+	}
+}
+
+func TestAuthorizeFallsBackWithoutLicense(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeRepo()
 	repo.grants["user-1"] = []AppGrant{{AppID: "app-1", ExtraPermissions: []Permission{PermAppDelete}}}
 
-	err := unlicensedService(repo).AuthorizeMember(ctx, "user-1", "app-1", PermAppDelete)
+	err := unlicensedService(repo).Authorize(ctx, Subject{UserID: "user-1"}, "app-1", PermAppDelete)
 	require.ErrorIs(t, err, ErrRequiresValidLicense,
 		"an expired license must never widen member access beyond community rules")
 }
@@ -225,31 +243,33 @@ func TestMemberVisibility(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeRepo()
 	repo.grants["user-1"] = []AppGrant{{AppID: "app-1"}, {AppID: "app-2"}}
+	member := Subject{UserID: "user-1"}
+	strangerMember := Subject{UserID: "user-2"}
 
 	// Community fallback: nothing is restricted.
-	restricted, _, err := unlicensedService(repo).MemberVisibleApps(ctx, "user-1")
+	restricted, _, err := unlicensedService(repo).VisibleApps(ctx, member)
 	require.NoError(t, err)
 	require.False(t, restricted)
-	visible, err := unlicensedService(repo).MemberCanSeeApp(ctx, "user-1", "app-3")
+	visible, err := unlicensedService(repo).CanSeeApp(ctx, member, "app-3")
 	require.NoError(t, err)
 	require.True(t, visible)
 
 	// Enforced: only granted apps, and a grant-less member sees nothing.
 	service := licensedService(repo)
-	restricted, ids, err := service.MemberVisibleApps(ctx, "user-1")
+	restricted, ids, err := service.VisibleApps(ctx, member)
 	require.NoError(t, err)
 	require.True(t, restricted)
 	require.ElementsMatch(t, []string{"app-1", "app-2"}, ids)
 
-	restricted, ids, err = service.MemberVisibleApps(ctx, "user-2")
+	restricted, ids, err = service.VisibleApps(ctx, strangerMember)
 	require.NoError(t, err)
 	require.True(t, restricted)
 	require.Empty(t, ids)
 
-	visible, err = service.MemberCanSeeApp(ctx, "user-1", "app-2")
+	visible, err = service.CanSeeApp(ctx, member, "app-2")
 	require.NoError(t, err)
 	require.True(t, visible)
-	visible, err = service.MemberCanSeeApp(ctx, "user-1", "app-3")
+	visible, err = service.CanSeeApp(ctx, member, "app-3")
 	require.NoError(t, err)
 	require.False(t, visible)
 }

--- a/ee/rbac/service_test.go
+++ b/ee/rbac/service_test.go
@@ -9,6 +9,9 @@ import (
 	"errors"
 	"testing"
 
+	"expo-open-ota/internal/services"
+	"expo-open-ota/internal/store"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -96,14 +99,19 @@ func (f *fakeRepo) ListAccessibleAppIDs(_ context.Context, userID string) ([]str
 }
 
 func licensedService(repo RBACRepository) *RBACService {
-	service := NewRBACService(repo)
+	service := NewRBACService(repo, nil)
 	service.licenseValid = func() bool { return true }
 	return service
 }
 
 func unlicensedService(repo RBACRepository) *RBACService {
-	service := NewRBACService(repo)
+	service := NewRBACService(repo, nil)
 	service.licenseValid = func() bool { return false }
+	return service
+}
+
+func withLookup(service *RBACService, lookup UserLookup) *RBACService {
+	service.userLookup = lookup
 	return service
 }
 
@@ -272,6 +280,43 @@ func TestMemberVisibility(t *testing.T) {
 	visible, err = service.CanSeeApp(ctx, member, "app-3")
 	require.NoError(t, err)
 	require.False(t, visible)
+}
+
+func TestVisibleAppsForPrincipal(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepo()
+	repo.grants["member-1"] = []AppGrant{{AppID: "app-1"}}
+	lookup := &fakeUserLookup{users: map[string]store.User{
+		"member-1": {Id: "member-1"},
+		"admin-1":  {Id: "admin-1", IsAdmin: true},
+	}}
+	service := withLookup(licensedService(repo), lookup)
+
+	// No principal (CLI) and community fallback: unrestricted.
+	restricted, _, err := service.VisibleAppsForPrincipal(ctx, nil)
+	require.NoError(t, err)
+	require.False(t, restricted)
+	restricted, _, err = withLookup(unlicensedService(repo), lookup).VisibleAppsForPrincipal(ctx, &services.DashboardPrincipal{UserId: "member-1"})
+	require.NoError(t, err)
+	require.False(t, restricted)
+
+	// A member sees their granted set; the admin flag is read fresh, so a
+	// stale admin claim does not widen anything.
+	restricted, visible, err := service.VisibleAppsForPrincipal(ctx, &services.DashboardPrincipal{UserId: "member-1", IsAdmin: true})
+	require.NoError(t, err)
+	require.True(t, restricted)
+	require.Equal(t, map[string]bool{"app-1": true}, visible)
+
+	// A real admin is unrestricted.
+	restricted, _, err = service.VisibleAppsForPrincipal(ctx, &services.DashboardPrincipal{UserId: "admin-1"})
+	require.NoError(t, err)
+	require.False(t, restricted)
+
+	// A deleted account's leftover session sees an empty world, not an error.
+	restricted, visible, err = service.VisibleAppsForPrincipal(ctx, &services.DashboardPrincipal{UserId: "ghost"})
+	require.NoError(t, err)
+	require.True(t, restricted)
+	require.Empty(t, visible)
 }
 
 func TestEffectivePermissionsDeduplicateInCatalogOrder(t *testing.T) {

--- a/ee/rbac/service_test.go
+++ b/ee/rbac/service_test.go
@@ -1,0 +1,275 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package rbac
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRepo struct {
+	roles map[string]Role
+	// grants is keyed by userID; the slice order mirrors what the store
+	// would return.
+	grants map[string][]AppGrant
+	// replaced records the last ReplaceUserGrants call for assertions.
+	replaced map[string][]GrantInput
+}
+
+func newFakeRepo() *fakeRepo {
+	return &fakeRepo{
+		roles:    map[string]Role{},
+		grants:   map[string][]AppGrant{},
+		replaced: map[string][]GrantInput{},
+	}
+}
+
+func (f *fakeRepo) ListRoles(_ context.Context) ([]Role, error) {
+	roles := make([]Role, 0, len(f.roles))
+	for _, role := range f.roles {
+		roles = append(roles, role)
+	}
+	return roles, nil
+}
+
+func (f *fakeRepo) GetRoleByID(_ context.Context, id string) (Role, error) {
+	role, ok := f.roles[id]
+	if !ok {
+		return Role{}, ErrRoleNotFound
+	}
+	return role, nil
+}
+
+func (f *fakeRepo) InsertRole(_ context.Context, role Role) (Role, error) {
+	f.roles[role.ID] = role
+	return role, nil
+}
+
+func (f *fakeRepo) UpdateRole(_ context.Context, id string, name string, permissions []Permission) error {
+	role, ok := f.roles[id]
+	if !ok {
+		return ErrRoleNotFound
+	}
+	role.Name = name
+	role.Permissions = permissions
+	f.roles[id] = role
+	return nil
+}
+
+func (f *fakeRepo) DeleteRole(_ context.Context, id string) error {
+	if _, ok := f.roles[id]; !ok {
+		return ErrRoleNotFound
+	}
+	delete(f.roles, id)
+	return nil
+}
+
+func (f *fakeRepo) ListUserGrants(_ context.Context, userID string) ([]AppGrant, error) {
+	return f.grants[userID], nil
+}
+
+func (f *fakeRepo) GetUserAppGrant(_ context.Context, userID string, appID string) (*AppGrant, error) {
+	for _, grant := range f.grants[userID] {
+		if grant.AppID == appID {
+			return &grant, nil
+		}
+	}
+	return nil, nil
+}
+
+func (f *fakeRepo) ReplaceUserGrants(_ context.Context, userID string, grants []GrantInput) error {
+	f.replaced[userID] = grants
+	return nil
+}
+
+func (f *fakeRepo) ListAccessibleAppIDs(_ context.Context, userID string) ([]string, error) {
+	ids := make([]string, 0, len(f.grants[userID]))
+	for _, grant := range f.grants[userID] {
+		ids = append(ids, grant.AppID)
+	}
+	return ids, nil
+}
+
+func licensedService(repo RBACRepository) *RBACService {
+	service := NewRBACService(repo)
+	service.licenseValid = func() bool { return true }
+	return service
+}
+
+func unlicensedService(repo RBACRepository) *RBACService {
+	service := NewRBACService(repo)
+	service.licenseValid = func() bool { return false }
+	return service
+}
+
+func TestEnabledRequiresRepoAndLicense(t *testing.T) {
+	require.False(t, licensedService(nil).Enabled(), "stateless mode can never enforce roles")
+	require.False(t, unlicensedService(newFakeRepo()).Enabled(), "no license, community rules")
+	require.True(t, licensedService(newFakeRepo()).Enabled())
+}
+
+func TestManagementRequiresControlPlane(t *testing.T) {
+	ctx := context.Background()
+	service := licensedService(nil)
+
+	_, err := service.ListRoles(ctx)
+	require.ErrorIs(t, err, ErrRequiresControlPlane)
+	_, err = service.CreateRole(ctx, "Release manager", []Permission{PermChannelRolloutManage})
+	require.ErrorIs(t, err, ErrRequiresControlPlane)
+	_, err = service.GetUserGrants(ctx, "user-1")
+	require.ErrorIs(t, err, ErrRequiresControlPlane)
+	require.ErrorIs(t, service.SetUserGrants(ctx, "user-1", nil), ErrRequiresControlPlane)
+}
+
+func TestWritesRequireLicenseButReadsStayOpen(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepo()
+	repo.roles["role-1"] = Role{ID: "role-1", Name: "Release manager"}
+	service := unlicensedService(repo)
+
+	_, err := service.CreateRole(ctx, "Ops", []Permission{PermBranchProtect})
+	require.ErrorIs(t, err, ErrRequiresValidLicense)
+	require.ErrorIs(t, service.UpdateRole(ctx, "role-1", "Ops", nil), ErrRequiresValidLicense)
+	require.ErrorIs(t, service.DeleteRole(ctx, "role-1"), ErrRequiresValidLicense)
+	require.ErrorIs(t, service.SetUserGrants(ctx, "user-1", nil), ErrRequiresValidLicense)
+
+	// Reads keep working so the dashboard can show what exists (dormant).
+	roles, err := service.ListRoles(ctx)
+	require.NoError(t, err)
+	require.Len(t, roles, 1)
+	_, err = service.GetUserGrants(ctx, "user-1")
+	require.NoError(t, err)
+}
+
+func TestCreateRoleValidatesInput(t *testing.T) {
+	ctx := context.Background()
+	service := licensedService(newFakeRepo())
+
+	validationErr := (*ValidationError)(nil)
+	_, err := service.CreateRole(ctx, "   ", []Permission{PermAppDelete})
+	require.True(t, errors.As(err, &validationErr), "empty name must be refused, got %v", err)
+	_, err = service.CreateRole(ctx, "Ops", []Permission{"branch:invalid"})
+	require.True(t, errors.As(err, &validationErr), "unknown permission must be refused, got %v", err)
+
+	role, err := service.CreateRole(ctx, "  Release manager  ", []Permission{PermChannelRolloutManage})
+	require.NoError(t, err)
+	require.Equal(t, "Release manager", role.Name, "name must be trimmed")
+	require.NotEmpty(t, role.ID)
+}
+
+func TestSetUserGrantsValidatesInput(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepo()
+	service := licensedService(repo)
+
+	validationErr := (*ValidationError)(nil)
+	err := service.SetUserGrants(ctx, "user-1", []GrantInput{
+		{AppID: "app-1"},
+		{AppID: "app-1"},
+	})
+	require.True(t, errors.As(err, &validationErr), "duplicate app must be refused, got %v", err)
+
+	err = service.SetUserGrants(ctx, "user-1", []GrantInput{
+		{AppID: "app-1", ExtraPermissions: []Permission{"nope"}},
+	})
+	require.True(t, errors.As(err, &validationErr), "unknown permission must be refused, got %v", err)
+
+	grants := []GrantInput{{AppID: "app-1", ExtraPermissions: []Permission{PermBranchCreate}}}
+	require.NoError(t, service.SetUserGrants(ctx, "user-1", grants))
+	require.Equal(t, grants, repo.replaced["user-1"])
+}
+
+func TestAuthorizeMember(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepo()
+	roleID := "role-1"
+	repo.grants["user-1"] = []AppGrant{{
+		AppID:            "app-1",
+		RoleID:           &roleID,
+		RolePermissions:  []Permission{PermChannelRolloutManage},
+		ExtraPermissions: []Permission{PermBranchCreate},
+	}}
+	service := licensedService(repo)
+
+	// Through the role and through the direct grant.
+	require.NoError(t, service.AuthorizeMember(ctx, "user-1", "app-1", PermChannelRolloutManage))
+	require.NoError(t, service.AuthorizeMember(ctx, "user-1", "app-1", PermBranchCreate))
+
+	// Granted app, missing permission: a 403 naming the permission.
+	err := service.AuthorizeMember(ctx, "user-1", "app-1", PermAppDelete)
+	deniedErr := (*ErrPermissionDenied)(nil)
+	require.True(t, errors.As(err, &deniedErr), "expected ErrPermissionDenied, got %v", err)
+	require.Equal(t, PermAppDelete, deniedErr.Permission)
+
+	// No grant on the app: it does not exist for this member.
+	require.ErrorIs(t, service.AuthorizeMember(ctx, "user-1", "app-2", PermBranchCreate), ErrNoAppAccess)
+	require.ErrorIs(t, service.AuthorizeMember(ctx, "user-2", "app-1", PermBranchCreate), ErrNoAppAccess)
+}
+
+func TestAuthorizeMemberFallsBackWithoutLicense(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepo()
+	repo.grants["user-1"] = []AppGrant{{AppID: "app-1", ExtraPermissions: []Permission{PermAppDelete}}}
+
+	err := unlicensedService(repo).AuthorizeMember(ctx, "user-1", "app-1", PermAppDelete)
+	require.ErrorIs(t, err, ErrRequiresValidLicense,
+		"an expired license must never widen member access beyond community rules")
+}
+
+func TestMemberVisibility(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepo()
+	repo.grants["user-1"] = []AppGrant{{AppID: "app-1"}, {AppID: "app-2"}}
+
+	// Community fallback: nothing is restricted.
+	restricted, _, err := unlicensedService(repo).MemberVisibleApps(ctx, "user-1")
+	require.NoError(t, err)
+	require.False(t, restricted)
+	visible, err := unlicensedService(repo).MemberCanSeeApp(ctx, "user-1", "app-3")
+	require.NoError(t, err)
+	require.True(t, visible)
+
+	// Enforced: only granted apps, and a grant-less member sees nothing.
+	service := licensedService(repo)
+	restricted, ids, err := service.MemberVisibleApps(ctx, "user-1")
+	require.NoError(t, err)
+	require.True(t, restricted)
+	require.ElementsMatch(t, []string{"app-1", "app-2"}, ids)
+
+	restricted, ids, err = service.MemberVisibleApps(ctx, "user-2")
+	require.NoError(t, err)
+	require.True(t, restricted)
+	require.Empty(t, ids)
+
+	visible, err = service.MemberCanSeeApp(ctx, "user-1", "app-2")
+	require.NoError(t, err)
+	require.True(t, visible)
+	visible, err = service.MemberCanSeeApp(ctx, "user-1", "app-3")
+	require.NoError(t, err)
+	require.False(t, visible)
+}
+
+func TestEffectivePermissionsDeduplicateInCatalogOrder(t *testing.T) {
+	grant := AppGrant{
+		AppID:            "app-1",
+		RolePermissions:  []Permission{PermChannelRolloutManage, PermBranchCreate},
+		ExtraPermissions: []Permission{PermBranchCreate, PermAppDelete},
+	}
+	require.Equal(t,
+		[]Permission{PermAppDelete, PermBranchCreate, PermChannelRolloutManage},
+		grant.Effective())
+
+	ctx := context.Background()
+	repo := newFakeRepo()
+	repo.grants["user-1"] = []AppGrant{grant, {AppID: "app-2"}}
+	byApp, err := licensedService(repo).EffectivePermissionsByApp(ctx, "user-1")
+	require.NoError(t, err)
+	require.Len(t, byApp, 2)
+	require.Equal(t, []Permission{PermAppDelete, PermBranchCreate, PermChannelRolloutManage}, byApp["app-1"])
+	require.Empty(t, byApp["app-2"], "a role-less, permission-less grant still lists the app (visibility)")
+}

--- a/ee/rbac/service_test.go
+++ b/ee/rbac/service_test.go
@@ -90,6 +90,16 @@ func (f *fakeRepo) ReplaceUserGrants(_ context.Context, userID string, grants []
 	return nil
 }
 
+func (f *fakeRepo) GrantCountsByUser(_ context.Context) (map[string]int64, error) {
+	counts := map[string]int64{}
+	for userID, grants := range f.grants {
+		if len(grants) > 0 {
+			counts[userID] = int64(len(grants))
+		}
+	}
+	return counts, nil
+}
+
 func (f *fakeRepo) ListAccessibleAppIDs(_ context.Context, userID string) ([]string, error) {
 	ids := make([]string, 0, len(f.grants[userID]))
 	for _, grant := range f.grants[userID] {

--- a/ee/rbac/store_postgres.go
+++ b/ee/rbac/store_postgres.go
@@ -1,0 +1,247 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package rbac
+
+import (
+	"context"
+	"errors"
+	"expo-open-ota/internal/database"
+	"expo-open-ota/internal/database/postgres/pgdb"
+	"expo-open-ota/internal/store"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type PostgresRBACStore struct {
+	engine *database.Engine
+}
+
+func NewPostgresRBACStore(engine *database.Engine) *PostgresRBACStore {
+	return &PostgresRBACStore{engine: engine}
+}
+
+func toPermissions(values []string) []Permission {
+	perms := make([]Permission, len(values))
+	for i, v := range values {
+		perms[i] = Permission(v)
+	}
+	return perms
+}
+
+// fromPermissions also keeps a nil slice from becoming SQL NULL: the array
+// columns are NOT NULL, empty means "no permissions".
+func fromPermissions(perms []Permission) []string {
+	values := make([]string, len(perms))
+	for i, p := range perms {
+		values[i] = string(p)
+	}
+	return values
+}
+
+func roleFromRow(row pgdb.Role) Role {
+	return Role{
+		ID:          row.ID.String(),
+		Name:        row.Name,
+		Permissions: toPermissions(row.Permissions),
+		CreatedAt:   row.CreatedAt.Time,
+		UpdatedAt:   row.UpdatedAt.Time,
+	}
+}
+
+func (s *PostgresRBACStore) ListRoles(ctx context.Context) ([]Role, error) {
+	rows, err := s.engine.Queries.ListRoles(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list roles from database: %w", err)
+	}
+	roles := make([]Role, len(rows))
+	for i, row := range rows {
+		roles[i] = roleFromRow(row)
+	}
+	return roles, nil
+}
+
+func (s *PostgresRBACStore) GetRoleByID(ctx context.Context, id string) (Role, error) {
+	row, err := s.engine.Queries.GetRoleByID(ctx, store.ToPgUUID(id))
+	if err != nil {
+		if database.IsNoRows(err) {
+			return Role{}, ErrRoleNotFound
+		}
+		return Role{}, fmt.Errorf("failed to read role from database: %w", err)
+	}
+	return roleFromRow(row), nil
+}
+
+func (s *PostgresRBACStore) InsertRole(ctx context.Context, role Role) (Role, error) {
+	row, err := s.engine.Queries.InsertRole(ctx, pgdb.InsertRoleParams{
+		ID:          store.ToPgUUID(role.ID),
+		Name:        role.Name,
+		Permissions: fromPermissions(role.Permissions),
+	})
+	if err != nil {
+		if database.IsUniqueViolation(err) {
+			return Role{}, &store.ErrResourceAlreadyExists{Resource: "role", Identifier: role.Name}
+		}
+		return Role{}, fmt.Errorf("failed to insert role in database: %w", err)
+	}
+	return roleFromRow(row), nil
+}
+
+func (s *PostgresRBACStore) UpdateRole(ctx context.Context, id string, name string, permissions []Permission) error {
+	commandTag, err := s.engine.Queries.UpdateRole(ctx, pgdb.UpdateRoleParams{
+		ID:          store.ToPgUUID(id),
+		Name:        name,
+		Permissions: fromPermissions(permissions),
+	})
+	if err != nil {
+		if database.IsUniqueViolation(err) {
+			return &store.ErrResourceAlreadyExists{Resource: "role", Identifier: name}
+		}
+		return fmt.Errorf("failed to update role in database: %w", err)
+	}
+	if commandTag.RowsAffected() == 0 {
+		return ErrRoleNotFound
+	}
+	return nil
+}
+
+func (s *PostgresRBACStore) DeleteRole(ctx context.Context, id string) error {
+	commandTag, err := s.engine.Queries.DeleteRole(ctx, store.ToPgUUID(id))
+	if err != nil {
+		// The ON DELETE RESTRICT from user_app_grants.role_id.
+		if database.IsForeignKeyViolation(err) {
+			return ErrRoleInUse
+		}
+		return fmt.Errorf("failed to delete role from database: %w", err)
+	}
+	if commandTag.RowsAffected() == 0 {
+		return ErrRoleNotFound
+	}
+	return nil
+}
+
+func (s *PostgresRBACStore) ListUserGrants(ctx context.Context, userID string) ([]AppGrant, error) {
+	rows, err := s.engine.Queries.ListUserAppGrants(ctx, store.ToPgUUID(userID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list user grants from database: %w", err)
+	}
+	grants := make([]AppGrant, len(rows))
+	for i, row := range rows {
+		grant := AppGrant{
+			AppID:            row.AppID.String(),
+			RoleName:         row.RoleName,
+			RolePermissions:  toPermissions(row.RolePermissions),
+			ExtraPermissions: toPermissions(row.ExtraPermissions),
+		}
+		if row.RoleID.Valid {
+			roleID := row.RoleID.String()
+			grant.RoleID = &roleID
+		}
+		grants[i] = grant
+	}
+	return grants, nil
+}
+
+// GetUserAppGrant returns nil (no error) when the member has no grant on the
+// app. RoleName stays nil here — the enforcement path only needs the
+// permissions, ListUserGrants is the display read.
+func (s *PostgresRBACStore) GetUserAppGrant(ctx context.Context, userID string, appID string) (*AppGrant, error) {
+	row, err := s.engine.Queries.GetUserAppGrant(ctx, pgdb.GetUserAppGrantParams{
+		UserID: store.ToPgUUID(userID),
+		AppID:  store.ToPgUUID(appID),
+	})
+	if err != nil {
+		if database.IsNoRows(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read user grant from database: %w", err)
+	}
+	grant := &AppGrant{
+		AppID:            row.AppID.String(),
+		RolePermissions:  toPermissions(row.RolePermissions),
+		ExtraPermissions: toPermissions(row.ExtraPermissions),
+	}
+	if row.RoleID.Valid {
+		roleID := row.RoleID.String()
+		grant.RoleID = &roleID
+	}
+	return grant, nil
+}
+
+// ReplaceUserGrants swaps every grant of one member atomically: readers never
+// observe a half-written set, and any failure (unknown app, unknown role)
+// rolls the previous grants back untouched.
+func (s *PostgresRBACStore) ReplaceUserGrants(ctx context.Context, userID string, grants []GrantInput) error {
+	pgUserID := store.ToPgUUID(userID)
+	err := s.engine.WithTx(ctx, func(q *pgdb.Queries) error {
+		if err := q.DeleteUserAppGrantsByUser(ctx, pgUserID); err != nil {
+			return err
+		}
+		for _, grant := range grants {
+			// The zero pgtype.UUID (Valid: false) is SQL NULL — a grant
+			// without a role.
+			var roleID pgtype.UUID
+			if grant.RoleID != nil {
+				roleID = store.ToPgUUID(*grant.RoleID)
+				if !roleID.Valid {
+					return &ValidationError{Message: fmt.Sprintf("invalid role id %q", *grant.RoleID)}
+				}
+			}
+			if err := q.InsertUserAppGrant(ctx, pgdb.InsertUserAppGrantParams{
+				UserID:           pgUserID,
+				AppID:            store.ToPgUUID(grant.AppID),
+				RoleID:           roleID,
+				ExtraPermissions: fromPermissions(grant.ExtraPermissions),
+			}); err != nil {
+				return replaceGrantError(err, grant)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		validationErr := (*ValidationError)(nil)
+		if errors.As(err, &validationErr) {
+			return err
+		}
+		return fmt.Errorf("failed to replace user grants in database: %w", err)
+	}
+	return nil
+}
+
+// replaceGrantError turns the grant insert's foreign-key violations into
+// messages naming the reference that does not exist, using the constraint
+// name Postgres reports.
+func replaceGrantError(err error, grant GrantInput) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && database.IsForeignKeyViolation(err) {
+		switch {
+		case strings.Contains(pgErr.ConstraintName, "app_id"):
+			return &ValidationError{Message: fmt.Sprintf("app %q does not exist", grant.AppID)}
+		case strings.Contains(pgErr.ConstraintName, "role_id"):
+			roleID := ""
+			if grant.RoleID != nil {
+				roleID = *grant.RoleID
+			}
+			return &ValidationError{Message: fmt.Sprintf("role %q does not exist", roleID)}
+		case strings.Contains(pgErr.ConstraintName, "user_id"):
+			return &ValidationError{Message: "user does not exist"}
+		}
+	}
+	return err
+}
+
+func (s *PostgresRBACStore) ListAccessibleAppIDs(ctx context.Context, userID string) ([]string, error) {
+	rows, err := s.engine.Queries.ListAccessibleAppIDs(ctx, store.ToPgUUID(userID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list accessible apps from database: %w", err)
+	}
+	ids := make([]string, len(rows))
+	for i, row := range rows {
+		ids[i] = row.String()
+	}
+	return ids, nil
+}

--- a/ee/rbac/store_postgres.go
+++ b/ee/rbac/store_postgres.go
@@ -234,6 +234,18 @@ func replaceGrantError(err error, grant GrantInput) error {
 	return err
 }
 
+func (s *PostgresRBACStore) GrantCountsByUser(ctx context.Context) (map[string]int64, error) {
+	rows, err := s.engine.Queries.CountGrantsPerUser(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to count grants per user from database: %w", err)
+	}
+	counts := make(map[string]int64, len(rows))
+	for _, row := range rows {
+		counts[row.UserID.String()] = row.GrantCount
+	}
+	return counts, nil
+}
+
 func (s *PostgresRBACStore) ListAccessibleAppIDs(ctx context.Context, userID string) ([]string, error) {
 	rows, err := s.engine.Queries.ListAccessibleAppIDs(ctx, store.ToPgUUID(userID))
 	if err != nil {

--- a/ee/rbac/store_postgres_test.go
+++ b/ee/rbac/store_postgres_test.go
@@ -151,6 +151,12 @@ func TestReplaceUserGrantsRoundtrip(t *testing.T) {
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{appOne, appTwo}, ids)
 
+	// The summary counts this user's grants (the database is shared across
+	// tests, so only assert this user's entry).
+	counts, err := rbacStore.GrantCountsByUser(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), counts[userID])
+
 	// A role that is assigned cannot be deleted.
 	require.ErrorIs(t, rbacStore.DeleteRole(ctx, role.ID), ErrRoleInUse)
 

--- a/ee/rbac/store_postgres_test.go
+++ b/ee/rbac/store_postgres_test.go
@@ -238,6 +238,23 @@ func TestUpdateRoleRefusesNameCollision(t *testing.T) {
 	fetched, err := rbacStore.GetRoleByID(ctx, second.ID)
 	require.NoError(t, err)
 	require.Equal(t, second.Name, fetched.Name)
+
+	// The listing carries both, sorted by name (the database is shared across
+	// tests, so assert relative order rather than the full set).
+	roles, err := rbacStore.ListRoles(ctx)
+	require.NoError(t, err)
+	firstIndex, secondIndex := -1, -1
+	for i, role := range roles {
+		switch role.ID {
+		case first.ID:
+			firstIndex = i
+		case second.ID:
+			secondIndex = i
+		}
+	}
+	require.GreaterOrEqual(t, firstIndex, 0)
+	require.GreaterOrEqual(t, secondIndex, 0)
+	require.Less(t, firstIndex, secondIndex, "ListRoles must sort by name")
 }
 
 func TestGrantsFollowUserAndAppDeletion(t *testing.T) {

--- a/ee/rbac/store_postgres_test.go
+++ b/ee/rbac/store_postgres_test.go
@@ -1,0 +1,267 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+// Integration tests for the RBAC store: the transactional grant replacement,
+// the FK mappings (role in use, unknown app/role) and the cascades need a
+// real Postgres. They skip unless TEST_DATABASE_URL is set, e.g.:
+//
+//	docker run -d --name eoo-pg -e POSTGRES_PASSWORD=test -p 55432:5432 postgres:16-alpine
+//	TEST_DATABASE_URL="postgres://postgres:test@localhost:55432/postgres?sslmode=disable" go test ./ee/rbac/
+
+package rbac
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"expo-open-ota/internal/database"
+	"expo-open-ota/internal/database/postgres"
+	"expo-open-ota/internal/database/postgres/pgdb"
+	"expo-open-ota/internal/store"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+func setupRBACStore(t *testing.T) (*PostgresRBACStore, *pgxpool.Pool) {
+	t.Helper()
+	dbURL := os.Getenv("TEST_DATABASE_URL")
+	if dbURL == "" {
+		// See the same guard in the sso store tests: a skip in CI is a green
+		// job that ran none of these guarded queries.
+		if os.Getenv("CI") != "" {
+			t.Fatal("TEST_DATABASE_URL must be set in CI: these tests cover SQL that the in-memory fakes cannot reach")
+		}
+		t.Skip("TEST_DATABASE_URL not set — start a Postgres and set it to run the rbac store tests")
+	}
+	// The seed migration fails fast on an empty database without the
+	// bootstrap pair.
+	t.Setenv("ADMIN_EMAIL", "seed-admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "Sup3rSecret!")
+	postgres.RunDBMigrations(dbURL)
+
+	pool, err := pgxpool.New(context.Background(), dbURL)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	return NewPostgresRBACStore(&database.Engine{Queries: pgdb.New(pool), DB: pool}), pool
+}
+
+func insertTestUser(t *testing.T, pool *pgxpool.Pool) string {
+	t.Helper()
+	userID := uuid.NewString()
+	_, err := pool.Exec(context.Background(),
+		"INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'irrelevant')",
+		userID, userID[:8]+"@example.com")
+	require.NoError(t, err)
+	return userID
+}
+
+func insertTestApp(t *testing.T, pool *pgxpool.Pool) string {
+	t.Helper()
+	appID := uuid.NewString()
+	_, err := pool.Exec(context.Background(),
+		"INSERT INTO apps (id, name) VALUES ($1, $2)", appID, "app-"+appID[:8])
+	require.NoError(t, err)
+	return appID
+}
+
+func TestRoleCRUDRoundtrip(t *testing.T) {
+	rbacStore, _ := setupRBACStore(t)
+	ctx := context.Background()
+
+	role, err := rbacStore.InsertRole(ctx, Role{
+		ID:          uuid.NewString(),
+		Name:        "Release manager " + uuid.NewString()[:8],
+		Permissions: []Permission{PermChannelRolloutManage, PermChannelEditBranch},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []Permission{PermChannelRolloutManage, PermChannelEditBranch}, role.Permissions)
+	require.False(t, role.CreatedAt.IsZero())
+
+	// The name is UNIQUE.
+	_, err = rbacStore.InsertRole(ctx, Role{ID: uuid.NewString(), Name: role.Name})
+	alreadyExists := (*store.ErrResourceAlreadyExists)(nil)
+	require.True(t, errors.As(err, &alreadyExists), "expected ErrResourceAlreadyExists, got %v", err)
+
+	fetched, err := rbacStore.GetRoleByID(ctx, role.ID)
+	require.NoError(t, err)
+	require.Equal(t, role.Name, fetched.Name)
+
+	require.NoError(t, rbacStore.UpdateRole(ctx, role.ID, role.Name+" v2", []Permission{PermBranchProtect}))
+	fetched, err = rbacStore.GetRoleByID(ctx, role.ID)
+	require.NoError(t, err)
+	require.Equal(t, role.Name+" v2", fetched.Name)
+	require.Equal(t, []Permission{PermBranchProtect}, fetched.Permissions)
+
+	require.NoError(t, rbacStore.DeleteRole(ctx, role.ID))
+	require.ErrorIs(t, rbacStore.DeleteRole(ctx, role.ID), ErrRoleNotFound)
+	require.ErrorIs(t, rbacStore.UpdateRole(ctx, role.ID, "ghost", nil), ErrRoleNotFound)
+	_, err = rbacStore.GetRoleByID(ctx, role.ID)
+	require.ErrorIs(t, err, ErrRoleNotFound)
+}
+
+func TestReplaceUserGrantsRoundtrip(t *testing.T) {
+	rbacStore, pool := setupRBACStore(t)
+	ctx := context.Background()
+
+	userID := insertTestUser(t, pool)
+	appOne := insertTestApp(t, pool)
+	appTwo := insertTestApp(t, pool)
+	role, err := rbacStore.InsertRole(ctx, Role{
+		ID:          uuid.NewString(),
+		Name:        "Ops " + uuid.NewString()[:8],
+		Permissions: []Permission{PermBranchProtect},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, rbacStore.ReplaceUserGrants(ctx, userID, []GrantInput{
+		{AppID: appOne, RoleID: &role.ID, ExtraPermissions: []Permission{PermCertificateRead}},
+		{AppID: appTwo},
+	}))
+
+	grants, err := rbacStore.ListUserGrants(ctx, userID)
+	require.NoError(t, err)
+	require.Len(t, grants, 2)
+	byApp := map[string]AppGrant{}
+	for _, grant := range grants {
+		byApp[grant.AppID] = grant
+	}
+	granted := byApp[appOne]
+	require.NotNil(t, granted.RoleID)
+	require.Equal(t, role.ID, *granted.RoleID)
+	require.NotNil(t, granted.RoleName)
+	require.Equal(t, role.Name, *granted.RoleName)
+	require.Equal(t, []Permission{PermBranchProtect}, granted.RolePermissions)
+	require.Equal(t, []Permission{PermCertificateRead}, granted.ExtraPermissions)
+	require.Nil(t, byApp[appTwo].RoleID, "a role-less grant keeps a nil role")
+
+	// The enforcement read resolves the role's permissions too.
+	enforcement, err := rbacStore.GetUserAppGrant(ctx, userID, appOne)
+	require.NoError(t, err)
+	require.NotNil(t, enforcement)
+	require.True(t, enforcement.Has(PermBranchProtect))
+	require.True(t, enforcement.Has(PermCertificateRead))
+	require.False(t, enforcement.Has(PermAppDelete))
+
+	ids, err := rbacStore.ListAccessibleAppIDs(ctx, userID)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{appOne, appTwo}, ids)
+
+	// A role that is assigned cannot be deleted.
+	require.ErrorIs(t, rbacStore.DeleteRole(ctx, role.ID), ErrRoleInUse)
+
+	// Replacement is wholesale: the next set fully supersedes the previous one.
+	require.NoError(t, rbacStore.ReplaceUserGrants(ctx, userID, []GrantInput{{AppID: appTwo}}))
+	grants, err = rbacStore.ListUserGrants(ctx, userID)
+	require.NoError(t, err)
+	require.Len(t, grants, 1)
+	require.Equal(t, appTwo, grants[0].AppID)
+	missing, err := rbacStore.GetUserAppGrant(ctx, userID, appOne)
+	require.NoError(t, err)
+	require.Nil(t, missing, "no grant reads as nil, not an error")
+
+	// The role is unassigned now, so it can go.
+	require.NoError(t, rbacStore.DeleteRole(ctx, role.ID))
+}
+
+func TestReplaceUserGrantsRollsBackOnBadReference(t *testing.T) {
+	rbacStore, pool := setupRBACStore(t)
+	ctx := context.Background()
+
+	userID := insertTestUser(t, pool)
+	appID := insertTestApp(t, pool)
+	require.NoError(t, rbacStore.ReplaceUserGrants(ctx, userID, []GrantInput{{AppID: appID}}))
+
+	validationErr := (*ValidationError)(nil)
+
+	// Unknown app: refused and the previous grants survive the rollback.
+	err := rbacStore.ReplaceUserGrants(ctx, userID, []GrantInput{{AppID: uuid.NewString()}})
+	require.True(t, errors.As(err, &validationErr), "expected ValidationError, got %v", err)
+	grants, err := rbacStore.ListUserGrants(ctx, userID)
+	require.NoError(t, err)
+	require.Len(t, grants, 1, "failed replacement must leave the previous grants untouched")
+
+	// Unknown role.
+	ghostRole := uuid.NewString()
+	err = rbacStore.ReplaceUserGrants(ctx, userID, []GrantInput{{AppID: appID, RoleID: &ghostRole}})
+	require.True(t, errors.As(err, &validationErr), "expected ValidationError, got %v", err)
+
+	// Malformed role id.
+	badRole := "not-a-uuid"
+	err = rbacStore.ReplaceUserGrants(ctx, userID, []GrantInput{{AppID: appID, RoleID: &badRole}})
+	require.True(t, errors.As(err, &validationErr), "expected ValidationError, got %v", err)
+
+	// Grants written for a user deleted in the meantime: the user_id FK branch.
+	_, err = pool.Exec(ctx, "DELETE FROM users WHERE id = $1", userID)
+	require.NoError(t, err)
+	err = rbacStore.ReplaceUserGrants(ctx, userID, []GrantInput{{AppID: appID}})
+	require.True(t, errors.As(err, &validationErr), "expected ValidationError, got %v", err)
+}
+
+func TestReplaceUserGrantsWithEmptySetClearsEverything(t *testing.T) {
+	rbacStore, pool := setupRBACStore(t)
+	ctx := context.Background()
+
+	userID := insertTestUser(t, pool)
+	appID := insertTestApp(t, pool)
+	require.NoError(t, rbacStore.ReplaceUserGrants(ctx, userID, []GrantInput{{AppID: appID}}))
+
+	// The admin removing every access is a plain replacement by nothing.
+	require.NoError(t, rbacStore.ReplaceUserGrants(ctx, userID, nil))
+	grants, err := rbacStore.ListUserGrants(ctx, userID)
+	require.NoError(t, err)
+	require.Empty(t, grants)
+	ids, err := rbacStore.ListAccessibleAppIDs(ctx, userID)
+	require.NoError(t, err)
+	require.Empty(t, ids)
+}
+
+func TestUpdateRoleRefusesNameCollision(t *testing.T) {
+	rbacStore, _ := setupRBACStore(t)
+	ctx := context.Background()
+
+	suffix := uuid.NewString()[:8]
+	first, err := rbacStore.InsertRole(ctx, Role{ID: uuid.NewString(), Name: "First " + suffix})
+	require.NoError(t, err)
+	second, err := rbacStore.InsertRole(ctx, Role{ID: uuid.NewString(), Name: "Second " + suffix})
+	require.NoError(t, err)
+
+	err = rbacStore.UpdateRole(ctx, second.ID, first.Name, nil)
+	alreadyExists := (*store.ErrResourceAlreadyExists)(nil)
+	require.True(t, errors.As(err, &alreadyExists), "expected ErrResourceAlreadyExists, got %v", err)
+
+	// The refused rename left the role untouched.
+	fetched, err := rbacStore.GetRoleByID(ctx, second.ID)
+	require.NoError(t, err)
+	require.Equal(t, second.Name, fetched.Name)
+}
+
+func TestGrantsFollowUserAndAppDeletion(t *testing.T) {
+	rbacStore, pool := setupRBACStore(t)
+	ctx := context.Background()
+
+	userID := insertTestUser(t, pool)
+	appID := insertTestApp(t, pool)
+	require.NoError(t, rbacStore.ReplaceUserGrants(ctx, userID, []GrantInput{{AppID: appID}}))
+
+	// Deleting the app cascades its grants away.
+	_, err := pool.Exec(ctx, "DELETE FROM apps WHERE id = $1", appID)
+	require.NoError(t, err)
+	ids, err := rbacStore.ListAccessibleAppIDs(ctx, userID)
+	require.NoError(t, err)
+	require.Empty(t, ids)
+
+	// Same story for the user.
+	appID = insertTestApp(t, pool)
+	require.NoError(t, rbacStore.ReplaceUserGrants(ctx, userID, []GrantInput{{AppID: appID}}))
+	_, err = pool.Exec(ctx, "DELETE FROM users WHERE id = $1", userID)
+	require.NoError(t, err)
+	var count int64
+	require.NoError(t, pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM user_app_grants WHERE user_id = $1", userID).Scan(&count))
+	require.Zero(t, count)
+}

--- a/internal/database/postgres/migrations/20260720000000_user_roles.sql
+++ b/internal/database/postgres/migrations/20260720000000_user_roles.sql
@@ -1,0 +1,42 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Named permission bundles (Enterprise Edition, ee/rbac). A role is global:
+-- it describes what a member may do on an app; which apps it applies to is
+-- decided per user in user_app_grants. The permission strings are validated
+-- in Go against the ee/rbac catalog before every write.
+CREATE TABLE roles (
+    id UUID PRIMARY KEY,
+    name VARCHAR(255) NOT NULL UNIQUE,
+    permissions TEXT[] NOT NULL DEFAULT '{}',
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- One row = one member's access to one app. No row, no access: with an active
+-- enterprise license members only see the apps they are granted (admins bypass
+-- the whole table). Effective permissions are the union of the role's
+-- permissions and extra_permissions; either side may be empty, a row with both
+-- empty still grants read access to the app.
+CREATE TABLE user_app_grants (
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    app_id UUID NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+    -- RESTRICT: deleting a role that is still assigned must fail loudly
+    -- instead of silently stripping permissions from members.
+    role_id UUID REFERENCES roles(id) ON DELETE RESTRICT,
+    extra_permissions TEXT[] NOT NULL DEFAULT '{}',
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, app_id)
+);
+
+CREATE INDEX idx_user_app_grants_app ON user_app_grants (app_id);
+CREATE INDEX idx_user_app_grants_role ON user_app_grants (role_id);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS user_app_grants;
+DROP TABLE IF EXISTS roles;
+-- +goose StatementEnd

--- a/internal/database/postgres/pgdb/models.go
+++ b/internal/database/postgres/pgdb/models.go
@@ -69,6 +69,14 @@ type EnterpriseLicense struct {
 	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
 }
 
+type Role struct {
+	ID          pgtype.UUID        `json:"id"`
+	Name        string             `json:"name"`
+	Permissions []string           `json:"permissions"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
+}
+
 type RuntimeVersion struct {
 	ID        int64              `json:"id"`
 	AppID     pgtype.UUID        `json:"app_id"`
@@ -127,4 +135,13 @@ type User struct {
 	UpdatedAt       pgtype.Timestamptz `json:"updated_at"`
 	LastConnectedAt pgtype.Timestamptz `json:"last_connected_at"`
 	Enabled         bool               `json:"enabled"`
+}
+
+type UserAppGrant struct {
+	UserID           pgtype.UUID        `json:"user_id"`
+	AppID            pgtype.UUID        `json:"app_id"`
+	RoleID           pgtype.UUID        `json:"role_id"`
+	ExtraPermissions []string           `json:"extra_permissions"`
+	CreatedAt        pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
 }

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -41,6 +41,18 @@ func (q *Queries) ClearUpdateRollout(ctx context.Context, arg ClearUpdateRollout
 	return result.RowsAffected(), nil
 }
 
+const countGrantsByRole = `-- name: CountGrantsByRole :one
+SELECT COUNT(*) FROM user_app_grants
+WHERE role_id = $1
+`
+
+func (q *Queries) CountGrantsByRole(ctx context.Context, roleID pgtype.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countGrantsByRole, roleID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const deleteAppByID = `-- name: DeleteAppByID :execresult
 DELETE FROM apps
 WHERE id = $1
@@ -105,12 +117,35 @@ func (q *Queries) DeleteEnterpriseLicense(ctx context.Context) error {
 	return err
 }
 
+const deleteRole = `-- name: DeleteRole :execresult
+DELETE FROM roles
+WHERE id = $1
+`
+
+// The FK from user_app_grants is ON DELETE RESTRICT: deleting a role that is
+// still assigned fails with a foreign-key violation the store maps to a
+// friendly "role in use" error.
+func (q *Queries) DeleteRole(ctx context.Context, id pgtype.UUID) (pgconn.CommandTag, error) {
+	return q.db.Exec(ctx, deleteRole, id)
+}
+
 const deleteSSOConfig = `-- name: DeleteSSOConfig :exec
 DELETE FROM sso_config
 `
 
 func (q *Queries) DeleteSSOConfig(ctx context.Context) error {
 	_, err := q.db.Exec(ctx, deleteSSOConfig)
+	return err
+}
+
+const deleteUserAppGrantsByUser = `-- name: DeleteUserAppGrantsByUser :exec
+DELETE FROM user_app_grants
+WHERE user_id = $1
+`
+
+// Grants are replaced wholesale (delete + insert in one transaction).
+func (q *Queries) DeleteUserAppGrantsByUser(ctx context.Context, userID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, deleteUserAppGrantsByUser, userID)
 	return err
 }
 
@@ -776,6 +811,24 @@ func (q *Queries) GetLatestUpdateWithRollout(ctx context.Context, arg GetLatestU
 	return i, err
 }
 
+const getRoleByID = `-- name: GetRoleByID :one
+SELECT id, name, permissions, created_at, updated_at FROM roles
+WHERE id = $1 LIMIT 1
+`
+
+func (q *Queries) GetRoleByID(ctx context.Context, id pgtype.UUID) (Role, error) {
+	row := q.db.QueryRow(ctx, getRoleByID, id)
+	var i Role
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Permissions,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const getRuntimeVersionsWithUpdateCount = `-- name: GetRuntimeVersionsWithUpdateCount :many
 SELECT 
     rv.id, 
@@ -1169,6 +1222,43 @@ func (q *Queries) GetUpdatesMetadataByBranchName(ctx context.Context, arg GetUpd
 	return items, nil
 }
 
+const getUserAppGrant = `-- name: GetUserAppGrant :one
+SELECT g.user_id, g.app_id, g.role_id, g.extra_permissions,
+       r.permissions AS role_permissions
+FROM user_app_grants g
+LEFT JOIN roles r ON r.id = g.role_id
+WHERE g.user_id = $1 AND g.app_id = $2
+LIMIT 1
+`
+
+type GetUserAppGrantParams struct {
+	UserID pgtype.UUID `json:"user_id"`
+	AppID  pgtype.UUID `json:"app_id"`
+}
+
+type GetUserAppGrantRow struct {
+	UserID           pgtype.UUID `json:"user_id"`
+	AppID            pgtype.UUID `json:"app_id"`
+	RoleID           pgtype.UUID `json:"role_id"`
+	ExtraPermissions []string    `json:"extra_permissions"`
+	RolePermissions  []string    `json:"role_permissions"`
+}
+
+// The enforcement read behind every member mutation: the grant row for one
+// (user, app) pair with the role's permissions resolved.
+func (q *Queries) GetUserAppGrant(ctx context.Context, arg GetUserAppGrantParams) (GetUserAppGrantRow, error) {
+	row := q.db.QueryRow(ctx, getUserAppGrant, arg.UserID, arg.AppID)
+	var i GetUserAppGrantRow
+	err := row.Scan(
+		&i.UserID,
+		&i.AppID,
+		&i.RoleID,
+		&i.ExtraPermissions,
+		&i.RolePermissions,
+	)
+	return i, err
+}
+
 const getUserByEmail = `-- name: GetUserByEmail :one
 SELECT id, email, password_hash, is_admin, created_at, updated_at, last_connected_at, enabled FROM users
 WHERE email = $1 LIMIT 1
@@ -1437,6 +1527,33 @@ func (q *Queries) InsertChannelRollout(ctx context.Context, arg InsertChannelRol
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const insertRole = `-- name: InsertRole :one
+
+INSERT INTO roles (id, name, permissions)
+VALUES ($1, $2, $3)
+RETURNING id, name, permissions, created_at, updated_at
+`
+
+type InsertRoleParams struct {
+	ID          pgtype.UUID `json:"id"`
+	Name        string      `json:"name"`
+	Permissions []string    `json:"permissions"`
+}
+
+// Enterprise user roles & per-app grants (ee/rbac)
+func (q *Queries) InsertRole(ctx context.Context, arg InsertRoleParams) (Role, error) {
+	row := q.db.QueryRow(ctx, insertRole, arg.ID, arg.Name, arg.Permissions)
+	var i Role
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Permissions,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const insertRuntimeVersion = `-- name: InsertRuntimeVersion :one
@@ -1723,6 +1840,28 @@ func (q *Queries) InsertUser(ctx context.Context, arg InsertUserParams) (InsertU
 	return i, err
 }
 
+const insertUserAppGrant = `-- name: InsertUserAppGrant :exec
+INSERT INTO user_app_grants (user_id, app_id, role_id, extra_permissions)
+VALUES ($1, $2, $3, $4)
+`
+
+type InsertUserAppGrantParams struct {
+	UserID           pgtype.UUID `json:"user_id"`
+	AppID            pgtype.UUID `json:"app_id"`
+	RoleID           pgtype.UUID `json:"role_id"`
+	ExtraPermissions []string    `json:"extra_permissions"`
+}
+
+func (q *Queries) InsertUserAppGrant(ctx context.Context, arg InsertUserAppGrantParams) error {
+	_, err := q.db.Exec(ctx, insertUserAppGrant,
+		arg.UserID,
+		arg.AppID,
+		arg.RoleID,
+		arg.ExtraPermissions,
+	)
+	return err
+}
+
 const isBranchProtected = `-- name: IsBranchProtected :one
 SELECT protected FROM branches
 WHERE app_id = $1 AND name = $2
@@ -1738,6 +1877,108 @@ func (q *Queries) IsBranchProtected(ctx context.Context, arg IsBranchProtectedPa
 	var protected bool
 	err := row.Scan(&protected)
 	return protected, err
+}
+
+const listAccessibleAppIDs = `-- name: ListAccessibleAppIDs :many
+SELECT app_id FROM user_app_grants
+WHERE user_id = $1
+`
+
+func (q *Queries) ListAccessibleAppIDs(ctx context.Context, userID pgtype.UUID) ([]pgtype.UUID, error) {
+	rows, err := q.db.Query(ctx, listAccessibleAppIDs, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []pgtype.UUID
+	for rows.Next() {
+		var app_id pgtype.UUID
+		if err := rows.Scan(&app_id); err != nil {
+			return nil, err
+		}
+		items = append(items, app_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listRoles = `-- name: ListRoles :many
+SELECT id, name, permissions, created_at, updated_at FROM roles
+ORDER BY name ASC
+`
+
+func (q *Queries) ListRoles(ctx context.Context) ([]Role, error) {
+	rows, err := q.db.Query(ctx, listRoles)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Role
+	for rows.Next() {
+		var i Role
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.Permissions,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listUserAppGrants = `-- name: ListUserAppGrants :many
+SELECT g.user_id, g.app_id, g.role_id, g.extra_permissions,
+       r.name AS role_name, r.permissions AS role_permissions
+FROM user_app_grants g
+LEFT JOIN roles r ON r.id = g.role_id
+WHERE g.user_id = $1
+ORDER BY g.app_id ASC
+`
+
+type ListUserAppGrantsRow struct {
+	UserID           pgtype.UUID `json:"user_id"`
+	AppID            pgtype.UUID `json:"app_id"`
+	RoleID           pgtype.UUID `json:"role_id"`
+	ExtraPermissions []string    `json:"extra_permissions"`
+	RoleName         *string     `json:"role_name"`
+	RolePermissions  []string    `json:"role_permissions"`
+}
+
+// The member's grants with their role resolved, one row per granted app.
+func (q *Queries) ListUserAppGrants(ctx context.Context, userID pgtype.UUID) ([]ListUserAppGrantsRow, error) {
+	rows, err := q.db.Query(ctx, listUserAppGrants, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListUserAppGrantsRow
+	for rows.Next() {
+		var i ListUserAppGrantsRow
+		if err := rows.Scan(
+			&i.UserID,
+			&i.AppID,
+			&i.RoleID,
+			&i.ExtraPermissions,
+			&i.RoleName,
+			&i.RolePermissions,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const markUpdateAsChecked = `-- name: MarkUpdateAsChecked :execrows
@@ -2255,6 +2496,22 @@ func (q *Queries) UpdateChannelRolloutPercentage(ctx context.Context, arg Update
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const updateRole = `-- name: UpdateRole :execresult
+UPDATE roles
+SET name = $2, permissions = $3, updated_at = CURRENT_TIMESTAMP
+WHERE id = $1
+`
+
+type UpdateRoleParams struct {
+	ID          pgtype.UUID `json:"id"`
+	Name        string      `json:"name"`
+	Permissions []string    `json:"permissions"`
+}
+
+func (q *Queries) UpdateRole(ctx context.Context, arg UpdateRoleParams) (pgconn.CommandTag, error) {
+	return q.db.Exec(ctx, updateRole, arg.ID, arg.Name, arg.Permissions)
 }
 
 const updateUserEnabledByID = `-- name: UpdateUserEnabledByID :execresult

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -64,7 +64,7 @@ func (q *Queries) DeleteAppByID(ctx context.Context, id pgtype.UUID) (pgconn.Com
 
 const deleteBranchByName = `-- name: DeleteBranchByName :execresult
 DELETE FROM branches
-WHERE name = $1 AND app_id = $2
+WHERE name = $1 AND app_id = $2 AND NOT protected
 `
 
 type DeleteBranchByNameParams struct {
@@ -72,6 +72,10 @@ type DeleteBranchByNameParams struct {
 	AppID pgtype.UUID `json:"app_id"`
 }
 
+// NOT protected: a protected branch cannot be deleted by anyone, admins
+// included — protection must be lifted first. The guard runs inside the
+// DELETE itself so a concurrent protect cannot race it; the store
+// disambiguates the 0-rows result into protected vs not-found.
 func (q *Queries) DeleteBranchByName(ctx context.Context, arg DeleteBranchByNameParams) (pgconn.CommandTag, error) {
 	return q.db.Exec(ctx, deleteBranchByName, arg.Name, arg.AppID)
 }

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -53,6 +53,39 @@ func (q *Queries) CountGrantsByRole(ctx context.Context, roleID pgtype.UUID) (in
 	return count, err
 }
 
+const countGrantsPerUser = `-- name: CountGrantsPerUser :many
+SELECT user_id, COUNT(*) AS grant_count
+FROM user_app_grants
+GROUP BY user_id
+`
+
+type CountGrantsPerUserRow struct {
+	UserID     pgtype.UUID `json:"user_id"`
+	GrantCount int64       `json:"grant_count"`
+}
+
+// Backs the Users page warning: members with zero grants see an empty
+// dashboard, admins should notice at a glance.
+func (q *Queries) CountGrantsPerUser(ctx context.Context) ([]CountGrantsPerUserRow, error) {
+	rows, err := q.db.Query(ctx, countGrantsPerUser)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []CountGrantsPerUserRow
+	for rows.Next() {
+		var i CountGrantsPerUserRow
+		if err := rows.Scan(&i.UserID, &i.GrantCount); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const deleteAppByID = `-- name: DeleteAppByID :execresult
 DELETE FROM apps
 WHERE id = $1

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -814,3 +814,66 @@ SELECT ch.name AS channel_name
 FROM channel_rollouts cr
 JOIN channels ch ON cr.channel_id = ch.id
 WHERE cr.rollout_branch_id = (SELECT branches.id FROM branches WHERE branches.app_id = $1 AND branches.name = $2);
+
+-- Enterprise user roles & per-app grants (ee/rbac)
+
+-- name: InsertRole :one
+INSERT INTO roles (id, name, permissions)
+VALUES ($1, $2, $3)
+RETURNING *;
+
+-- name: GetRoleByID :one
+SELECT * FROM roles
+WHERE id = $1 LIMIT 1;
+
+-- name: ListRoles :many
+SELECT * FROM roles
+ORDER BY name ASC;
+
+-- name: UpdateRole :execresult
+UPDATE roles
+SET name = $2, permissions = $3, updated_at = CURRENT_TIMESTAMP
+WHERE id = $1;
+
+-- name: DeleteRole :execresult
+-- The FK from user_app_grants is ON DELETE RESTRICT: deleting a role that is
+-- still assigned fails with a foreign-key violation the store maps to a
+-- friendly "role in use" error.
+DELETE FROM roles
+WHERE id = $1;
+
+-- name: CountGrantsByRole :one
+SELECT COUNT(*) FROM user_app_grants
+WHERE role_id = $1;
+
+-- name: ListUserAppGrants :many
+-- The member's grants with their role resolved, one row per granted app.
+SELECT g.user_id, g.app_id, g.role_id, g.extra_permissions,
+       r.name AS role_name, r.permissions AS role_permissions
+FROM user_app_grants g
+LEFT JOIN roles r ON r.id = g.role_id
+WHERE g.user_id = $1
+ORDER BY g.app_id ASC;
+
+-- name: GetUserAppGrant :one
+-- The enforcement read behind every member mutation: the grant row for one
+-- (user, app) pair with the role's permissions resolved.
+SELECT g.user_id, g.app_id, g.role_id, g.extra_permissions,
+       r.permissions AS role_permissions
+FROM user_app_grants g
+LEFT JOIN roles r ON r.id = g.role_id
+WHERE g.user_id = $1 AND g.app_id = $2
+LIMIT 1;
+
+-- name: ListAccessibleAppIDs :many
+SELECT app_id FROM user_app_grants
+WHERE user_id = $1;
+
+-- name: DeleteUserAppGrantsByUser :exec
+-- Grants are replaced wholesale (delete + insert in one transaction).
+DELETE FROM user_app_grants
+WHERE user_id = $1;
+
+-- name: InsertUserAppGrant :exec
+INSERT INTO user_app_grants (user_id, app_id, role_id, extra_permissions)
+VALUES ($1, $2, $3, $4);

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -881,3 +881,10 @@ WHERE user_id = $1;
 -- name: InsertUserAppGrant :exec
 INSERT INTO user_app_grants (user_id, app_id, role_id, extra_permissions)
 VALUES ($1, $2, $3, $4);
+
+-- name: CountGrantsPerUser :many
+-- Backs the Users page warning: members with zero grants see an empty
+-- dashboard, admins should notice at a glance.
+SELECT user_id, COUNT(*) AS grant_count
+FROM user_app_grants
+GROUP BY user_id;

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -75,8 +75,12 @@ WHERE name = $1 AND app_id = $2
 LIMIT 1;
 
 -- name: DeleteBranchByName :execresult
+-- NOT protected: a protected branch cannot be deleted by anyone, admins
+-- included — protection must be lifted first. The guard runs inside the
+-- DELETE itself so a concurrent protect cannot race it; the store
+-- disambiguates the 0-rows result into protected vs not-found.
 DELETE FROM branches
-WHERE name = $1 AND app_id = $2;
+WHERE name = $1 AND app_id = $2 AND NOT protected;
 
 -- name: GetBranchesByAppID :many
 SELECT DISTINCT ON (branches.id) 

--- a/internal/handlers/dashboard/apps_handler.go
+++ b/internal/handlers/dashboard/apps_handler.go
@@ -1,12 +1,14 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"expo-open-ota/config"
 	cache2 "expo-open-ota/internal/cache"
 	"expo-open-ota/internal/dashboard"
 	"expo-open-ota/internal/handlers"
+	"expo-open-ota/internal/middleware"
 	"expo-open-ota/internal/services"
 	"expo-open-ota/internal/store"
 	"expo-open-ota/internal/validation"
@@ -16,14 +18,49 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// AppVisibilityFilter narrows the dashboard app list to what the requesting
+// account may see. Injected from the wiring (ee/rbac) so this community
+// handler needs no ee import; nil-safe for tests that build the handler
+// directly. restricted=false means nothing is filtered (admin, community
+// fallback); otherwise only the ids in visible are.
+type AppVisibilityFilter func(ctx context.Context, principal *services.DashboardPrincipal) (restricted bool, visible map[string]bool, err error)
+
 type AppHandler struct {
 	appService *services.AppService
+	// visibleApps filters the responses of the app listing; the cache keeps
+	// the unfiltered list (keyed per app set, not per user), so filtering
+	// always happens after the cache read.
+	visibleApps AppVisibilityFilter
 }
 
-func NewAppHandler(appService *services.AppService) *AppHandler {
+func NewAppHandler(appService *services.AppService, visibleApps AppVisibilityFilter) *AppHandler {
 	return &AppHandler{
-		appService: appService,
+		appService:  appService,
+		visibleApps: visibleApps,
 	}
+}
+
+// filterVisibleApps applies the visibility filter for this request. The
+// returned error means the filter itself failed and the caller must 500
+// rather than fall back to the unfiltered list.
+func (h *AppHandler) filterVisibleApps(r *http.Request, apps []config.AppDescriptor) ([]config.AppDescriptor, error) {
+	if h.visibleApps == nil {
+		return apps, nil
+	}
+	restricted, visible, err := h.visibleApps(r.Context(), middleware.PrincipalFromContext(r.Context()))
+	if err != nil {
+		return nil, err
+	}
+	if !restricted {
+		return apps, nil
+	}
+	filtered := make([]config.AppDescriptor, 0, len(apps))
+	for _, app := range apps {
+		if visible[app.Id] {
+			filtered = append(filtered, app)
+		}
+	}
+	return filtered, nil
 }
 
 func (h *AppHandler) CreateAppHandler(w http.ResponseWriter, r *http.Request) {
@@ -127,25 +164,32 @@ func (h *AppHandler) DeleteAppHandler(w http.ResponseWriter, r *http.Request) {
 func (h *AppHandler) GetAppsHandler(w http.ResponseWriter, r *http.Request) {
 	cache := cache2.GetCache()
 	cacheKey := dashboard.ComputeGetAppsCacheKey()
-	if cacheValue := cache.Get(cacheKey); cacheValue != "" {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(cacheValue))
-		return
+	// The cache holds the unfiltered list: entries are shared across
+	// accounts, so per-user visibility is applied after the read, never
+	// baked into the key or the cached value.
+	var apps []config.AppDescriptor
+	cachedValue := cache.Get(cacheKey)
+	if cachedValue == "" || json.Unmarshal([]byte(cachedValue), &apps) != nil {
+		var err error
+		apps, err = h.appService.GetApps(r.Context())
+		if err != nil {
+			handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while fetching apps.")
+			return
+		}
+		marshaledFullList, _ := json.Marshal(apps)
+		ttl := 3600
+		cache.Set(cacheKey, string(marshaledFullList), &ttl)
 	}
-	apps, err := h.appService.GetApps(r.Context())
+
+	visibleAppsList, err := h.filterVisibleApps(r, apps)
 	if err != nil {
 		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while fetching apps.")
 		return
 	}
-
-	marshaledResponse, _ := json.Marshal(apps)
+	marshaledResponse, _ := json.Marshal(visibleAppsList)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	w.Write(marshaledResponse)
-
-	ttl := 3600
-	cache.Set(cacheKey, string(marshaledResponse), &ttl)
 }
 
 func (h *AppHandler) UpdateAppHandler(w http.ResponseWriter, r *http.Request) {

--- a/internal/handlers/dashboard/apps_handler_test.go
+++ b/internal/handlers/dashboard/apps_handler_test.go
@@ -1,0 +1,92 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"expo-open-ota/config"
+	cache2 "expo-open-ota/internal/cache"
+	"expo-open-ota/internal/dashboard"
+	"expo-open-ota/internal/services"
+	"expo-open-ota/internal/store"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeAppRepo serves a fixed app list; only GetApps matters here.
+type fakeAppRepo struct {
+	apps []config.AppDescriptor
+}
+
+func (f *fakeAppRepo) InsertApp(_ context.Context, _ store.InsertAppParameters) (string, error) {
+	panic("unused")
+}
+func (f *fakeAppRepo) DeleteAppByID(_ context.Context, _ string) error { panic("unused") }
+func (f *fakeAppRepo) GetApps(_ context.Context) ([]config.AppDescriptor, error) {
+	return f.apps, nil
+}
+func (f *fakeAppRepo) UpdateAppNameByID(_ context.Context, _ string, _ string) error {
+	panic("unused")
+}
+func (f *fakeAppRepo) GetAppByID(_ context.Context, _ string) (config.AppConfig, error) {
+	panic("unused")
+}
+
+func getApps(t *testing.T, handler *AppHandler) (int, []config.AppDescriptor) {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	handler.GetAppsHandler(recorder, httptest.NewRequest(http.MethodGet, "/api/apps", nil))
+	var apps []config.AppDescriptor
+	if recorder.Code == http.StatusOK {
+		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &apps))
+	}
+	return recorder.Code, apps
+}
+
+// The cache stores the unfiltered list shared by every account, so the
+// visibility filter must apply on the cache-hit path too — a member's request
+// right after an admin warmed the cache is the regression this guards.
+func TestGetAppsHandlerFiltersAfterCacheRead(t *testing.T) {
+	cache2.GetCache().Delete(dashboard.ComputeGetAppsCacheKey())
+	t.Cleanup(func() { cache2.GetCache().Delete(dashboard.ComputeGetAppsCacheKey()) })
+
+	appService := services.NewAppService(&fakeAppRepo{apps: []config.AppDescriptor{
+		{Id: "app-1", Name: "One"},
+		{Id: "app-2", Name: "Two"},
+	}})
+
+	// First request, unrestricted (admin view): warms the cache with both apps.
+	unrestricted := NewAppHandler(appService, func(context.Context, *services.DashboardPrincipal) (bool, map[string]bool, error) {
+		return false, nil, nil
+	})
+	status, apps := getApps(t, unrestricted)
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, apps, 2)
+
+	// Second request, restricted member: served from the warm cache, and
+	// still only their app.
+	restricted := NewAppHandler(appService, func(context.Context, *services.DashboardPrincipal) (bool, map[string]bool, error) {
+		return true, map[string]bool{"app-2": true}, nil
+	})
+	status, apps = getApps(t, restricted)
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, apps, 1)
+	require.Equal(t, "app-2", apps[0].Id)
+
+	// A member with no grants gets an empty list, not an error.
+	invisible := NewAppHandler(appService, func(context.Context, *services.DashboardPrincipal) (bool, map[string]bool, error) {
+		return true, map[string]bool{}, nil
+	})
+	status, apps = getApps(t, invisible)
+	require.Equal(t, http.StatusOK, status)
+	require.Empty(t, apps)
+
+	// No filter injected (community handler construction): everything shows.
+	community := NewAppHandler(appService, nil)
+	status, apps = getApps(t, community)
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, apps, 2)
+}

--- a/internal/handlers/dashboard/branches_handler.go
+++ b/internal/handlers/dashboard/branches_handler.go
@@ -94,6 +94,10 @@ func (h *BranchHandler) DeleteBranchHandler(w http.ResponseWriter, r *http.Reque
 			handlers.RenderError(w, http.StatusConflict, rolloutErr.Error())
 			return
 		}
+		if protectedErr := (*store.ErrBranchProtected)(nil); errors.As(err, &protectedErr) {
+			handlers.RenderError(w, http.StatusConflict, protectedErr.Error())
+			return
+		}
 		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while deleting the branch.")
 		return
 	}

--- a/internal/handlers/dashboard/settings_handler.go
+++ b/internal/handlers/dashboard/settings_handler.go
@@ -7,6 +7,7 @@ import (
 	"expo-open-ota/internal/cdn"
 	"expo-open-ota/internal/handlers"
 	"expo-open-ota/internal/helpers"
+	"expo-open-ota/internal/middleware"
 	"expo-open-ota/internal/providers/expo"
 	"expo-open-ota/internal/services"
 	"net/http"
@@ -18,12 +19,16 @@ type SettingsHandler struct {
 	// from the wiring so this community handler needs no ee import. Nil-safe
 	// for tests that build the handler directly.
 	ssoEnabled func(context.Context) bool
+	// visibleApps filters the embedded app list the same way the app listing
+	// endpoint does; same injection story, same nil-safety.
+	visibleApps AppVisibilityFilter
 }
 
-func NewSettingsHandler(appService *services.AppService, ssoEnabled func(context.Context) bool) *SettingsHandler {
+func NewSettingsHandler(appService *services.AppService, ssoEnabled func(context.Context) bool, visibleApps AppVisibilityFilter) *SettingsHandler {
 	return &SettingsHandler{
-		appService: appService,
-		ssoEnabled: ssoEnabled,
+		appService:  appService,
+		ssoEnabled:  ssoEnabled,
+		visibleApps: visibleApps,
 	}
 }
 
@@ -98,6 +103,24 @@ func (h *SettingsHandler) GetSettingsHandler(w http.ResponseWriter, r *http.Requ
 	expoAccountUsername := ""
 	if !config.IsDBMode() && len(apps) > 0 {
 		expoAccountUsername = expo.FetchSelfUsername(apps[0].Id)
+	}
+	// Filter after the stateless expo lookup above: that one needs any app id
+	// and only runs without a control plane, where nothing is ever filtered.
+	if h.visibleApps != nil {
+		restricted, visible, err := h.visibleApps(r.Context(), middleware.PrincipalFromContext(r.Context()))
+		if err != nil {
+			handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while fetching app settings")
+			return
+		}
+		if restricted {
+			filtered := make([]config.AppDescriptor, 0, len(apps))
+			for _, app := range apps {
+				if visible[app.Id] {
+					filtered = append(filtered, app)
+				}
+			}
+			apps = filtered
+		}
 	}
 	marshaledResponse, _ := json.Marshal(SettingsEnv{
 		BASE_URL:                               config.GetEnv("BASE_URL"),

--- a/internal/middleware/auth_middleware.go
+++ b/internal/middleware/auth_middleware.go
@@ -27,6 +27,24 @@ func WithPrincipal(ctx context.Context, principal *services.DashboardPrincipal) 
 	return context.WithValue(ctx, principalContextKey{}, principal)
 }
 
+type cliAuthContextKey struct{}
+
+// WithCliAuth marks the request as authenticated by an app-scoped CLI
+// credential. The marker exists so downstream gates can assert "validated CLI
+// request" as a fact instead of inferring it from the absence of a dashboard
+// principal, which would silently fail open on a route someone mounts without
+// the auth middleware.
+func WithCliAuth(ctx context.Context, appId string) context.Context {
+	return context.WithValue(ctx, cliAuthContextKey{}, appId)
+}
+
+// CliAuthAppFromContext returns the app the CLI credential was validated for,
+// or "" when the request did not authenticate through the CLI path.
+func CliAuthAppFromContext(ctx context.Context) string {
+	appId, _ := ctx.Value(cliAuthContextKey{}).(string)
+	return appId
+}
+
 // NewAuthMiddleware guards a route with one of two unrelated credentials,
 // picked by the Use-Cli-Auth header:
 //   - "true": a CLI credential scoped to an app (an eoo_ API key in DB mode, an
@@ -64,7 +82,7 @@ func NewAuthMiddleware(dashboardAuthService *services.DashboardAuthService, cliA
 					return
 				}
 
-				next.ServeHTTP(w, r)
+				next.ServeHTTP(w, r.WithContext(WithCliAuth(r.Context(), appId)))
 				return
 			}
 			bearerToken, err := helpers.GetBearerToken(r)

--- a/internal/middleware/auth_middleware_test.go
+++ b/internal/middleware/auth_middleware_test.go
@@ -7,7 +7,9 @@ import (
 	"strconv"
 	"testing"
 
+	"expo-open-ota/internal/database/postgres/pgdb"
 	"expo-open-ota/internal/services"
+	"expo-open-ota/internal/types"
 
 	"github.com/gorilla/mux"
 )
@@ -26,6 +28,7 @@ func runAuthMiddleware(t *testing.T, configure func(r *http.Request)) *httptest.
 			w.Header().Set("X-Principal-Email", principal.Email)
 			w.Header().Set("X-Principal-Admin", strconv.FormatBool(principal.IsAdmin))
 		}
+		w.Header().Set("X-Cli-App", CliAuthAppFromContext(r.Context()))
 		w.WriteHeader(http.StatusOK)
 	})
 	r := httptest.NewRequest("GET", "/settings", nil)
@@ -67,6 +70,9 @@ func TestAuthMiddleware(t *testing.T) {
 		if got := w.Header().Get("X-Principal-Admin"); got != "true" {
 			t.Fatalf("expected the stateless principal to be admin, got %q", got)
 		}
+		if got := w.Header().Get("X-Cli-App"); got != "" {
+			t.Fatalf("a dashboard session must not carry the CLI marker, got %q", got)
+		}
 	})
 
 	t.Run("invalid bearer token is rejected", func(t *testing.T) {
@@ -84,4 +90,52 @@ func TestAuthMiddleware(t *testing.T) {
 			t.Fatalf("expected 401 with no Authorization header, got %d", w.Code)
 		}
 	})
+}
+
+// fakeCliAuthRepo accepts any credential and answers with key id 0, which
+// skips the access policy exactly like stateless mode does.
+type fakeCliAuthRepo struct{}
+
+func (fakeCliAuthRepo) ValidateCliCredential(_ context.Context, _ string, _ types.Auth) (int64, error) {
+	return 0, nil
+}
+func (fakeCliAuthRepo) InsertApiKey(_ context.Context, _ string, _ string, _ string, _ string) error {
+	return nil
+}
+func (fakeCliAuthRepo) GetApiKeysMetadataByAppID(_ context.Context, _ string) ([]pgdb.GetApiKeysMetadataByAppIDRow, error) {
+	return nil, nil
+}
+func (fakeCliAuthRepo) RevokeApiKeyByID(_ context.Context, _ int64, _ string) error {
+	return nil
+}
+
+// The CLI branch must stamp the validated app on the context: downstream
+// gates (ee/rbac's RequireAppVisible) assert this marker instead of inferring
+// "CLI" from a missing principal, and would fail closed without it.
+func TestAuthMiddlewareCliBranchStampsMarker(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret")
+
+	router := mux.NewRouter()
+	appRouter := router.PathPrefix("/{APP_ID}").Subrouter()
+	appRouter.Use(NewAuthMiddleware(services.NewDashboardAuthService(nil), services.NewCliAuthService(fakeCliAuthRepo{}, nil)))
+	appRouter.HandleFunc("/branches", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Cli-App", CliAuthAppFromContext(r.Context()))
+		if PrincipalFromContext(r.Context()) != nil {
+			t.Error("a CLI request must not carry a dashboard principal")
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	r := httptest.NewRequest("GET", "/my-app/branches", nil)
+	r.Header.Set("Use-Cli-Auth", "true")
+	r.Header.Set("Authorization", "Bearer eoo_some-api-key")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected the validated CLI request to pass, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("X-Cli-App"); got != "my-app" {
+		t.Fatalf("expected the CLI marker to carry the validated app id, got %q", got)
+	}
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -2,6 +2,7 @@ package infrastructure
 
 import (
 	"expo-open-ota/config"
+	"expo-open-ota/ee/rbac"
 	dashutils "expo-open-ota/internal/dashboard"
 	"expo-open-ota/internal/metrics"
 	"expo-open-ota/internal/middleware"
@@ -120,12 +121,18 @@ func NewRouter(container *AppContainer) *mux.Router {
 	authSubrouter.Use(middleware.NewAuthMiddleware(container.DashboardAuthService, container.CliAuthService))
 	authSubrouter.HandleFunc("/settings", container.SettingsHandler.GetSettingsHandler).Methods(http.MethodGet)
 
-	// adminOnly makes member accounts read-only: every dashboard mutation —
-	// users, apps, branches, channels, mappings, API tokens — plus the signing
-	// certificate download is admin-only. Members keep the GET routes, /api/me
-	// and their own password change. It wraps individual routes rather than a
-	// subrouter because admin and non-admin routes share path prefixes.
+	// Two gates share the mutation routes. adminOnly guards the global
+	// administration surface (users, roles, license, SSO, app creation).
+	// requirePermission guards the app-scoped mutations: admins always pass,
+	// members need the permission on the route's app through their enterprise
+	// grants (ee/rbac), and without a control plane or a valid license it
+	// degrades to exactly adminOnly's behavior, keeping members read-only.
+	// Both wrap individual routes rather than a subrouter because admin and
+	// non-admin routes share path prefixes.
 	adminOnly := middleware.NewAdminMiddleware(container.UserRepo)
+	requirePermission := func(perm rbac.Permission) mux.MiddlewareFunc {
+		return rbac.RequirePermission(container.RBACService, container.UserRepo, perm)
+	}
 
 	// Current account
 	authSubrouter.HandleFunc("/me", container.UsersHandler.GetMeHandler).Methods(http.MethodGet)
@@ -165,13 +172,15 @@ func NewRouter(container *AppContainer) *mux.Router {
 	authSubrouter.Handle("/users/{USER_ID}/grants", adminOnly(http.HandlerFunc(container.RBACHandler.SetUserGrantsHandler))).Methods(http.MethodPut)
 	authSubrouter.HandleFunc("/me/permissions", container.RBACHandler.GetMyPermissionsHandler).Methods(http.MethodGet)
 
-	// Apps management router
+	// Apps management router. Creating an app is global administration and
+	// stays admin-only; acting on an existing app is permission-gated.
 	authSubrouter.Handle("/apps", adminOnly(http.HandlerFunc(container.AppHandler.CreateAppHandler))).Methods(http.MethodPost)
-	authSubrouter.Handle("/apps/{APP_ID}", adminOnly(http.HandlerFunc(container.AppHandler.DeleteAppHandler))).Methods(http.MethodDelete)
-	authSubrouter.Handle("/apps/{APP_ID}", adminOnly(http.HandlerFunc(container.AppHandler.UpdateAppHandler))).Methods(http.MethodPatch)
+	authSubrouter.Handle("/apps/{APP_ID}", requirePermission(rbac.PermAppDelete)(http.HandlerFunc(container.AppHandler.DeleteAppHandler))).Methods(http.MethodDelete)
+	authSubrouter.Handle("/apps/{APP_ID}", requirePermission(rbac.PermAppRename)(http.HandlerFunc(container.AppHandler.UpdateAppHandler))).Methods(http.MethodPatch)
 	authSubrouter.HandleFunc("/apps", container.AppHandler.GetAppsHandler).Methods(http.MethodGet)
-	// The signing certificate is key material — admin eyes only.
-	authSubrouter.Handle("/apps/{APP_ID}/certificate", adminOnly(http.HandlerFunc(container.AppHandler.DownloadAppCertificateHandler))).Methods(http.MethodGet)
+	// The signing certificate is key material — admins, or the explicit
+	// certificate:read permission.
+	authSubrouter.Handle("/apps/{APP_ID}/certificate", requirePermission(rbac.PermCertificateRead)(http.HandlerFunc(container.AppHandler.DownloadAppCertificateHandler))).Methods(http.MethodGet)
 
 	// App-scoped dashboard routes: Auth first, then AppResolver validates the
 	// id and short-circuits unknown apps with 404 before handlers run. Without
@@ -182,37 +191,37 @@ func NewRouter(container *AppContainer) *mux.Router {
 	appAuthSubrouter.StrictSlash(true)
 	appAuthSubrouter.Use(middleware.AppResolverMiddleware(container.AppRepo))
 	appAuthSubrouter.HandleFunc("/", container.AppHandler.GetAppHandler).Methods(http.MethodGet)
-	appAuthSubrouter.Handle("/branches", adminOnly(http.HandlerFunc(container.BranchHandler.CreateBranchHandler))).Methods(http.MethodPost)
-	appAuthSubrouter.Handle("/branches/{BRANCH}", adminOnly(http.HandlerFunc(container.BranchHandler.DeleteBranchHandler))).Methods(http.MethodDelete)
+	appAuthSubrouter.Handle("/branches", requirePermission(rbac.PermBranchCreate)(http.HandlerFunc(container.BranchHandler.CreateBranchHandler))).Methods(http.MethodPost)
+	appAuthSubrouter.Handle("/branches/{BRANCH}", requirePermission(rbac.PermBranchDelete)(http.HandlerFunc(container.BranchHandler.DeleteBranchHandler))).Methods(http.MethodDelete)
 	appAuthSubrouter.HandleFunc("/branches", container.BranchHandler.GetBranchesHandler).Methods(http.MethodGet)
-	appAuthSubrouter.Handle("/channels", adminOnly(http.HandlerFunc(container.ChannelHandler.CreateChannelHandler))).Methods(http.MethodPost)
-	appAuthSubrouter.Handle("/channels/{CHANNEL}", adminOnly(http.HandlerFunc(container.ChannelHandler.DeleteChannelHandler))).Methods(http.MethodDelete)
+	appAuthSubrouter.Handle("/channels", requirePermission(rbac.PermChannelCreate)(http.HandlerFunc(container.ChannelHandler.CreateChannelHandler))).Methods(http.MethodPost)
+	appAuthSubrouter.Handle("/channels/{CHANNEL}", requirePermission(rbac.PermChannelDelete)(http.HandlerFunc(container.ChannelHandler.DeleteChannelHandler))).Methods(http.MethodDelete)
 	appAuthSubrouter.HandleFunc("/channels", container.ChannelHandler.GetChannelsHandler).Methods(http.MethodGet)
-	// Progressive rollouts (control-plane only; reads stay open like the sibling
-	// listings, every mutation is admin-only). Channel rollouts are keyed by channel
-	// name, per-update rollouts by (branch, runtime version).
+	// Progressive rollouts (control-plane only; reads stay open like the
+	// sibling listings). One permission covers a channel rollout's whole
+	// lifecycle, its per-update sibling has its own.
 	appAuthSubrouter.HandleFunc("/channels/{CHANNEL}/rollout", container.RolloutHandler.GetChannelRolloutHandler).Methods(http.MethodGet)
-	appAuthSubrouter.Handle("/channels/{CHANNEL}/rollout", adminOnly(http.HandlerFunc(container.RolloutHandler.StartChannelRolloutHandler))).Methods(http.MethodPost)
-	appAuthSubrouter.Handle("/channels/{CHANNEL}/rollout", adminOnly(http.HandlerFunc(container.RolloutHandler.UpdateChannelRolloutHandler))).Methods(http.MethodPatch)
-	appAuthSubrouter.Handle("/channels/{CHANNEL}/rollout/end", adminOnly(http.HandlerFunc(container.RolloutHandler.EndChannelRolloutHandler))).Methods(http.MethodPost)
+	appAuthSubrouter.Handle("/channels/{CHANNEL}/rollout", requirePermission(rbac.PermChannelRolloutManage)(http.HandlerFunc(container.RolloutHandler.StartChannelRolloutHandler))).Methods(http.MethodPost)
+	appAuthSubrouter.Handle("/channels/{CHANNEL}/rollout", requirePermission(rbac.PermChannelRolloutManage)(http.HandlerFunc(container.RolloutHandler.UpdateChannelRolloutHandler))).Methods(http.MethodPatch)
+	appAuthSubrouter.Handle("/channels/{CHANNEL}/rollout/end", requirePermission(rbac.PermChannelRolloutManage)(http.HandlerFunc(container.RolloutHandler.EndChannelRolloutHandler))).Methods(http.MethodPost)
 	appAuthSubrouter.HandleFunc("/branch/{BRANCH}/runtimeVersion/{RUNTIME_VERSION}/rollout", container.RolloutHandler.GetUpdateRolloutHandler).Methods(http.MethodGet)
-	appAuthSubrouter.Handle("/branch/{BRANCH}/runtimeVersion/{RUNTIME_VERSION}/rollout", adminOnly(http.HandlerFunc(container.RolloutHandler.SetUpdateRolloutPercentageHandler))).Methods(http.MethodPut)
-	appAuthSubrouter.Handle("/branch/{BRANCH}/runtimeVersion/{RUNTIME_VERSION}/rollout/revert", adminOnly(http.HandlerFunc(container.RolloutHandler.RevertUpdateRolloutHandler))).Methods(http.MethodPost)
+	appAuthSubrouter.Handle("/branch/{BRANCH}/runtimeVersion/{RUNTIME_VERSION}/rollout", requirePermission(rbac.PermUpdateRolloutManage)(http.HandlerFunc(container.RolloutHandler.SetUpdateRolloutPercentageHandler))).Methods(http.MethodPut)
+	appAuthSubrouter.Handle("/branch/{BRANCH}/runtimeVersion/{RUNTIME_VERSION}/rollout/revert", requirePermission(rbac.PermUpdateRolloutManage)(http.HandlerFunc(container.RolloutHandler.RevertUpdateRolloutHandler))).Methods(http.MethodPost)
 	appAuthSubrouter.HandleFunc("/branch/{BRANCH}/runtimeVersions", container.BranchHandler.GetRuntimeVersionsHandler).Methods(http.MethodGet)
 	appAuthSubrouter.HandleFunc("/branch/{BRANCH}/runtimeVersion/{RUNTIME_VERSION}/updates", container.UpdateHandler.GetUpdatesHandler).Methods(http.MethodGet)
 	appAuthSubrouter.HandleFunc("/branch/{BRANCH}/runtimeVersion/{RUNTIME_VERSION}/updates/{UPDATE_ID}", container.UpdateHandler.GetUpdateDetailsHandler).Methods(http.MethodGet)
-	appAuthSubrouter.Handle("/branch/{BRANCH_ID}/updateChannelBranchMapping", adminOnly(http.HandlerFunc(container.BranchHandler.UpdateChannelBranchMappingHandler))).Methods(http.MethodPost)
-	// An API token is publishing power over the app — minting and revoking are
-	// admin actions. The list stays readable: it only carries names and hints.
-	appAuthSubrouter.Handle("/apiKeys", adminOnly(http.HandlerFunc(container.ApiKeyHandler.CreateApiKeyHandler))).Methods(http.MethodPost)
+	appAuthSubrouter.Handle("/branch/{BRANCH_ID}/updateChannelBranchMapping", requirePermission(rbac.PermChannelEditBranch)(http.HandlerFunc(container.BranchHandler.UpdateChannelBranchMappingHandler))).Methods(http.MethodPost)
+	// An API token is publishing power over the app — minting and revoking
+	// need the apikeys:manage permission (or an admin). The list stays
+	// readable: it only carries names and hints.
+	appAuthSubrouter.Handle("/apiKeys", requirePermission(rbac.PermApiKeysManage)(http.HandlerFunc(container.ApiKeyHandler.CreateApiKeyHandler))).Methods(http.MethodPost)
 	appAuthSubrouter.HandleFunc("/apiKeys", container.ApiKeyHandler.GetApiKeysHandler).Methods(http.MethodGet)
-	appAuthSubrouter.Handle("/apiKeys/{API_KEY_ID}/revoke", adminOnly(http.HandlerFunc(container.ApiKeyHandler.RevokeApiKeyHandler))).Methods(http.MethodDelete)
-	// Enterprise: per-key access restrictions (protected-branch access + IP
-	// allowlist) and branch protection. Reads stay open like the key list;
-	// the writes change what a token can do, so they are admin-only and
-	// license-gated in the service.
+	appAuthSubrouter.Handle("/apiKeys/{API_KEY_ID}/revoke", requirePermission(rbac.PermApiKeysManage)(http.HandlerFunc(container.ApiKeyHandler.RevokeApiKeyHandler))).Methods(http.MethodDelete)
+	// Enterprise: per-key access restrictions ride with the token permission
+	// (they change what a token can do); toggling branch protection is its
+	// own permission. Both stay license-gated in their service.
 	appAuthSubrouter.HandleFunc("/apiKeys/restrictions", container.ApiKeyRestrictionHandler.GetApiKeyRestrictionsHandler).Methods(http.MethodGet)
-	appAuthSubrouter.Handle("/apiKeys/{API_KEY_ID}/restrictions", adminOnly(http.HandlerFunc(container.ApiKeyRestrictionHandler.SetApiKeyRestrictionsHandler))).Methods(http.MethodPut)
-	appAuthSubrouter.Handle("/branches/{BRANCH}/protection", adminOnly(http.HandlerFunc(container.ApiKeyRestrictionHandler.SetBranchProtectionHandler))).Methods(http.MethodPut)
+	appAuthSubrouter.Handle("/apiKeys/{API_KEY_ID}/restrictions", requirePermission(rbac.PermApiKeysManage)(http.HandlerFunc(container.ApiKeyRestrictionHandler.SetApiKeyRestrictionsHandler))).Methods(http.MethodPut)
+	appAuthSubrouter.Handle("/branches/{BRANCH}/protection", requirePermission(rbac.PermBranchProtect)(http.HandlerFunc(container.ApiKeyRestrictionHandler.SetBranchProtectionHandler))).Methods(http.MethodPut)
 	return r
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -170,6 +170,7 @@ func NewRouter(container *AppContainer) *mux.Router {
 	authSubrouter.Handle("/roles/{ROLE_ID}", adminOnly(http.HandlerFunc(container.RBACHandler.DeleteRoleHandler))).Methods(http.MethodDelete)
 	authSubrouter.Handle("/users/{USER_ID}/grants", adminOnly(http.HandlerFunc(container.RBACHandler.GetUserGrantsHandler))).Methods(http.MethodGet)
 	authSubrouter.Handle("/users/{USER_ID}/grants", adminOnly(http.HandlerFunc(container.RBACHandler.SetUserGrantsHandler))).Methods(http.MethodPut)
+	authSubrouter.Handle("/users/grants/summary", adminOnly(http.HandlerFunc(container.RBACHandler.GetGrantSummaryHandler))).Methods(http.MethodGet)
 	authSubrouter.HandleFunc("/me/permissions", container.RBACHandler.GetMyPermissionsHandler).Methods(http.MethodGet)
 
 	// Apps management router. Creating an app is global administration and

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -131,7 +131,7 @@ func NewRouter(container *AppContainer) *mux.Router {
 	// non-admin routes share path prefixes.
 	adminOnly := middleware.NewAdminMiddleware(container.UserRepo)
 	requirePermission := func(perm rbac.Permission) mux.MiddlewareFunc {
-		return rbac.RequirePermission(container.RBACService, container.UserRepo, perm)
+		return rbac.RequirePermission(container.RBACService, perm)
 	}
 
 	// Current account
@@ -190,6 +190,11 @@ func NewRouter(container *AppContainer) *mux.Router {
 	appAuthSubrouter := authSubrouter.PathPrefix("/apps/{APP_ID}").Subrouter()
 	appAuthSubrouter.StrictSlash(true)
 	appAuthSubrouter.Use(middleware.AppResolverMiddleware(container.AppRepo))
+	// After the resolver: enterprise visibility. While roles are enforced, a
+	// member without a grant on this app gets the same 404 as an unknown id,
+	// on reads and mutations alike. Validated CLI credentials pass through on
+	// their context marker.
+	appAuthSubrouter.Use(rbac.RequireAppVisible(container.RBACService))
 	appAuthSubrouter.HandleFunc("/", container.AppHandler.GetAppHandler).Methods(http.MethodGet)
 	appAuthSubrouter.Handle("/branches", requirePermission(rbac.PermBranchCreate)(http.HandlerFunc(container.BranchHandler.CreateBranchHandler))).Methods(http.MethodPost)
 	appAuthSubrouter.Handle("/branches/{BRANCH}", requirePermission(rbac.PermBranchDelete)(http.HandlerFunc(container.BranchHandler.DeleteBranchHandler))).Methods(http.MethodDelete)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -150,6 +150,21 @@ func NewRouter(container *AppContainer) *mux.Router {
 	authSubrouter.Handle("/users/{USER_ID}", adminOnly(http.HandlerFunc(container.UsersHandler.UpdateUserHandler))).Methods(http.MethodPatch)
 	authSubrouter.Handle("/users/{USER_ID}", adminOnly(http.HandlerFunc(container.UsersHandler.DeleteUserHandler))).Methods(http.MethodDelete)
 
+	// Enterprise user roles & per-app grants (control-plane only). Managing
+	// who can do what is an administration surface, so every route is
+	// admin-only; the license gate lives in the service (reads work without a
+	// license so the dashboard can show dormant grants, writes refuse).
+	// /me/permissions is the one exception: every signed-in account may ask
+	// what it is allowed to do — display support, the middlewares re-check
+	// every mutation anyway.
+	authSubrouter.Handle("/roles", adminOnly(http.HandlerFunc(container.RBACHandler.ListRolesHandler))).Methods(http.MethodGet)
+	authSubrouter.Handle("/roles", adminOnly(http.HandlerFunc(container.RBACHandler.CreateRoleHandler))).Methods(http.MethodPost)
+	authSubrouter.Handle("/roles/{ROLE_ID}", adminOnly(http.HandlerFunc(container.RBACHandler.UpdateRoleHandler))).Methods(http.MethodPut)
+	authSubrouter.Handle("/roles/{ROLE_ID}", adminOnly(http.HandlerFunc(container.RBACHandler.DeleteRoleHandler))).Methods(http.MethodDelete)
+	authSubrouter.Handle("/users/{USER_ID}/grants", adminOnly(http.HandlerFunc(container.RBACHandler.GetUserGrantsHandler))).Methods(http.MethodGet)
+	authSubrouter.Handle("/users/{USER_ID}/grants", adminOnly(http.HandlerFunc(container.RBACHandler.SetUserGrantsHandler))).Methods(http.MethodPut)
+	authSubrouter.HandleFunc("/me/permissions", container.RBACHandler.GetMyPermissionsHandler).Methods(http.MethodGet)
+
 	// Apps management router
 	authSubrouter.Handle("/apps", adminOnly(http.HandlerFunc(container.AppHandler.CreateAppHandler))).Methods(http.MethodPost)
 	authSubrouter.Handle("/apps/{APP_ID}", adminOnly(http.HandlerFunc(container.AppHandler.DeleteAppHandler))).Methods(http.MethodDelete)

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -5,6 +5,7 @@ import (
 	"expo-open-ota/config"
 	"expo-open-ota/ee/apikeyrestrictions"
 	"expo-open-ota/ee/licensing"
+	"expo-open-ota/ee/rbac"
 	"expo-open-ota/ee/sso"
 	"expo-open-ota/internal/bucket"
 	"expo-open-ota/internal/database"
@@ -30,6 +31,8 @@ type AppContainer struct {
 	ChannelHandler           *dashhandlers.ChannelHandler
 	ExpoProtocolHandler      *handlers.ExpoProtocolHandler
 	LicenseHandler           *licensing.LicenseHandler
+	RBACHandler              *rbac.RBACHandler
+	RBACService              *rbac.RBACService
 	RollbackHandler          *handlers.RollbackHandler
 	RolloutHandler           *dashhandlers.RolloutHandler
 	SettingsHandler          *dashhandlers.SettingsHandler
@@ -76,6 +79,9 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	// And again: per-key access restrictions and branch protection are an
 	// enterprise feature backed by the database.
 	var apiKeyRestrictionRepo apikeyrestrictions.ApiKeyRestrictionRepository
+	// User roles and per-app grants (ee/rbac) live in the database too; nil
+	// keeps the whole feature on the community fallback.
+	var rbacRepo rbac.RBACRepository
 
 	cleanup := func() {}
 	dbUrl := config.GetDBURL()
@@ -106,6 +112,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		licenseRepo = licensing.NewPostgresLicenseStore(dbEngine)
 		ssoRepo = sso.NewPostgresSSOStore(dbEngine)
 		apiKeyRestrictionRepo = apikeyrestrictions.NewPostgresApiKeyRestrictionStore(dbEngine)
+		rbacRepo = rbac.NewPostgresRBACStore(dbEngine)
 		branchRepo = store.NewPostgresBranchStore(dbEngine)
 		channelRepo = store.NewPostgresChannelStore(dbEngine)
 		updateRepo = store.NewPostgresUpdateStore(dbEngine)
@@ -135,6 +142,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	licenseService.StartSync(ctx, 30*time.Second)
 
 	apiKeyRestrictionService := apikeyrestrictions.NewApiKeyRestrictionService(apiKeyRestrictionRepo)
+	rbacService := rbac.NewRBACService(rbacRepo)
 	dashboardAuthService := services.NewDashboardAuthService(userRepo)
 	// The restriction service doubles as the CLI access policy: every CLI
 	// request runs through its enforcement after authenticating.
@@ -166,6 +174,8 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		ChannelHandler:           dashhandlers.NewChannelHandler(channelService),
 		ExpoProtocolHandler:      handlers.NewExpoProtocolHandler(expoProtocolService),
 		LicenseHandler:           licensing.NewLicenseHandler(licenseService),
+		RBACHandler:              rbac.NewRBACHandler(rbacService, userRepo),
+		RBACService:              rbacService,
 		RepublishHandler:         handlers.NewRepublishHandler(cliAuthService, deploymentService),
 		RollbackHandler:          handlers.NewRollbackHandler(cliAuthService, deploymentService),
 		RolloutHandler:           dashhandlers.NewRolloutHandler(rolloutService, updateService),

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -142,7 +142,11 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	licenseService.StartSync(ctx, 30*time.Second)
 
 	apiKeyRestrictionService := apikeyrestrictions.NewApiKeyRestrictionService(apiKeyRestrictionRepo)
-	rbacService := rbac.NewRBACService(rbacRepo)
+	rbacService := rbac.NewRBACService(rbacRepo, userRepo)
+	// The community list handlers (apps, settings) receive this method as
+	// their AppVisibilityFilter: they filter what a member sees without their
+	// package ever importing ee/rbac.
+	visibleApps := rbacService.VisibleAppsForPrincipal
 	dashboardAuthService := services.NewDashboardAuthService(userRepo)
 	// The restriction service doubles as the CLI access policy: every CLI
 	// request runs through its enforcement after authenticating.
@@ -168,18 +172,18 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		CliAuthService:           cliAuthService,
 		ApiKeyHandler:            dashhandlers.NewApiKeyHandler(cliAuthService),
 		ApiKeyRestrictionHandler: apikeyrestrictions.NewApiKeyRestrictionHandler(apiKeyRestrictionService),
-		AppHandler:               dashhandlers.NewAppHandler(appService),
+		AppHandler:               dashhandlers.NewAppHandler(appService, visibleApps),
 		AppRepo:                  appRepo,
 		BranchHandler:            dashhandlers.NewBranchHandler(branchService),
 		ChannelHandler:           dashhandlers.NewChannelHandler(channelService),
 		ExpoProtocolHandler:      handlers.NewExpoProtocolHandler(expoProtocolService),
 		LicenseHandler:           licensing.NewLicenseHandler(licenseService),
-		RBACHandler:              rbac.NewRBACHandler(rbacService, userRepo),
+		RBACHandler:              rbac.NewRBACHandler(rbacService),
 		RBACService:              rbacService,
 		RepublishHandler:         handlers.NewRepublishHandler(cliAuthService, deploymentService),
 		RollbackHandler:          handlers.NewRollbackHandler(cliAuthService, deploymentService),
 		RolloutHandler:           dashhandlers.NewRolloutHandler(rolloutService, updateService),
-		SettingsHandler:          dashhandlers.NewSettingsHandler(appService, ssoService.Enabled),
+		SettingsHandler:          dashhandlers.NewSettingsHandler(appService, ssoService.Enabled, visibleApps),
 		SSOHandler:               sso.NewSSOHandler(ssoService),
 		UpdateHandler:            dashhandlers.NewUpdateHandler(updateService),
 		UploadHandler:            handlers.NewUploadHandler(cliAuthService, deploymentService),

--- a/internal/store/branch_postgres.go
+++ b/internal/store/branch_postgres.go
@@ -51,12 +51,19 @@ func (s *PostgresBranchStore) DeleteBranchByName(ctx context.Context, appId stri
 	if commandTag.RowsAffected() == 0 {
 		// The DELETE refuses protected branches inside the statement; a miss is
 		// either that refusal or a branch that does not exist. The follow-up
-		// read only picks the right error message.
+		// read picks the right error, and an infrastructure failure on that
+		// read must surface as such, not masquerade as a missing branch.
 		protected, protErr := s.engine.Queries.IsBranchProtected(ctx, pgdb.IsBranchProtectedParams{
 			AppID: pgAppID,
 			Name:  branchName,
 		})
-		if protErr == nil && protected {
+		if protErr != nil {
+			if database.IsNoRows(protErr) {
+				return &ErrResourceNotFound{Resource: "branch", Identifier: fmt.Sprintf("name: %s, appId: %s", branchName, appId)}
+			}
+			return fmt.Errorf("failed to check branch protection after a refused delete: %w", protErr)
+		}
+		if protected {
 			return &ErrBranchProtected{BranchName: branchName}
 		}
 		return &ErrResourceNotFound{Resource: "branch", Identifier: fmt.Sprintf("name: %s, appId: %s", branchName, appId)}

--- a/internal/store/branch_postgres.go
+++ b/internal/store/branch_postgres.go
@@ -49,6 +49,16 @@ func (s *PostgresBranchStore) DeleteBranchByName(ctx context.Context, appId stri
 		return err
 	}
 	if commandTag.RowsAffected() == 0 {
+		// The DELETE refuses protected branches inside the statement; a miss is
+		// either that refusal or a branch that does not exist. The follow-up
+		// read only picks the right error message.
+		protected, protErr := s.engine.Queries.IsBranchProtected(ctx, pgdb.IsBranchProtectedParams{
+			AppID: pgAppID,
+			Name:  branchName,
+		})
+		if protErr == nil && protected {
+			return &ErrBranchProtected{BranchName: branchName}
+		}
 		return &ErrResourceNotFound{Resource: "branch", Identifier: fmt.Sprintf("name: %s, appId: %s", branchName, appId)}
 	}
 	return nil

--- a/internal/store/branch_postgres_test.go
+++ b/internal/store/branch_postgres_test.go
@@ -1,0 +1,99 @@
+// Integration tests for the guarded branch delete: the "protected branches
+// cannot be deleted" rule is enforced inside the DELETE statement itself,
+// which the in-memory fakes cannot exercise. They need a real Postgres and
+// skip unless TEST_DATABASE_URL is set, e.g.:
+//
+//	docker run -d --name eoo-pg -e POSTGRES_PASSWORD=test -p 55432:5432 postgres:16-alpine
+//	TEST_DATABASE_URL="postgres://postgres:test@localhost:55432/postgres?sslmode=disable" go test ./internal/store/
+//
+// The package is store_test on purpose: an internal test would create an
+// import cycle (store -> database/postgres -> migrations -> store).
+package store_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"expo-open-ota/internal/database"
+	"expo-open-ota/internal/database/postgres"
+	"expo-open-ota/internal/database/postgres/pgdb"
+	"expo-open-ota/internal/store"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+func setupBranchStore(t *testing.T) (*store.PostgresBranchStore, *pgxpool.Pool) {
+	t.Helper()
+	dbURL := os.Getenv("TEST_DATABASE_URL")
+	if dbURL == "" {
+		// See the same guard in user_postgres_test.go: a skip in CI is a green
+		// job that ran none of these guarded queries.
+		if os.Getenv("CI") != "" {
+			t.Fatal("TEST_DATABASE_URL must be set in CI: these tests cover SQL that the in-memory fakes cannot reach")
+		}
+		t.Skip("TEST_DATABASE_URL not set — start a Postgres and set it to run the guarded-query tests")
+	}
+	// The seed migration fails fast on an empty database without the
+	// bootstrap pair.
+	t.Setenv("ADMIN_EMAIL", "seed-admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "Sup3rSecret!")
+	postgres.RunDBMigrations(dbURL)
+
+	pool, err := pgxpool.New(context.Background(), dbURL)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	return store.NewPostgresBranchStore(&database.Engine{Queries: pgdb.New(pool), DB: pool}), pool
+}
+
+func insertAppWithBranch(t *testing.T, pool *pgxpool.Pool, branchName string, protected bool) string {
+	t.Helper()
+	ctx := context.Background()
+	appId := uuid.NewString()
+	_, err := pool.Exec(ctx, "INSERT INTO apps (id, name) VALUES ($1, $2)", appId, "app-"+appId[:8])
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, "INSERT INTO branches (app_id, name, protected) VALUES ($1, $2, $3)", appId, branchName, protected)
+	require.NoError(t, err)
+	return appId
+}
+
+func branchExists(t *testing.T, pool *pgxpool.Pool, appId string, branchName string) bool {
+	t.Helper()
+	var exists bool
+	require.NoError(t, pool.QueryRow(context.Background(),
+		"SELECT EXISTS (SELECT 1 FROM branches WHERE app_id = $1 AND name = $2)", appId, branchName).Scan(&exists))
+	return exists
+}
+
+func TestDeleteBranchRefusesProtectedBranch(t *testing.T) {
+	branchStore, pool := setupBranchStore(t)
+	ctx := context.Background()
+
+	appId := insertAppWithBranch(t, pool, "production", true)
+
+	err := branchStore.DeleteBranchByName(ctx, appId, "production")
+	protectedErr := (*store.ErrBranchProtected)(nil)
+	require.True(t, errors.As(err, &protectedErr), "expected ErrBranchProtected, got %v", err)
+	require.True(t, branchExists(t, pool, appId, "production"), "the protected branch must survive the delete attempt")
+
+	// Lifting the protection unblocks the delete.
+	_, err = pool.Exec(ctx, "UPDATE branches SET protected = FALSE WHERE app_id = $1 AND name = $2", appId, "production")
+	require.NoError(t, err)
+	require.NoError(t, branchStore.DeleteBranchByName(ctx, appId, "production"))
+	require.False(t, branchExists(t, pool, appId, "production"))
+}
+
+func TestDeleteBranchStillReportsMissingBranch(t *testing.T) {
+	branchStore, pool := setupBranchStore(t)
+	ctx := context.Background()
+
+	appId := insertAppWithBranch(t, pool, "staging", false)
+
+	err := branchStore.DeleteBranchByName(ctx, appId, "does-not-exist")
+	notFoundErr := (*store.ErrResourceNotFound)(nil)
+	require.True(t, errors.As(err, &notFoundErr), "expected ErrResourceNotFound, got %v", err)
+	require.True(t, branchExists(t, pool, appId, "staging"))
+}

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -41,6 +41,14 @@ func (e *ErrBranchInActiveRollout) Error() string {
 	return fmt.Sprintf("cannot delete branch %q because it is serving an active rollout on the following channels: [%s]. Promote or revert these rollouts first.", e.BranchName, channelsList)
 }
 
+type ErrBranchProtected struct {
+	BranchName string
+}
+
+func (e *ErrBranchProtected) Error() string {
+	return fmt.Sprintf("cannot delete branch %q because it is protected. Remove its protection first.", e.BranchName)
+}
+
 type ErrChannelHasActiveRollout struct {
 	ChannelName string
 }


### PR DESCRIPTION
This pull request introduces several improvements to the dashboard application, primarily focused on enhancing role-based access control (RBAC) and user experience for app-scoped pages. The key changes include the introduction of a `RequiresApp` component to handle empty app states, integration of a new roles management page, and an improved user creation flow with direct role assignment. Additionally, a reusable `GrantsEditor` component is added for assigning roles and permissions to users.

**RBAC and Roles Management Enhancements:**

* Added a new `/roles` page, integrated into the sidebar and routing, for managing roles. (`apps/dashboard/src/App.tsx`, `apps/dashboard/src/components/app-sidebar.tsx`) [[1]](diffhunk://#diff-1f2d307449b13a083ae29e6755022141a01f879b12018c84b75256fb1ca62da7R18-R33) [[2]](diffhunk://#diff-1f2d307449b13a083ae29e6755022141a01f879b12018c84b75256fb1ca62da7R55-R71) [[3]](diffhunk://#diff-b219dcc8263fe4f09cb8c85f571fa443ed908f6188613ac2344d47fbeeb818edR15) [[4]](diffhunk://#diff-b219dcc8263fe4f09cb8c85f571fa443ed908f6188613ac2344d47fbeeb818edR201-R203)
* Introduced the `PermissionsProvider` to the app context, enabling RBAC features throughout the dashboard. (`apps/dashboard/src/App.tsx`) [[1]](diffhunk://#diff-1f2d307449b13a083ae29e6755022141a01f879b12018c84b75256fb1ca62da7R18-R33) [[2]](diffhunk://#diff-1f2d307449b13a083ae29e6755022141a01f879b12018c84b75256fb1ca62da7R55-R71)

**App-Scoped Page Experience:**

* Added the `RequiresApp` component, which wraps app-scoped pages (e.g., Updates, Channels, App Info, Tokens). When no apps are available, it displays a clear empty state with contextual messaging and a create app button for admins. (`apps/dashboard/src/components/RequiresApp.tsx`, `apps/dashboard/src/App.tsx`) [[1]](diffhunk://#diff-b18b2cb736ab2c43c26e9268a609d9110b45d1933e545c451250033242153140R1-R62) [[2]](diffhunk://#diff-1f2d307449b13a083ae29e6755022141a01f879b12018c84b75256fb1ca62da7R18-R33) [[3]](diffhunk://#diff-1f2d307449b13a083ae29e6755022141a01f879b12018c84b75256fb1ca62da7R55-R71)

**User Creation and Grants Assignment:**

* Updated the user creation modal to support direct assignment of roles and per-app permissions when RBAC is enabled. This uses the new `GrantsEditor` component, and handles errors if grant assignment fails after user creation. (`apps/dashboard/src/components/user-creation-modal.tsx`) [[1]](diffhunk://#diff-30e8782ee9b4f22be3609f69b15b92caae6b5a51e7802c6d97e219116d6c0260R4) [[2]](diffhunk://#diff-30e8782ee9b4f22be3609f69b15b92caae6b5a51e7802c6d97e219116d6c0260R18-R19) [[3]](diffhunk://#diff-30e8782ee9b4f22be3609f69b15b92caae6b5a51e7802c6d97e219116d6c0260R29-R44) [[4]](diffhunk://#diff-30e8782ee9b4f22be3609f69b15b92caae6b5a51e7802c6d97e219116d6c0260R56-R79) [[5]](diffhunk://#diff-30e8782ee9b4f22be3609f69b15b92caae6b5a51e7802c6d97e219116d6c0260L61-R94) [[6]](diffhunk://#diff-30e8782ee9b4f22be3609f69b15b92caae6b5a51e7802c6d97e219116d6c0260R145-R154)
* Added the `GrantsEditor` component for selecting apps, assigning roles, and customizing permissions per app during user creation or editing. (`apps/dashboard/src/ee/components/GrantsEditor.tsx`)

**Other:**

* Updated the social card image in `README.md` to use an SVG cover. (`README.md`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added enterprise RBAC for per-app roles, custom permission editing, and user role/grant management (including role sheets and a dedicated Roles page).
  - Introduced permission-aware “No app available” handling and added a Roles navigation link.
  - Added dashboard visibility filtering so members only see apps they can access.
- **Bug Fixes**
  - Protected branches can’t be deleted (clear conflict response).
  - Improved access control gating across app features based on fine-grained permissions.
- **Documentation**
  - Refreshed the README cover image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->