### PR TITLE
Fix concurrency issues in GCS and S3 bucket operations

### DIFF
--- a/internal/bucket/gcsBucket.go
+++ b/internal/bucket/gcsBucket.go
@@ -13,10 +13,10 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"cloud.google.com/go/storage"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/iterator"
 )
 
@@ -47,37 +47,37 @@ func (b *GCSBucket) DeleteUpdateFolder(appId, branch, runtimeVersion, updateId s
 		return err
 	}
 	prefix := b.prefixedKey(fmt.Sprintf("%s/%s/%s/%s/", appId, branch, runtimeVersion, updateId))
-	it := bh.Objects(ctx, &storage.Query{Prefix: prefix})
-	sem := make(chan struct{}, runtime.NumCPU())
-	var wg sync.WaitGroup
-	errCh := make(chan error, 16)
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(runtime.NumCPU())
+	it := bh.Objects(gctx, &storage.Query{Prefix: prefix})
+	var listErr error
 	for {
 		attrs, err := it.Next()
 		if err == iterator.Done {
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("failed to list objects: %w", err)
+			listErr = fmt.Errorf("failed to list objects: %w", err)
+			break
 		}
 		if attrs.Name == "" { // prefix entry
 			continue
 		}
-		wg.Add(1)
-		sem <- struct{}{}
-		go func(name string) {
-			defer wg.Done()
-			defer func() { <-sem }()
-			if err := bh.Object(name).Delete(ctx); err != nil {
-				errCh <- fmt.Errorf("failed to delete object %s: %w", name, err)
+		name := attrs.Name
+		g.Go(func() error {
+			if err := bh.Object(name).Delete(gctx); err != nil {
+				return fmt.Errorf("failed to delete object %s: %w", name, err)
 			}
-		}(attrs.Name)
+			return nil
+		})
 	}
-	wg.Wait()
-	close(errCh)
-	for e := range errCh {
-		if e != nil {
-			return e
-		}
+	// A worker error cancels gctx, which also aborts the listing above; the
+	// worker error is the interesting one, so report it first.
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	if listErr != nil {
+		return listErr
 	}
 	return nil
 }
@@ -277,18 +277,18 @@ func (b *GCSBucket) CreateUpdateFrom(previousUpdate *types.Update, newUpdateId s
 	sourcePrefix := b.prefixedKey(fmt.Sprintf("%s/%s/%s/%s/", previousUpdate.AppId, previousUpdate.Branch, previousUpdate.RuntimeVersion, previousUpdate.UpdateId))
 	targetPrefix := b.prefixedKey(fmt.Sprintf("%s/%s/%s/%s/", previousUpdate.AppId, previousUpdate.Branch, previousUpdate.RuntimeVersion, newUpdateId))
 
-	it := bh.Objects(ctx, &storage.Query{Prefix: sourcePrefix})
-	var wg sync.WaitGroup
-	errChan := make(chan error, 16)
-	sem := make(chan struct{}, runtime.NumCPU())
-
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(runtime.NumCPU())
+	it := bh.Objects(gctx, &storage.Query{Prefix: sourcePrefix})
+	var listErr error
 	for {
 		attrs, err := it.Next()
 		if err == iterator.Done {
 			break
 		}
 		if err != nil {
-			return nil, fmt.Errorf("failed to list objects: %w", err)
+			listErr = fmt.Errorf("failed to list objects: %w", err)
+			break
 		}
 		if attrs.Name == "" {
 			continue
@@ -300,24 +300,22 @@ func (b *GCSBucket) CreateUpdateFrom(previousUpdate *types.Update, newUpdateId s
 		src := attrs.Name
 		dst := targetPrefix + relPath
 
-		wg.Add(1)
-		go func(srcKey, dstKey string) {
-			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
-			cop := bh.Object(dstKey).CopierFrom(bh.Object(srcKey))
-			if _, err := cop.Run(ctx); err != nil {
-				errChan <- fmt.Errorf("copy %s -> %s: %w", srcKey, dstKey, err)
+		g.Go(func() error {
+			cop := bh.Object(dst).CopierFrom(bh.Object(src))
+			if _, err := cop.Run(gctx); err != nil {
+				return fmt.Errorf("copy %s -> %s: %w", src, dst, err)
 			}
-		}(src, dst)
+			return nil
+		})
 	}
 
-	wg.Wait()
-	close(errChan)
-	for e := range errChan {
-		if e != nil {
-			return nil, e
-		}
+	// A worker error cancels gctx, which also aborts the listing above; the
+	// worker error is the interesting one, so report it first.
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	if listErr != nil {
+		return nil, listErr
 	}
 
 	updateId, err := strconv.ParseInt(newUpdateId, 10, 64)

--- a/internal/bucket/s3Bucket.go
+++ b/internal/bucket/s3Bucket.go
@@ -13,12 +13,12 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"golang.org/x/sync/errgroup"
 )
 
 type S3Bucket struct {
@@ -329,14 +329,15 @@ func (b *S3Bucket) CreateUpdateFrom(previousUpdate *types.Update, newUpdateId st
 		Prefix: awssdk.String(sourcePrefix),
 	})
 
-	var wg sync.WaitGroup
-	errChan := make(chan error, 16)
-	sem := make(chan struct{}, runtime.NumCPU())
+	g, gctx := errgroup.WithContext(context.TODO())
+	g.SetLimit(runtime.NumCPU())
 
+	var listErr error
 	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(context.TODO())
+		page, err := paginator.NextPage(gctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list objects: %w", err)
+			listErr = fmt.Errorf("failed to list objects: %w", err)
+			break
 		}
 
 		for _, object := range page.Contents {
@@ -350,43 +351,37 @@ func (b *S3Bucket) CreateUpdateFrom(previousUpdate *types.Update, newUpdateId st
 			srcKey := key
 			dstKey := targetPrefix + relPath
 
-			wg.Add(1)
-			go func(srcKey, dstKey string) {
-				defer wg.Done()
-				sem <- struct{}{}
-				defer func() { <-sem }()
-
-				getObjOutput, err := s3Client.GetObject(context.TODO(), &s3.GetObjectInput{
+			g.Go(func() error {
+				getObjOutput, err := s3Client.GetObject(gctx, &s3.GetObjectInput{
 					Bucket: awssdk.String(b.BucketName),
 					Key:    awssdk.String(srcKey),
 				})
 				if err != nil {
-					errChan <- fmt.Errorf("error getting object %s: %w", srcKey, err)
-					return
+					return fmt.Errorf("error getting object %s: %w", srcKey, err)
 				}
 				defer getObjOutput.Body.Close()
 
-				_, err = s3Client.PutObject(context.TODO(), &s3.PutObjectInput{
+				_, err = s3Client.PutObject(gctx, &s3.PutObjectInput{
 					Bucket:        awssdk.String(b.BucketName),
 					Key:           awssdk.String(dstKey),
 					Body:          getObjOutput.Body,
 					ContentLength: getObjOutput.ContentLength,
 				})
 				if err != nil {
-					errChan <- fmt.Errorf("error putting object %s: %w", dstKey, err)
-					return
+					return fmt.Errorf("error putting object %s: %w", dstKey, err)
 				}
-			}(srcKey, dstKey)
+				return nil
+			})
 		}
 	}
 
-	wg.Wait()
-	close(errChan)
-
-	for e := range errChan {
-		if e != nil {
-			return nil, e
-		}
+	// A worker error cancels gctx, which also aborts the listing above; the
+	// worker error is the interesting one, so report it first.
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	if listErr != nil {
+		return nil, listErr
 	}
 
 	updateId, err := strconv.ParseInt(newUpdateId, 10, 64)

--- a/internal/handlers/republish_handler.go
+++ b/internal/handlers/republish_handler.go
@@ -6,7 +6,6 @@ import (
 	"expo-open-ota/internal/helpers"
 	"expo-open-ota/internal/services"
 	types2 "expo-open-ota/internal/types"
-	"fmt"
 	"log"
 	"net/http"
 
@@ -77,14 +76,12 @@ func (h *RepublishHandler) HandleRepublish(w http.ResponseWriter, r *http.Reques
 		}
 		var rErr *services.RepublishError
 		if errors.As(err, &rErr) {
-			fmt.Printf("[RequestID: %s] Republish error: %v", requestID, rErr)
+			log.Printf("[RequestID: %s] Republish error: %v", requestID, rErr)
 			http.Error(w, rErr.Message, rErr.Status)
 			return
-		} else {
-			fmt.Printf("[RequestID: %s] Unexpected error during republish: %v", requestID, err)
-			http.Error(w, "An unexpected error occurred during republish", http.StatusInternalServerError)
-			return
 		}
+		log.Printf("[RequestID: %s] Unexpected error during republish: %v", requestID, err)
+		http.Error(w, "An unexpected error occurred during republish", http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/handlers/republish_handler.go
+++ b/internal/handlers/republish_handler.go
@@ -6,6 +6,7 @@ import (
 	"expo-open-ota/internal/helpers"
 	"expo-open-ota/internal/services"
 	types2 "expo-open-ota/internal/types"
+	"fmt"
 	"log"
 	"net/http"
 
@@ -76,10 +77,14 @@ func (h *RepublishHandler) HandleRepublish(w http.ResponseWriter, r *http.Reques
 		}
 		var rErr *services.RepublishError
 		if errors.As(err, &rErr) {
+			fmt.Printf("[RequestID: %s] Republish error: %v", requestID, rErr)
 			http.Error(w, rErr.Message, rErr.Status)
 			return
+		} else {
+			fmt.Printf("[RequestID: %s] Unexpected error during republish: %v", requestID, err)
+			http.Error(w, "An unexpected error occurred during republish", http.StatusInternalServerError)
+			return
 		}
-		http.Error(w, "Error republishing update", http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
This pull request refactors the parallelization and error handling logic in the GCS and S3 bucket operations to use `errgroup` for better concurrency management and error propagation. It also improves error logging in the republish handler. The main themes are improved concurrency, error handling, and logging.

**Concurrency and Error Handling Improvements:**

* Refactored GCS bucket methods (`DeleteUpdateFolder`, `CreateUpdateFrom`) in `gcsBucket.go` to use `errgroup` instead of manual goroutine and channel management, simplifying the code and ensuring that errors are properly propagated and cancel ongoing operations. [[1]](diffhunk://#diff-9c04171846b870d6f57a6b765c301f254641fa2af8757115ce88c14593e110bbL16-R19) [[2]](diffhunk://#diff-9c04171846b870d6f57a6b765c301f254641fa2af8757115ce88c14593e110bbL50-R80) [[3]](diffhunk://#diff-9c04171846b870d6f57a6b765c301f254641fa2af8757115ce88c14593e110bbL280-R291) [[4]](diffhunk://#diff-9c04171846b870d6f57a6b765c301f254641fa2af8757115ce88c14593e110bbL303-R318)
* Refactored S3 bucket method (`CreateUpdateFrom`) in `s3Bucket.go` to use `errgroup` for managing concurrent copy operations, replacing manual goroutine, sync, and error channel logic. [[1]](diffhunk://#diff-9702883cf6afa050fd97174f6680bc27a35de0df6769d3e41c190c7e64fc0f5fL16-R21) [[2]](diffhunk://#diff-9702883cf6afa050fd97174f6680bc27a35de0df6769d3e41c190c7e64fc0f5fL332-R340) [[3]](diffhunk://#diff-9702883cf6afa050fd97174f6680bc27a35de0df6769d3e41c190c7e64fc0f5fL353-R384)

**Logging and Error Reporting:**

* Enhanced error logging in `HandleRepublish` in `republish_handler.go` to include request IDs and distinguish between expected and unexpected errors, improving observability and debugging. [[1]](diffhunk://#diff-d5cd441ab7a88fc37f99ab1831a341dcd3d94916c58273352c8d84c0bb6caa7fR9) [[2]](diffhunk://#diff-d5cd441ab7a88fc37f99ab1831a341dcd3d94916c58273352c8d84c0bb6caa7fR80-L82)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of cloud storage copy/delete operations by promptly canceling remaining work when an error occurs, reducing inconsistent partial updates.
  * Improved republish error handling: known republish failures now return the provided message and status, while unexpected errors return a consistent generic 500 response.
  * Added more detailed logging for republish failures to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->