### PR TITLE
feat: implement advisory lock for PostgreSQL migrations to prevent race conditions

### DIFF
--- a/ee/rbac/main_test.go
+++ b/ee/rbac/main_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package rbac
+
+import (
+	"os"
+	"testing"
+
+	"expo-open-ota/internal/database/postgres/pgtest"
+)
+
+// The Postgres-backed tests in this package share TEST_DATABASE_URL with
+// internal/store and ee/sso; pgtest serializes the packages so their wholesale
+// cleanups cannot wipe each other's rows.
+func TestMain(m *testing.M) {
+	os.Exit(pgtest.RunSerialized(m))
+}

--- a/ee/sso/main_test.go
+++ b/ee/sso/main_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package sso
+
+import (
+	"os"
+	"testing"
+
+	"expo-open-ota/internal/database/postgres/pgtest"
+)
+
+// The Postgres-backed tests in this package share TEST_DATABASE_URL with
+// internal/store and ee/rbac; pgtest serializes the packages so their wholesale
+// cleanups cannot wipe each other's rows.
+func TestMain(m *testing.M) {
+	os.Exit(pgtest.RunSerialized(m))
+}

--- a/internal/database/postgres/migrations.go
+++ b/internal/database/postgres/migrations.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	_ "expo-open-ota/internal/database/postgres/migrations"
 	"log"
+	"time"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/pressly/goose/v3"
@@ -16,6 +17,11 @@ var embedMigrations embed.FS
 
 // Arbitrary app-wide id for the Postgres advisory lock that serializes migrators.
 const migrationAdvisoryLockID = 823672941
+
+// Upper bound on waiting for the advisory lock: long enough for a slow leader
+// to finish its migrations, short enough that a stuck lock surfaces as a crash
+// instead of a silent hang.
+const migrationLockTimeout = 5 * time.Minute
 
 func RunDBMigrations(dbURL string) {
 	db, err := sql.Open("pgx", dbURL)
@@ -48,7 +54,9 @@ func RunDBMigrations(dbURL string) {
 	if _, err := conn.ExecContext(lockCtx, "SELECT pg_advisory_lock($1)", migrationAdvisoryLockID); err != nil {
 		log.Fatalf("❌ [DATABASE] Failed to acquire migration advisory lock: %v", err)
 	}
-	defer conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", migrationAdvisoryLockID)
+	// Background, not lockCtx: the unlock runs after goose.Up, possibly past the
+	// timeout. A failed unlock is harmless anyway, conn.Close releases the lock.
+	defer conn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", migrationAdvisoryLockID)
 
 	// WithAllowMissing applies migrations whose version is lower than the one already
 	// recorded in the database. Parallel PRs get merged out of timestamp order, so a

--- a/internal/database/postgres/migrations.go
+++ b/internal/database/postgres/migrations.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"context"
 	"database/sql"
 	"embed"
 	_ "expo-open-ota/internal/database/postgres/migrations"
@@ -12,6 +13,9 @@ import (
 
 //go:embed migrations/*
 var embedMigrations embed.FS
+
+// Arbitrary app-wide id for the Postgres advisory lock that serializes migrators.
+const migrationAdvisoryLockID = 823672941
 
 func RunDBMigrations(dbURL string) {
 	db, err := sql.Open("pgx", dbURL)
@@ -27,6 +31,23 @@ func RunDBMigrations(dbURL string) {
 	}
 
 	log.Println("🔧 [DATABASE] Checking and running PostgreSQL schema migrations...")
+
+	// Several migrators can run at once: parallel test packages sharing one
+	// TEST_DATABASE_URL, or multiple server replicas booting simultaneously.
+	// Without a lock they race inside goose.Up (duplicate CREATE TABLE hits
+	// pg_type_typname_nsp_index) and the loser dies on Fatalf. An advisory
+	// lock serializes them: the first applies, the rest wait then no-op.
+	// Advisory locks are session-scoped, so hold a dedicated connection.
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		log.Fatalf("❌ [DATABASE] Failed to acquire connection for migration lock: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", migrationAdvisoryLockID); err != nil {
+		log.Fatalf("❌ [DATABASE] Failed to acquire migration advisory lock: %v", err)
+	}
+	defer conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", migrationAdvisoryLockID)
 
 	// WithAllowMissing applies migrations whose version is lower than the one already
 	// recorded in the database. Parallel PRs get merged out of timestamp order, so a

--- a/internal/database/postgres/migrations.go
+++ b/internal/database/postgres/migrations.go
@@ -38,13 +38,14 @@ func RunDBMigrations(dbURL string) {
 	// pg_type_typname_nsp_index) and the loser dies on Fatalf. An advisory
 	// lock serializes them: the first applies, the rest wait then no-op.
 	// Advisory locks are session-scoped, so hold a dedicated connection.
-	ctx := context.Background()
-	conn, err := db.Conn(ctx)
+	lockCtx, cancel := context.WithTimeout(context.Background(), migrationLockTimeout)
+	defer cancel()
+	conn, err := db.Conn(lockCtx)
 	if err != nil {
 		log.Fatalf("❌ [DATABASE] Failed to acquire connection for migration lock: %v", err)
 	}
 	defer conn.Close()
-	if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", migrationAdvisoryLockID); err != nil {
+	if _, err := conn.ExecContext(lockCtx, "SELECT pg_advisory_lock($1)", migrationAdvisoryLockID); err != nil {
 		log.Fatalf("❌ [DATABASE] Failed to acquire migration advisory lock: %v", err)
 	}
 	defer conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", migrationAdvisoryLockID)

--- a/internal/database/postgres/pgtest/pgtest.go
+++ b/internal/database/postgres/pgtest/pgtest.go
@@ -1,0 +1,61 @@
+// Package pgtest serializes the test packages that share TEST_DATABASE_URL.
+//
+// go test ./... runs packages in parallel, and the Postgres-backed store tests
+// (internal/store, ee/rbac, ee/sso) all point at the same database. Their
+// cleanups are deliberately wholesale (DELETE FROM users) and their assertions
+// global (admin counts), so two packages running at once wipe each other's
+// rows mid-test. Every package that touches TEST_DATABASE_URL must declare:
+//
+//	func TestMain(m *testing.M) { os.Exit(pgtest.RunSerialized(m)) }
+package pgtest
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// Must differ from the migration lock id in the parent package: this lock is
+// held for a whole package run, the migration one only around goose.Up.
+const packageAdvisoryLockID = 823672942
+
+// Upper bound on waiting for the other test packages to finish.
+const packageLockTimeout = 5 * time.Minute
+
+// RunSerialized runs the package's tests under a Postgres advisory lock shared
+// by every test package that uses TEST_DATABASE_URL, so at most one of them
+// touches the database at a time. Without the env var it just runs the tests
+// (they skip or fail on their own).
+func RunSerialized(m *testing.M) int {
+	dbURL := os.Getenv("TEST_DATABASE_URL")
+	if dbURL == "" {
+		return m.Run()
+	}
+
+	db, err := sql.Open("pgx", dbURL)
+	if err != nil {
+		log.Fatalf("pgtest: failed to open connection for the package lock: %v", err)
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), packageLockTimeout)
+	defer cancel()
+
+	// The lock is session-scoped, so it must live on a dedicated connection
+	// pinned for the whole run; Postgres releases it when the process exits.
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		log.Fatalf("pgtest: failed to acquire connection for the package lock: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", packageAdvisoryLockID); err != nil {
+		log.Fatalf("pgtest: failed to acquire the package lock: %v", err)
+	}
+
+	return m.Run()
+}

--- a/internal/store/main_test.go
+++ b/internal/store/main_test.go
@@ -1,0 +1,15 @@
+package store_test
+
+import (
+	"os"
+	"testing"
+
+	"expo-open-ota/internal/database/postgres/pgtest"
+)
+
+// The Postgres-backed tests in this package share TEST_DATABASE_URL with
+// ee/rbac and ee/sso; pgtest serializes the packages so their wholesale
+// cleanups cannot wipe each other's rows.
+func TestMain(m *testing.M) {
+	os.Exit(pgtest.RunSerialized(m))
+}


### PR DESCRIPTION
This pull request improves the reliability of database migrations by adding a PostgreSQL advisory lock to serialize concurrent migration attempts. This prevents race conditions when multiple processes or test packages attempt to run migrations at the same time.

**Database migration reliability:**

* Added a constant `migrationAdvisoryLockID` and logic to acquire a session-scoped PostgreSQL advisory lock before running migrations in `RunDBMigrations`, ensuring that only one migrator runs at a time and others wait or no-op, preventing duplicate migration errors. [[1]](diffhunk://#diff-a919bab54a6a563f4767b3a277aabba65f343972d5204fff79c5ca3bf173e1e9R17-R19) [[2]](diffhunk://#diff-a919bab54a6a563f4767b3a277aabba65f343972d5204fff79c5ca3bf173e1e9R35-R51)
* Imported `context` to support advisory lock acquisition with context-aware database connections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration reliability by preventing concurrent migration runs via a database-level lock.
  * Migration execution now waits for any in-progress migration to finish, reducing race conditions and failures.
* **Tests**
  * Added serialized execution for Postgres-backed tests to prevent shared test databases from being cleaned up by other test suites mid-run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->