### PR TITLE
identity: schema + store

### DIFF
--- a/ee/identity/identity.go
+++ b/ee/identity/identity.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+// Package identity maps expo-eas-client install UUIDs to operator-defined
+// metadata (userId, tenant, ...), fed by `identify` log events on the observe
+// ingestion route. The dashboard "Identity" section declares which metadata
+// keys are accepted and with which type; everything else coming from the wire
+// is dropped, so hostile payloads are bounded by construction.
+//
+// The package is EE-licensed but NOT license-gated: the feature works on
+// community deployments too.
+package identity
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"time"
+	"unicode/utf8"
+)
+
+type ValueType string
+
+const (
+	ValueTypeString  ValueType = "string"
+	ValueTypeNumber  ValueType = "number"
+	ValueTypeBoolean ValueType = "boolean"
+)
+
+const (
+	// DefaultMaxLength bounds string values when the operator does not pick a
+	// limit; MaxLengthCeiling bounds what the operator may pick. Identity
+	// metadata is lookup keys, not payloads.
+	DefaultMaxLength = 256
+	MaxLengthCeiling = 1024
+	// MaxSchemaKeys caps the allowlist size. Every declared key multiplies the
+	// worst-case device row that the unauthenticated wire can fill, so the
+	// operator-side bound keeps hostile identifies at ~tens of KB per row
+	// instead of megabytes.
+	MaxSchemaKeys = 100
+)
+
+// Key names stay path-friendly and unambiguous: they end up in API routes,
+// autocomplete queries and JSONB lookups.
+var keyPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$`)
+
+// KeySpec is one allowlisted metadata key as declared in the dashboard.
+type KeySpec struct {
+	Key       string    `json:"key"`
+	Type      ValueType `json:"type"`
+	MaxLength int       `json:"maxLength"`
+}
+
+// Schema is an app's full allowlist, keyed by metadata key.
+type Schema map[string]KeySpec
+
+func ValidateKeySpec(spec KeySpec) error {
+	if !keyPattern.MatchString(spec.Key) {
+		return fmt.Errorf("invalid metadata key %q: must match %s", spec.Key, keyPattern.String())
+	}
+	switch spec.Type {
+	case ValueTypeString, ValueTypeNumber, ValueTypeBoolean:
+	default:
+		return fmt.Errorf("invalid value type %q for key %q: must be string, number or boolean", spec.Type, spec.Key)
+	}
+	if spec.MaxLength < 1 || spec.MaxLength > MaxLengthCeiling {
+		return fmt.Errorf("invalid max length %d for key %q: must be in [1, %d]", spec.MaxLength, spec.Key, MaxLengthCeiling)
+	}
+	return nil
+}
+
+// Sanitize filters raw wire metadata down to the allowlist. A value survives
+// only when its key is declared and its JSON type matches the declared type;
+// violations drop the single entry, never the whole identify. Oversized
+// strings are dropped rather than truncated (a truncated userId would corrupt
+// the mapping silently). The dropped keys come back for counters and logs.
+//
+// Client-side validation (expo-app-metrics caps) is irrelevant here: anything
+// can be forged with a plain HTTP request, this is the enforcement point.
+func (s Schema) Sanitize(raw map[string]any) (map[string]any, []string) {
+	sanitized := make(map[string]any, len(raw))
+	var dropped []string
+	for key, value := range raw {
+		spec, declared := s[key]
+		if !declared {
+			dropped = append(dropped, key)
+			continue
+		}
+		coerced, ok := coerceValue(spec, value)
+		if !ok {
+			dropped = append(dropped, key)
+			continue
+		}
+		sanitized[key] = coerced
+	}
+	return sanitized, dropped
+}
+
+// coerceValue validates one raw value against its spec. Numbers normalize to
+// float64 (what JSON decoding produces anyway); NaN and infinities are
+// dropped because they do not survive json.Marshal into JSONB.
+func coerceValue(spec KeySpec, value any) (any, bool) {
+	switch spec.Type {
+	case ValueTypeString:
+		str, ok := value.(string)
+		if !ok || utf8.RuneCountInString(str) > spec.MaxLength {
+			return nil, false
+		}
+		return str, true
+	case ValueTypeNumber:
+		num, ok := toFloat(value)
+		if !ok || math.IsNaN(num) || math.IsInf(num, 0) {
+			return nil, false
+		}
+		return num, true
+	case ValueTypeBoolean:
+		b, ok := value.(bool)
+		if !ok {
+			return nil, false
+		}
+		return b, true
+	}
+	return nil, false
+}
+
+func toFloat(value any) (float64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case uint32:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	case json.Number:
+		// The future ingest path may decode with UseNumber(); support it now
+		// so numbers do not silently start dropping when it does.
+		f, err := v.Float64()
+		return f, err == nil
+	}
+	return 0, false
+}
+
+// RenderValue is the canonical text form of a metadata value, used as the
+// identity_value_stats key. Integral floats render without a decimal part so
+// 42 and 42.0 count as the same value.
+func RenderValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case bool:
+		return strconv.FormatBool(v)
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	default:
+		// Unreachable after Sanitize; fmt keeps a debuggable fallback.
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// Device is one install of an app and what we know about it. Timestamps stay
+// time.Time here; formatting belongs to the handlers (same split as ee/audit).
+type Device struct {
+	AppID       string
+	EASClientID string
+	Metadata    map[string]any
+	CountryCode *string
+	City        *string
+	Lat         *float64
+	Lng         *float64
+	FirstSeenAt time.Time
+	LastSeenAt  time.Time
+}
+
+// Geo is an optional enrichment resolved from the request IP (GeoLite2,
+// city-level accuracy: lat/lng is a city centroid, not a device position).
+// Fields are per-field optional because partial resolutions are the norm
+// (country without city is very common); a nil field never overwrites a
+// previously known value, only a present one does.
+type Geo struct {
+	CountryCode *string
+	City        *string
+	Lat         *float64
+	Lng         *float64
+}
+
+// ValueCount is one autocomplete suggestion for a metadata key.
+type ValueCount struct {
+	Value       string `json:"value"`
+	DeviceCount int64  `json:"deviceCount"`
+}
+
+// ApplyResult reports what an identify did: the device after merge, and which
+// incoming keys were rejected by the allowlist.
+type ApplyResult struct {
+	Device      Device
+	DroppedKeys []string
+}

--- a/ee/identity/identity_test.go
+++ b/ee/identity/identity_test.go
@@ -5,6 +5,7 @@
 package identity
 
 import (
+	"encoding/json"
 	"math"
 	"strings"
 	"testing"
@@ -81,6 +82,16 @@ func TestSanitize(t *testing.T) {
 		sanitized, dropped := schema.Sanitize(map[string]any{"userId": "éèêëàâüö"})
 		require.Empty(t, dropped)
 		require.Equal(t, "éèêëàâüö", sanitized["userId"])
+	})
+
+	t.Run("json.Number and unsigned ints coerce like numbers", func(t *testing.T) {
+		sanitized, dropped := schema.Sanitize(map[string]any{"seats": json.Number("42")})
+		require.Empty(t, dropped)
+		require.Equal(t, float64(42), sanitized["seats"])
+		sanitized, _ = schema.Sanitize(map[string]any{"seats": uint64(7)})
+		require.Equal(t, float64(7), sanitized["seats"])
+		_, dropped = schema.Sanitize(map[string]any{"seats": json.Number("not-a-number")})
+		require.Equal(t, []string{"seats"}, dropped)
 	})
 
 	t.Run("non-finite numbers are dropped", func(t *testing.T) {

--- a/ee/identity/identity_test.go
+++ b/ee/identity/identity_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package identity
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateKeySpec(t *testing.T) {
+	valid := []KeySpec{
+		{Key: "userId", Type: ValueTypeString, MaxLength: 256},
+		{Key: "is_internal", Type: ValueTypeBoolean, MaxLength: 1},
+		{Key: "org.tier-2", Type: ValueTypeNumber, MaxLength: 64},
+	}
+	for _, spec := range valid {
+		require.NoError(t, ValidateKeySpec(spec), spec.Key)
+	}
+
+	invalid := []KeySpec{
+		{Key: "", Type: ValueTypeString, MaxLength: 10},
+		{Key: "_leading", Type: ValueTypeString, MaxLength: 10},
+		{Key: "has space", Type: ValueTypeString, MaxLength: 10},
+		{Key: strings.Repeat("k", 65), Type: ValueTypeString, MaxLength: 10},
+		{Key: "ok", Type: ValueType("uuid"), MaxLength: 10},
+		{Key: "ok", Type: ValueTypeString, MaxLength: 0},
+		{Key: "ok", Type: ValueTypeString, MaxLength: MaxLengthCeiling + 1},
+	}
+	for _, spec := range invalid {
+		require.Error(t, ValidateKeySpec(spec), "%+v", spec)
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	schema := Schema{
+		"userId":     {Key: "userId", Type: ValueTypeString, MaxLength: 8},
+		"seats":      {Key: "seats", Type: ValueTypeNumber, MaxLength: DefaultMaxLength},
+		"isInternal": {Key: "isInternal", Type: ValueTypeBoolean, MaxLength: DefaultMaxLength},
+	}
+
+	sanitized, dropped := schema.Sanitize(map[string]any{
+		"userId":     "user_42",
+		"seats":      int64(12),
+		"isInternal": true,
+		// Undeclared key: the 50k-keys attack lands here and dies here.
+		"junk": "x",
+		// Declared key, wrong JSON type.
+		"seats2":     "12",
+		"userIdLong": "way too long for the limit",
+	})
+	require.Equal(t, map[string]any{
+		"userId":     "user_42",
+		"seats":      float64(12),
+		"isInternal": true,
+	}, sanitized)
+	require.ElementsMatch(t, []string{"junk", "seats2", "userIdLong"}, dropped)
+
+	t.Run("type mismatches drop the entry only", func(t *testing.T) {
+		sanitized, dropped := schema.Sanitize(map[string]any{
+			"userId":     42,                       // number into string
+			"seats":      "12",                     // string into number
+			"isInternal": "true",                   // string into boolean
+			"junk":       map[string]any{"a": "b"}, // containers never pass
+		})
+		require.Empty(t, sanitized)
+		require.Len(t, dropped, 4)
+	})
+
+	t.Run("oversized strings are dropped, not truncated", func(t *testing.T) {
+		sanitized, dropped := schema.Sanitize(map[string]any{"userId": "123456789"})
+		require.Empty(t, sanitized)
+		require.Equal(t, []string{"userId"}, dropped)
+	})
+
+	t.Run("max length counts runes, not bytes", func(t *testing.T) {
+		sanitized, dropped := schema.Sanitize(map[string]any{"userId": "éèêëàâüö"})
+		require.Empty(t, dropped)
+		require.Equal(t, "éèêëàâüö", sanitized["userId"])
+	})
+
+	t.Run("non-finite numbers are dropped", func(t *testing.T) {
+		for _, v := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+			sanitized, dropped := schema.Sanitize(map[string]any{"seats": v})
+			require.Empty(t, sanitized)
+			require.Equal(t, []string{"seats"}, dropped)
+		}
+	})
+
+	t.Run("null and nil never pass", func(t *testing.T) {
+		sanitized, dropped := schema.Sanitize(map[string]any{"userId": nil})
+		require.Empty(t, sanitized)
+		require.Equal(t, []string{"userId"}, dropped)
+	})
+
+	t.Run("empty schema drops everything", func(t *testing.T) {
+		sanitized, dropped := Schema{}.Sanitize(map[string]any{"userId": "x"})
+		require.Empty(t, sanitized)
+		require.Equal(t, []string{"userId"}, dropped)
+	})
+}
+
+func TestRenderValue(t *testing.T) {
+	require.Equal(t, "acme", RenderValue("acme"))
+	require.Equal(t, "true", RenderValue(true))
+	require.Equal(t, "false", RenderValue(false))
+	// Integral floats render without a decimal part: 42 identified from JS and
+	// 42.0 re-decoded from JSONB must count as the same value.
+	require.Equal(t, "42", RenderValue(float64(42)))
+	require.Equal(t, "42.5", RenderValue(42.5))
+}

--- a/ee/identity/store_postgres.go
+++ b/ee/identity/store_postgres.go
@@ -10,6 +10,7 @@ import (
 	"expo-open-ota/internal/database"
 	"expo-open-ota/internal/database/postgres/pgdb"
 	"fmt"
+	"sort"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -23,6 +24,9 @@ func NewPostgresIdentityStore(engine *database.Engine) *PostgresIdentityStore {
 	return &PostgresIdentityStore{engine: engine}
 }
 
+// toPgUUID differs from store.ToPgUUID on purpose: identity ids come from the
+// unauthenticated wire, so a parse failure must surface as an error the caller
+// can act on, not as a zero UUID silently written to the database.
 func toPgUUID(id string) (pgtype.UUID, error) {
 	parsed, err := uuid.Parse(id)
 	if err != nil {
@@ -33,6 +37,14 @@ func toPgUUID(id string) (pgtype.UUID, error) {
 
 func specFromRow(row pgdb.IdentitySchema) KeySpec {
 	return KeySpec{Key: row.Key, Type: ValueType(row.ValueType), MaxLength: int(row.MaxLength)}
+}
+
+func schemaFromRows(rows []pgdb.IdentitySchema) Schema {
+	schema := make(Schema, len(rows))
+	for _, row := range rows {
+		schema[row.Key] = specFromRow(row)
+	}
+	return schema
 }
 
 func deviceFromRow(row pgdb.DeviceIdentity) (Device, error) {
@@ -50,8 +62,8 @@ func deviceFromRow(row pgdb.DeviceIdentity) (Device, error) {
 		City:        row.City,
 		Lat:         row.Lat,
 		Lng:         row.Lng,
-		FirstSeenAt: row.FirstSeenAt.Time.UTC().Format("2006-01-02T15:04:05.000Z"),
-		LastSeenAt:  row.LastSeenAt.Time.UTC().Format("2006-01-02T15:04:05.000Z"),
+		FirstSeenAt: row.FirstSeenAt.Time,
+		LastSeenAt:  row.LastSeenAt.Time,
 	}, nil
 }
 
@@ -67,11 +79,7 @@ func (s *PostgresIdentityStore) GetSchema(ctx context.Context, appID string) (Sc
 	if err != nil {
 		return nil, fmt.Errorf("listing identity schema: %w", err)
 	}
-	schema := make(Schema, len(rows))
-	for _, row := range rows {
-		schema[row.Key] = specFromRow(row)
-	}
-	return schema, nil
+	return schemaFromRows(rows), nil
 }
 
 func (s *PostgresIdentityStore) UpsertSchemaKey(ctx context.Context, appID string, spec KeySpec) (KeySpec, error) {
@@ -85,16 +93,35 @@ func (s *PostgresIdentityStore) UpsertSchemaKey(ctx context.Context, appID strin
 	if err != nil {
 		return KeySpec{}, err
 	}
-	row, err := s.engine.Queries.UpsertIdentitySchemaKey(ctx, pgdb.UpsertIdentitySchemaKeyParams{
-		AppID:     appUUID,
-		Key:       spec.Key,
-		ValueType: string(spec.Type),
-		MaxLength: int32(spec.MaxLength),
+
+	var saved KeySpec
+	err = s.engine.WithTx(ctx, func(q *pgdb.Queries) error {
+		// The key-count cap runs in the same transaction as the insert so two
+		// concurrent declarations cannot both slip under the limit. Updating
+		// an already-declared key is always allowed, even at the cap.
+		existing, err := q.ListIdentitySchemaKeys(ctx, appUUID)
+		if err != nil {
+			return fmt.Errorf("listing identity schema: %w", err)
+		}
+		if _, declared := schemaFromRows(existing)[spec.Key]; !declared && len(existing) >= MaxSchemaKeys {
+			return fmt.Errorf("identity schema is limited to %d keys per app", MaxSchemaKeys)
+		}
+		row, err := q.UpsertIdentitySchemaKey(ctx, pgdb.UpsertIdentitySchemaKeyParams{
+			AppID:     appUUID,
+			Key:       spec.Key,
+			ValueType: string(spec.Type),
+			MaxLength: int32(spec.MaxLength),
+		})
+		if err != nil {
+			return fmt.Errorf("upserting identity schema key: %w", err)
+		}
+		saved = specFromRow(row)
+		return nil
 	})
 	if err != nil {
-		return KeySpec{}, fmt.Errorf("upserting identity schema key: %w", err)
+		return KeySpec{}, err
 	}
-	return specFromRow(row), nil
+	return saved, nil
 }
 
 // DeleteSchemaKey removes a key from the allowlist and wipes its autocomplete
@@ -106,24 +133,35 @@ func (s *PostgresIdentityStore) DeleteSchemaKey(ctx context.Context, appID strin
 	if err != nil {
 		return false, err
 	}
-	tx, err := s.engine.DB.Begin(ctx)
+	var deleted bool
+	err = s.engine.WithTx(ctx, func(q *pgdb.Queries) error {
+		tag, err := q.DeleteIdentitySchemaKey(ctx, pgdb.DeleteIdentitySchemaKeyParams{AppID: appUUID, Key: key})
+		if err != nil {
+			return fmt.Errorf("deleting identity schema key: %w", err)
+		}
+		if err := q.DeleteIdentityValueStatsForKey(ctx, pgdb.DeleteIdentityValueStatsForKeyParams{AppID: appUUID, Key: key}); err != nil {
+			return fmt.Errorf("deleting identity value stats: %w", err)
+		}
+		deleted = tag.RowsAffected() > 0
+		return nil
+	})
 	if err != nil {
-		return false, fmt.Errorf("beginning delete schema key tx: %w", err)
+		return false, err
 	}
-	defer func() { _ = tx.Rollback(ctx) }()
-	qtx := s.engine.Queries.WithTx(tx)
+	return deleted, nil
+}
 
-	tag, err := qtx.DeleteIdentitySchemaKey(ctx, pgdb.DeleteIdentitySchemaKeyParams{AppID: appUUID, Key: key})
-	if err != nil {
-		return false, fmt.Errorf("deleting identity schema key: %w", err)
-	}
-	if err := qtx.DeleteIdentityValueStatsForKey(ctx, pgdb.DeleteIdentityValueStatsForKeyParams{AppID: appUUID, Key: key}); err != nil {
-		return false, fmt.Errorf("deleting identity value stats: %w", err)
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return false, fmt.Errorf("committing delete schema key tx: %w", err)
-	}
-	return tag.RowsAffected() > 0, nil
+// statOp is one pending change to identity_value_stats. Ops are executed in
+// deterministic (key, value) order across the whole transaction: increments
+// and decrements both take row locks held until commit, and Go map iteration
+// order is random, so unordered execution lets two identifies of DIFFERENT
+// devices that share stat rows (same tenant, same plan...) acquire those locks
+// in opposite orders and deadlock. Sorting by key alone is not enough: A
+// moving tenant acme->globex and B moving globex->acme would still cross.
+type statOp struct {
+	key       string
+	value     string
+	decrement bool
 }
 
 // ApplyIdentify runs one identify against the store: sanitize the raw wire
@@ -142,101 +180,108 @@ func (s *PostgresIdentityStore) ApplyIdentify(ctx context.Context, appID string,
 		return ApplyResult{}, err
 	}
 
-	tx, err := s.engine.DB.Begin(ctx)
-	if err != nil {
-		return ApplyResult{}, fmt.Errorf("beginning identify tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
-	qtx := s.engine.Queries.WithTx(tx)
-
-	// The schema read shares the transaction so a concurrent allowlist change
-	// cannot produce a merge that mixes two versions of the schema.
-	schemaRows, err := qtx.ListIdentitySchemaKeys(ctx, appUUID)
-	if err != nil {
-		return ApplyResult{}, fmt.Errorf("listing identity schema: %w", err)
-	}
-	schema := make(Schema, len(schemaRows))
-	for _, row := range schemaRows {
-		schema[row.Key] = specFromRow(row)
-	}
-	sanitized, dropped := schema.Sanitize(raw)
-
-	if err := qtx.EnsureDeviceIdentity(ctx, pgdb.EnsureDeviceIdentityParams{AppID: appUUID, EasClientID: clientUUID}); err != nil {
-		return ApplyResult{}, fmt.Errorf("ensuring device row: %w", err)
-	}
-	current, err := qtx.GetDeviceIdentityForUpdate(ctx, pgdb.GetDeviceIdentityForUpdateParams{AppID: appUUID, EasClientID: clientUUID})
-	if err != nil {
-		return ApplyResult{}, fmt.Errorf("locking device row: %w", err)
-	}
-	previous := map[string]any{}
-	if len(current.Metadata) > 0 {
-		if err := json.Unmarshal(current.Metadata, &previous); err != nil {
-			return ApplyResult{}, fmt.Errorf("corrupt device metadata: %w", err)
+	var result ApplyResult
+	err = s.engine.WithTx(ctx, func(q *pgdb.Queries) error {
+		// The schema read shares the transaction so a concurrent allowlist
+		// change cannot produce a merge mixing two versions of the schema.
+		schemaRows, err := q.ListIdentitySchemaKeys(ctx, appUUID)
+		if err != nil {
+			return fmt.Errorf("listing identity schema: %w", err)
 		}
-	}
+		sanitized, dropped := schemaFromRows(schemaRows).Sanitize(raw)
 
-	merged := make(map[string]any, len(previous)+len(sanitized))
-	for key, value := range previous {
-		merged[key] = value
-	}
-	for key, value := range sanitized {
-		merged[key] = value
-	}
-	mergedJSON, err := json.Marshal(merged)
-	if err != nil {
-		return ApplyResult{}, fmt.Errorf("marshalling merged metadata: %w", err)
-	}
+		if err := q.EnsureDeviceIdentity(ctx, pgdb.EnsureDeviceIdentityParams{AppID: appUUID, EasClientID: clientUUID}); err != nil {
+			return fmt.Errorf("ensuring device row: %w", err)
+		}
+		current, err := q.GetDeviceIdentityForUpdate(ctx, pgdb.GetDeviceIdentityForUpdateParams{AppID: appUUID, EasClientID: clientUUID})
+		if err != nil {
+			return fmt.Errorf("locking device row: %w", err)
+		}
+		previous := map[string]any{}
+		if len(current.Metadata) > 0 {
+			if err := json.Unmarshal(current.Metadata, &previous); err != nil {
+				return fmt.Errorf("corrupt device metadata: %w", err)
+			}
+		}
 
-	params := pgdb.UpdateDeviceIdentityParams{
-		AppID:       appUUID,
-		EasClientID: clientUUID,
-		Metadata:    mergedJSON,
-	}
-	if geo != nil {
-		params.CountryCode = &geo.CountryCode
-		params.City = &geo.City
-		params.Lat = &geo.Lat
-		params.Lng = &geo.Lng
-	}
-	updated, err := qtx.UpdateDeviceIdentity(ctx, params)
-	if err != nil {
-		return ApplyResult{}, fmt.Errorf("updating device row: %w", err)
-	}
+		merged := make(map[string]any, len(previous)+len(sanitized))
+		for key, value := range previous {
+			merged[key] = value
+		}
+		var ops []statOp
+		for key, value := range sanitized {
+			merged[key] = value
+			newRendered := RenderValue(value)
+			if oldValue, existed := previous[key]; existed {
+				oldRendered := RenderValue(oldValue)
+				if oldRendered == newRendered {
+					continue
+				}
+				ops = append(ops, statOp{key: key, value: oldRendered, decrement: true})
+			}
+			ops = append(ops, statOp{key: key, value: newRendered})
+		}
+		mergedJSON, err := json.Marshal(merged)
+		if err != nil {
+			return fmt.Errorf("marshalling merged metadata: %w", err)
+		}
 
-	// Value stats: a key newly set counts its value in; a changed value moves
-	// the device from the old value's count to the new one. Comparison happens
-	// on the rendered form, the same normalization the stats table stores.
-	for key, value := range sanitized {
-		newRendered := RenderValue(value)
-		oldValue, existed := previous[key]
-		if existed {
-			oldRendered := RenderValue(oldValue)
-			if oldRendered == newRendered {
+		params := pgdb.UpdateDeviceIdentityParams{
+			AppID:       appUUID,
+			EasClientID: clientUUID,
+			Metadata:    mergedJSON,
+		}
+		if geo != nil {
+			params.CountryCode = geo.CountryCode
+			params.City = geo.City
+			params.Lat = geo.Lat
+			params.Lng = geo.Lng
+		}
+		updated, err := q.UpdateDeviceIdentity(ctx, params)
+		if err != nil {
+			return fmt.Errorf("updating device row: %w", err)
+		}
+
+		sort.Slice(ops, func(i, j int) bool {
+			if ops[i].key != ops[j].key {
+				return ops[i].key < ops[j].key
+			}
+			if ops[i].value != ops[j].value {
+				return ops[i].value < ops[j].value
+			}
+			return ops[i].decrement
+		})
+		for _, op := range ops {
+			if op.decrement {
+				decParams := pgdb.DecrementIdentityValueStatParams{AppID: appUUID, Key: op.key, Value: op.value}
+				if err := q.DecrementIdentityValueStat(ctx, decParams); err != nil {
+					return fmt.Errorf("decrementing value stat: %w", err)
+				}
+				// Prune immediately: same row, already locked by the
+				// decrement, so this cannot introduce a new lock ordering.
+				delParams := pgdb.DeleteZeroIdentityValueStatsParams{AppID: appUUID, Key: op.key, Value: op.value}
+				if err := q.DeleteZeroIdentityValueStats(ctx, delParams); err != nil {
+					return fmt.Errorf("pruning zero value stat: %w", err)
+				}
 				continue
 			}
-			decParams := pgdb.DecrementIdentityValueStatParams{AppID: appUUID, Key: key, Value: oldRendered}
-			if err := qtx.DecrementIdentityValueStat(ctx, decParams); err != nil {
-				return ApplyResult{}, fmt.Errorf("decrementing value stat: %w", err)
-			}
-			delParams := pgdb.DeleteZeroIdentityValueStatsParams{AppID: appUUID, Key: key, Value: oldRendered}
-			if err := qtx.DeleteZeroIdentityValueStats(ctx, delParams); err != nil {
-				return ApplyResult{}, fmt.Errorf("pruning zero value stat: %w", err)
+			incParams := pgdb.IncrementIdentityValueStatParams{AppID: appUUID, Key: op.key, Value: op.value}
+			if err := q.IncrementIdentityValueStat(ctx, incParams); err != nil {
+				return fmt.Errorf("incrementing value stat: %w", err)
 			}
 		}
-		incParams := pgdb.IncrementIdentityValueStatParams{AppID: appUUID, Key: key, Value: newRendered}
-		if err := qtx.IncrementIdentityValueStat(ctx, incParams); err != nil {
-			return ApplyResult{}, fmt.Errorf("incrementing value stat: %w", err)
-		}
-	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return ApplyResult{}, fmt.Errorf("committing identify tx: %w", err)
-	}
-	device, err := deviceFromRow(updated)
+		device, err := deviceFromRow(updated)
+		if err != nil {
+			return err
+		}
+		result = ApplyResult{Device: device, DroppedKeys: dropped}
+		return nil
+	})
 	if err != nil {
 		return ApplyResult{}, err
 	}
-	return ApplyResult{Device: device, DroppedKeys: dropped}, nil
+	return result, nil
 }
 
 // GetDevice returns nil when the install was never seen.
@@ -264,15 +309,36 @@ func (s *PostgresIdentityStore) GetDevice(ctx context.Context, appID string, eas
 }
 
 // SearchMetadataValues is the autocomplete behind searchMetadata: top values
-// of one key ranked by device count, optionally narrowed by a substring.
+// of one key ranked by device count, optionally narrowed by a substring. The
+// two arms are separate prepared statements on purpose (see queries.sql).
 func (s *PostgresIdentityStore) SearchMetadataValues(ctx context.Context, appID string, key string, search string, limit int) ([]ValueCount, error) {
 	appUUID, err := toPgUUID(appID)
 	if err != nil {
 		return nil, err
 	}
-	if limit < 1 || limit > 100 {
+	switch {
+	case limit < 1:
 		limit = 20
+	case limit > 100:
+		limit = 100
 	}
+
+	if search == "" {
+		rows, err := s.engine.Queries.TopIdentityValues(ctx, pgdb.TopIdentityValuesParams{
+			AppID:      appUUID,
+			Key:        key,
+			MaxResults: int32(limit),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing top identity values: %w", err)
+		}
+		values := make([]ValueCount, 0, len(rows))
+		for _, row := range rows {
+			values = append(values, ValueCount{Value: row.Value, DeviceCount: row.DeviceCount})
+		}
+		return values, nil
+	}
+
 	rows, err := s.engine.Queries.SearchIdentityValues(ctx, pgdb.SearchIdentityValuesParams{
 		AppID:      appUUID,
 		Key:        key,

--- a/ee/identity/store_postgres.go
+++ b/ee/identity/store_postgres.go
@@ -1,0 +1,290 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package identity
+
+import (
+	"context"
+	"encoding/json"
+	"expo-open-ota/internal/database"
+	"expo-open-ota/internal/database/postgres/pgdb"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type PostgresIdentityStore struct {
+	engine *database.Engine
+}
+
+func NewPostgresIdentityStore(engine *database.Engine) *PostgresIdentityStore {
+	return &PostgresIdentityStore{engine: engine}
+}
+
+func toPgUUID(id string) (pgtype.UUID, error) {
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		return pgtype.UUID{}, fmt.Errorf("invalid uuid %q: %w", id, err)
+	}
+	return pgtype.UUID{Bytes: parsed, Valid: true}, nil
+}
+
+func specFromRow(row pgdb.IdentitySchema) KeySpec {
+	return KeySpec{Key: row.Key, Type: ValueType(row.ValueType), MaxLength: int(row.MaxLength)}
+}
+
+func deviceFromRow(row pgdb.DeviceIdentity) (Device, error) {
+	metadata := map[string]any{}
+	if len(row.Metadata) > 0 {
+		if err := json.Unmarshal(row.Metadata, &metadata); err != nil {
+			return Device{}, fmt.Errorf("corrupt device metadata: %w", err)
+		}
+	}
+	return Device{
+		AppID:       uuid.UUID(row.AppID.Bytes).String(),
+		EASClientID: uuid.UUID(row.EasClientID.Bytes).String(),
+		Metadata:    metadata,
+		CountryCode: row.CountryCode,
+		City:        row.City,
+		Lat:         row.Lat,
+		Lng:         row.Lng,
+		FirstSeenAt: row.FirstSeenAt.Time.UTC().Format("2006-01-02T15:04:05.000Z"),
+		LastSeenAt:  row.LastSeenAt.Time.UTC().Format("2006-01-02T15:04:05.000Z"),
+	}, nil
+}
+
+// GetSchema returns the app's allowlist. An app with no declared keys gets an
+// empty schema, under which Sanitize drops everything: identity is opt-in per
+// app by declaring keys, there is no implicit passthrough.
+func (s *PostgresIdentityStore) GetSchema(ctx context.Context, appID string) (Schema, error) {
+	appUUID, err := toPgUUID(appID)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.engine.Queries.ListIdentitySchemaKeys(ctx, appUUID)
+	if err != nil {
+		return nil, fmt.Errorf("listing identity schema: %w", err)
+	}
+	schema := make(Schema, len(rows))
+	for _, row := range rows {
+		schema[row.Key] = specFromRow(row)
+	}
+	return schema, nil
+}
+
+func (s *PostgresIdentityStore) UpsertSchemaKey(ctx context.Context, appID string, spec KeySpec) (KeySpec, error) {
+	if spec.MaxLength == 0 {
+		spec.MaxLength = DefaultMaxLength
+	}
+	if err := ValidateKeySpec(spec); err != nil {
+		return KeySpec{}, err
+	}
+	appUUID, err := toPgUUID(appID)
+	if err != nil {
+		return KeySpec{}, err
+	}
+	row, err := s.engine.Queries.UpsertIdentitySchemaKey(ctx, pgdb.UpsertIdentitySchemaKeyParams{
+		AppID:     appUUID,
+		Key:       spec.Key,
+		ValueType: string(spec.Type),
+		MaxLength: int32(spec.MaxLength),
+	})
+	if err != nil {
+		return KeySpec{}, fmt.Errorf("upserting identity schema key: %w", err)
+	}
+	return specFromRow(row), nil
+}
+
+// DeleteSchemaKey removes a key from the allowlist and wipes its autocomplete
+// stats in the same transaction, so searchMetadata never suggests values of a
+// removed key. Values already merged into device metadata are left in place;
+// they stop being accepted and stop being suggested.
+func (s *PostgresIdentityStore) DeleteSchemaKey(ctx context.Context, appID string, key string) (bool, error) {
+	appUUID, err := toPgUUID(appID)
+	if err != nil {
+		return false, err
+	}
+	tx, err := s.engine.DB.Begin(ctx)
+	if err != nil {
+		return false, fmt.Errorf("beginning delete schema key tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	qtx := s.engine.Queries.WithTx(tx)
+
+	tag, err := qtx.DeleteIdentitySchemaKey(ctx, pgdb.DeleteIdentitySchemaKeyParams{AppID: appUUID, Key: key})
+	if err != nil {
+		return false, fmt.Errorf("deleting identity schema key: %w", err)
+	}
+	if err := qtx.DeleteIdentityValueStatsForKey(ctx, pgdb.DeleteIdentityValueStatsForKeyParams{AppID: appUUID, Key: key}); err != nil {
+		return false, fmt.Errorf("deleting identity value stats: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return false, fmt.Errorf("committing delete schema key tx: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+// ApplyIdentify runs one identify against the store: sanitize the raw wire
+// metadata against the allowlist, merge it into the device row (per-key merge,
+// incoming keys win), refresh geo when provided, and keep the per-value
+// device counts in sync. Everything happens in one transaction with the
+// device row locked, so concurrent identifies of the same install serialize
+// and the counts never drift from the merges that produced them.
+func (s *PostgresIdentityStore) ApplyIdentify(ctx context.Context, appID string, easClientID string, raw map[string]any, geo *Geo) (ApplyResult, error) {
+	appUUID, err := toPgUUID(appID)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	clientUUID, err := toPgUUID(easClientID)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+
+	tx, err := s.engine.DB.Begin(ctx)
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("beginning identify tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	qtx := s.engine.Queries.WithTx(tx)
+
+	// The schema read shares the transaction so a concurrent allowlist change
+	// cannot produce a merge that mixes two versions of the schema.
+	schemaRows, err := qtx.ListIdentitySchemaKeys(ctx, appUUID)
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("listing identity schema: %w", err)
+	}
+	schema := make(Schema, len(schemaRows))
+	for _, row := range schemaRows {
+		schema[row.Key] = specFromRow(row)
+	}
+	sanitized, dropped := schema.Sanitize(raw)
+
+	if err := qtx.EnsureDeviceIdentity(ctx, pgdb.EnsureDeviceIdentityParams{AppID: appUUID, EasClientID: clientUUID}); err != nil {
+		return ApplyResult{}, fmt.Errorf("ensuring device row: %w", err)
+	}
+	current, err := qtx.GetDeviceIdentityForUpdate(ctx, pgdb.GetDeviceIdentityForUpdateParams{AppID: appUUID, EasClientID: clientUUID})
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("locking device row: %w", err)
+	}
+	previous := map[string]any{}
+	if len(current.Metadata) > 0 {
+		if err := json.Unmarshal(current.Metadata, &previous); err != nil {
+			return ApplyResult{}, fmt.Errorf("corrupt device metadata: %w", err)
+		}
+	}
+
+	merged := make(map[string]any, len(previous)+len(sanitized))
+	for key, value := range previous {
+		merged[key] = value
+	}
+	for key, value := range sanitized {
+		merged[key] = value
+	}
+	mergedJSON, err := json.Marshal(merged)
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("marshalling merged metadata: %w", err)
+	}
+
+	params := pgdb.UpdateDeviceIdentityParams{
+		AppID:       appUUID,
+		EasClientID: clientUUID,
+		Metadata:    mergedJSON,
+	}
+	if geo != nil {
+		params.CountryCode = &geo.CountryCode
+		params.City = &geo.City
+		params.Lat = &geo.Lat
+		params.Lng = &geo.Lng
+	}
+	updated, err := qtx.UpdateDeviceIdentity(ctx, params)
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("updating device row: %w", err)
+	}
+
+	// Value stats: a key newly set counts its value in; a changed value moves
+	// the device from the old value's count to the new one. Comparison happens
+	// on the rendered form, the same normalization the stats table stores.
+	for key, value := range sanitized {
+		newRendered := RenderValue(value)
+		oldValue, existed := previous[key]
+		if existed {
+			oldRendered := RenderValue(oldValue)
+			if oldRendered == newRendered {
+				continue
+			}
+			decParams := pgdb.DecrementIdentityValueStatParams{AppID: appUUID, Key: key, Value: oldRendered}
+			if err := qtx.DecrementIdentityValueStat(ctx, decParams); err != nil {
+				return ApplyResult{}, fmt.Errorf("decrementing value stat: %w", err)
+			}
+			delParams := pgdb.DeleteZeroIdentityValueStatsParams{AppID: appUUID, Key: key, Value: oldRendered}
+			if err := qtx.DeleteZeroIdentityValueStats(ctx, delParams); err != nil {
+				return ApplyResult{}, fmt.Errorf("pruning zero value stat: %w", err)
+			}
+		}
+		incParams := pgdb.IncrementIdentityValueStatParams{AppID: appUUID, Key: key, Value: newRendered}
+		if err := qtx.IncrementIdentityValueStat(ctx, incParams); err != nil {
+			return ApplyResult{}, fmt.Errorf("incrementing value stat: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return ApplyResult{}, fmt.Errorf("committing identify tx: %w", err)
+	}
+	device, err := deviceFromRow(updated)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	return ApplyResult{Device: device, DroppedKeys: dropped}, nil
+}
+
+// GetDevice returns nil when the install was never seen.
+func (s *PostgresIdentityStore) GetDevice(ctx context.Context, appID string, easClientID string) (*Device, error) {
+	appUUID, err := toPgUUID(appID)
+	if err != nil {
+		return nil, err
+	}
+	clientUUID, err := toPgUUID(easClientID)
+	if err != nil {
+		return nil, err
+	}
+	row, err := s.engine.Queries.GetDeviceIdentity(ctx, pgdb.GetDeviceIdentityParams{AppID: appUUID, EasClientID: clientUUID})
+	if err != nil {
+		if database.IsNoRows(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("getting device identity: %w", err)
+	}
+	device, err := deviceFromRow(row)
+	if err != nil {
+		return nil, err
+	}
+	return &device, nil
+}
+
+// SearchMetadataValues is the autocomplete behind searchMetadata: top values
+// of one key ranked by device count, optionally narrowed by a substring.
+func (s *PostgresIdentityStore) SearchMetadataValues(ctx context.Context, appID string, key string, search string, limit int) ([]ValueCount, error) {
+	appUUID, err := toPgUUID(appID)
+	if err != nil {
+		return nil, err
+	}
+	if limit < 1 || limit > 100 {
+		limit = 20
+	}
+	rows, err := s.engine.Queries.SearchIdentityValues(ctx, pgdb.SearchIdentityValuesParams{
+		AppID:      appUUID,
+		Key:        key,
+		Search:     search,
+		MaxResults: int32(limit),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("searching identity values: %w", err)
+	}
+	values := make([]ValueCount, 0, len(rows))
+	for _, row := range rows {
+		values = append(values, ValueCount{Value: row.Value, DeviceCount: row.DeviceCount})
+	}
+	return values, nil
+}

--- a/ee/identity/store_postgres_test.go
+++ b/ee/identity/store_postgres_test.go
@@ -1,0 +1,273 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+// Integration tests for the identity store: the merge-under-lock transaction,
+// the value-stat bookkeeping and the trigram search need a real Postgres.
+// They skip unless TEST_DATABASE_URL is set, e.g.:
+//
+//	docker run -d --name eoo-pg -e POSTGRES_PASSWORD=test -p 55432:5432 postgres:16-alpine
+//	TEST_DATABASE_URL="postgres://postgres:test@localhost:55432/postgres?sslmode=disable" go test ./ee/identity/
+//
+// Every test creates its own app row, so tests never observe each other's
+// devices or stats even on a database reused across runs.
+
+package identity
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+
+	"expo-open-ota/internal/database"
+	"expo-open-ota/internal/database/postgres"
+	"expo-open-ota/internal/database/postgres/pgdb"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+func setupIdentityStore(t *testing.T) (*PostgresIdentityStore, *pgxpool.Pool) {
+	t.Helper()
+	dbURL := os.Getenv("TEST_DATABASE_URL")
+	if dbURL == "" {
+		// Same guard as the audit and rbac store tests: a skip in CI is a
+		// green job that ran none of these queries.
+		if os.Getenv("CI") != "" {
+			t.Fatal("TEST_DATABASE_URL must be set in CI: these tests cover SQL that unit tests cannot reach")
+		}
+		t.Skip("TEST_DATABASE_URL not set — start a Postgres and set it to run the identity store tests")
+	}
+	t.Setenv("ADMIN_EMAIL", "seed-admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "Sup3rSecret!")
+	postgres.RunDBMigrations(dbURL)
+
+	pool, err := pgxpool.New(context.Background(), dbURL)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	return NewPostgresIdentityStore(&database.Engine{Queries: pgdb.New(pool), DB: pool}), pool
+}
+
+func seedApp(t *testing.T, pool *pgxpool.Pool) string {
+	t.Helper()
+	appID := uuid.NewString()
+	_, err := pool.Exec(context.Background(), "INSERT INTO apps (id, name) VALUES ($1, $2)", appID, "identity-test-"+appID[:8])
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), "DELETE FROM apps WHERE id = $1", appID)
+	})
+	return appID
+}
+
+func declareKey(t *testing.T, store *PostgresIdentityStore, appID, key string, valueType ValueType) {
+	t.Helper()
+	_, err := store.UpsertSchemaKey(context.Background(), appID, KeySpec{Key: key, Type: valueType, MaxLength: DefaultMaxLength})
+	require.NoError(t, err)
+}
+
+func TestSchemaCRUD(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+
+	schema, err := store.GetSchema(ctx, appID)
+	require.NoError(t, err)
+	require.Empty(t, schema)
+
+	_, err = store.UpsertSchemaKey(ctx, appID, KeySpec{Key: "userId", Type: ValueTypeString})
+	require.NoError(t, err)
+	_, err = store.UpsertSchemaKey(ctx, appID, KeySpec{Key: "seats", Type: ValueTypeNumber, MaxLength: 32})
+	require.NoError(t, err)
+
+	schema, err = store.GetSchema(ctx, appID)
+	require.NoError(t, err)
+	require.Len(t, schema, 2)
+	// Omitted max length lands on the default, not on zero.
+	require.Equal(t, DefaultMaxLength, schema["userId"].MaxLength)
+	require.Equal(t, 32, schema["seats"].MaxLength)
+
+	// Upsert re-types a key in place.
+	_, err = store.UpsertSchemaKey(ctx, appID, KeySpec{Key: "seats", Type: ValueTypeString, MaxLength: 32})
+	require.NoError(t, err)
+	schema, err = store.GetSchema(ctx, appID)
+	require.NoError(t, err)
+	require.Equal(t, ValueTypeString, schema["seats"].Type)
+
+	// Invalid specs are rejected before touching the database.
+	_, err = store.UpsertSchemaKey(ctx, appID, KeySpec{Key: "bad key", Type: ValueTypeString})
+	require.Error(t, err)
+
+	deleted, err := store.DeleteSchemaKey(ctx, appID, "seats")
+	require.NoError(t, err)
+	require.True(t, deleted)
+	deleted, err = store.DeleteSchemaKey(ctx, appID, "seats")
+	require.NoError(t, err)
+	require.False(t, deleted)
+}
+
+func TestApplyIdentifyMergesAndCounts(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	declareKey(t, store, appID, "userId", ValueTypeString)
+	declareKey(t, store, appID, "tenant", ValueTypeString)
+
+	clientID := uuid.NewString()
+	result, err := store.ApplyIdentify(ctx, appID, clientID, map[string]any{
+		"userId": "user_1",
+		"junk":   "dropped by the allowlist",
+	}, nil)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"userId": "user_1"}, result.Device.Metadata)
+	require.Equal(t, []string{"junk"}, result.DroppedKeys)
+
+	// Second identify adds a key and keeps the first one (per-key merge).
+	result, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"tenant": "acme"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"userId": "user_1", "tenant": "acme"}, result.Device.Metadata)
+
+	// Changing a value moves the device count from the old value to the new
+	// one and prunes the emptied row.
+	_, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"tenant": "globex"}, nil)
+	require.NoError(t, err)
+	values, err := store.SearchMetadataValues(ctx, appID, "tenant", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "globex", DeviceCount: 1}}, values)
+
+	// Re-identifying the same value must not inflate the count.
+	_, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"tenant": "globex"}, nil)
+	require.NoError(t, err)
+	values, err = store.SearchMetadataValues(ctx, appID, "tenant", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "globex", DeviceCount: 1}}, values)
+
+	device, err := store.GetDevice(ctx, appID, clientID)
+	require.NoError(t, err)
+	require.NotNil(t, device)
+	require.Equal(t, "globex", device.Metadata["tenant"])
+
+	missing, err := store.GetDevice(ctx, appID, uuid.NewString())
+	require.NoError(t, err)
+	require.Nil(t, missing)
+
+	_, err = store.ApplyIdentify(ctx, appID, "not-a-uuid", map[string]any{}, nil)
+	require.Error(t, err)
+}
+
+func TestApplyIdentifyGeoCoalesce(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	clientID := uuid.NewString()
+
+	result, err := store.ApplyIdentify(ctx, appID, clientID, nil, &Geo{CountryCode: "FR", City: "Paris", Lat: 48.85, Lng: 2.35})
+	require.NoError(t, err)
+	require.NotNil(t, result.Device.CountryCode)
+	require.Equal(t, "FR", *result.Device.CountryCode)
+
+	// An identify that resolves no geo keeps the previously known location.
+	result, err = store.ApplyIdentify(ctx, appID, clientID, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result.Device.CountryCode)
+	require.Equal(t, "FR", *result.Device.CountryCode)
+	require.NotNil(t, result.Device.Lat)
+	require.InDelta(t, 48.85, *result.Device.Lat, 0.001)
+}
+
+func TestSearchMetadataValuesRankingAndFilter(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	declareKey(t, store, appID, "tenant", ValueTypeString)
+
+	seed := map[string]int{"acme": 3, "acme-eu": 2, "globex": 1}
+	for tenant, devices := range seed {
+		for i := 0; i < devices; i++ {
+			_, err := store.ApplyIdentify(ctx, appID, uuid.NewString(), map[string]any{"tenant": tenant}, nil)
+			require.NoError(t, err)
+		}
+	}
+
+	// Empty search: top values by device count.
+	values, err := store.SearchMetadataValues(ctx, appID, "tenant", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "acme", DeviceCount: 3}, {Value: "acme-eu", DeviceCount: 2}, {Value: "globex", DeviceCount: 1}}, values)
+
+	// Case-insensitive substring narrows, ranking is preserved.
+	values, err = store.SearchMetadataValues(ctx, appID, "tenant", "ACME", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "acme", DeviceCount: 3}, {Value: "acme-eu", DeviceCount: 2}}, values)
+
+	// Limit applies after ranking.
+	values, err = store.SearchMetadataValues(ctx, appID, "tenant", "", 1)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "acme", DeviceCount: 3}}, values)
+
+	// Unknown key: no rows, no error.
+	values, err = store.SearchMetadataValues(ctx, appID, "nope", "", 10)
+	require.NoError(t, err)
+	require.Empty(t, values)
+}
+
+func TestDeleteSchemaKeyWipesItsStats(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	declareKey(t, store, appID, "tenant", ValueTypeString)
+	declareKey(t, store, appID, "plan", ValueTypeString)
+
+	_, err := store.ApplyIdentify(ctx, appID, uuid.NewString(), map[string]any{"tenant": "acme", "plan": "pro"}, nil)
+	require.NoError(t, err)
+
+	deleted, err := store.DeleteSchemaKey(ctx, appID, "tenant")
+	require.NoError(t, err)
+	require.True(t, deleted)
+
+	// The removed key stops being suggested; the surviving key is untouched.
+	values, err := store.SearchMetadataValues(ctx, appID, "tenant", "", 10)
+	require.NoError(t, err)
+	require.Empty(t, values)
+	values, err = store.SearchMetadataValues(ctx, appID, "plan", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "pro", DeviceCount: 1}}, values)
+
+	// And its values are no longer accepted on the next identify.
+	result, err := store.ApplyIdentify(ctx, appID, uuid.NewString(), map[string]any{"tenant": "acme"}, nil)
+	require.NoError(t, err)
+	require.Empty(t, result.Device.Metadata)
+	require.Equal(t, []string{"tenant"}, result.DroppedKeys)
+}
+
+// Concurrent first identifies of the same install must both land: the
+// insert-then-lock sequence serializes the merges, so neither metadata write
+// nor stat increment is lost.
+func TestApplyIdentifyConcurrentFirstWrite(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	declareKey(t, store, appID, "userId", ValueTypeString)
+	declareKey(t, store, appID, "tenant", ValueTypeString)
+
+	clientID := uuid.NewString()
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, errs[0] = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"userId": "user_1"}, nil)
+	}()
+	go func() {
+		defer wg.Done()
+		_, errs[1] = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"tenant": "acme"}, nil)
+	}()
+	wg.Wait()
+	require.NoError(t, errs[0])
+	require.NoError(t, errs[1])
+
+	device, err := store.GetDevice(ctx, appID, clientID)
+	require.NoError(t, err)
+	require.NotNil(t, device)
+	require.Equal(t, map[string]any{"userId": "user_1", "tenant": "acme"}, device.Metadata)
+}

--- a/ee/identity/store_postgres_test.go
+++ b/ee/identity/store_postgres_test.go
@@ -16,6 +16,7 @@ package identity
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"sync"
 	"testing"
@@ -156,13 +157,17 @@ func TestApplyIdentifyMergesAndCounts(t *testing.T) {
 	require.Error(t, err)
 }
 
+func strPtr(s string) *string     { return &s }
+func floatPtr(f float64) *float64 { return &f }
+
 func TestApplyIdentifyGeoCoalesce(t *testing.T) {
 	store, pool := setupIdentityStore(t)
 	appID := seedApp(t, pool)
 	ctx := context.Background()
 	clientID := uuid.NewString()
 
-	result, err := store.ApplyIdentify(ctx, appID, clientID, nil, &Geo{CountryCode: "FR", City: "Paris", Lat: 48.85, Lng: 2.35})
+	fullGeo := &Geo{CountryCode: strPtr("FR"), City: strPtr("Paris"), Lat: floatPtr(48.85), Lng: floatPtr(2.35)}
+	result, err := store.ApplyIdentify(ctx, appID, clientID, nil, fullGeo)
 	require.NoError(t, err)
 	require.NotNil(t, result.Device.CountryCode)
 	require.Equal(t, "FR", *result.Device.CountryCode)
@@ -172,6 +177,16 @@ func TestApplyIdentifyGeoCoalesce(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result.Device.CountryCode)
 	require.Equal(t, "FR", *result.Device.CountryCode)
+	require.NotNil(t, result.Device.Lat)
+	require.InDelta(t, 48.85, *result.Device.Lat, 0.001)
+
+	// A PARTIAL resolution (country-only is the common GeoLite2 case) updates
+	// what it knows and never blanks the rest with '' or 0/0.
+	result, err = store.ApplyIdentify(ctx, appID, clientID, nil, &Geo{CountryCode: strPtr("BE")})
+	require.NoError(t, err)
+	require.Equal(t, "BE", *result.Device.CountryCode)
+	require.NotNil(t, result.Device.City)
+	require.Equal(t, "Paris", *result.Device.City)
 	require.NotNil(t, result.Device.Lat)
 	require.InDelta(t, 48.85, *result.Device.Lat, 0.001)
 }
@@ -270,4 +285,122 @@ func TestApplyIdentifyConcurrentFirstWrite(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, device)
 	require.Equal(t, map[string]any{"userId": "user_1", "tenant": "acme"}, device.Metadata)
+
+	// The stat increments must survive the serialization too: a lost or
+	// double-counted increment would pass a metadata-only assertion.
+	values, err := store.SearchMetadataValues(ctx, appID, "userId", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "user_1", DeviceCount: 1}}, values)
+	values, err = store.SearchMetadataValues(ctx, appID, "tenant", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "acme", DeviceCount: 1}}, values)
+}
+
+// Two identifies of DIFFERENT devices sharing stat rows (same tenant/plan
+// values) must not deadlock: the store orders its stat-row locks by
+// (key, value) precisely for this. Before that ordering, this test deadlocked
+// within a handful of iterations (40P01 after the 1s deadlock_timeout).
+func TestApplyIdentifyConcurrentSharedStatRowsNoDeadlock(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	declareKey(t, store, appID, "tenant", ValueTypeString)
+	declareKey(t, store, appID, "plan", ValueTypeString)
+	declareKey(t, store, appID, "region", ValueTypeString)
+
+	deviceA, deviceB := uuid.NewString(), uuid.NewString()
+	payload := map[string]any{"tenant": "acme", "plan": "pro", "region": "eu"}
+	// Alternating payload so decrements and increments cross between rounds.
+	alternate := map[string]any{"tenant": "globex", "plan": "free", "region": "us"}
+
+	const rounds = 40
+	var wg sync.WaitGroup
+	errsA := make([]error, rounds)
+	errsB := make([]error, rounds)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < rounds; i++ {
+			p := payload
+			if i%2 == 1 {
+				p = alternate
+			}
+			if _, err := store.ApplyIdentify(ctx, appID, deviceA, p, nil); err != nil {
+				errsA[i] = err
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < rounds; i++ {
+			p := alternate
+			if i%2 == 1 {
+				p = payload
+			}
+			if _, err := store.ApplyIdentify(ctx, appID, deviceB, p, nil); err != nil {
+				errsB[i] = err
+				return
+			}
+		}
+	}()
+	wg.Wait()
+	for i := 0; i < rounds; i++ {
+		require.NoError(t, errsA[i], "device A round %d", i)
+		require.NoError(t, errsB[i], "device B round %d", i)
+	}
+
+	// Both devices ran an even number of rounds, so A ends on `alternate` and
+	// B ends on `payload`: every value should count exactly one device.
+	for key, want := range map[string][]ValueCount{
+		"tenant": {{Value: "acme", DeviceCount: 1}, {Value: "globex", DeviceCount: 1}},
+		"plan":   {{Value: "free", DeviceCount: 1}, {Value: "pro", DeviceCount: 1}},
+		"region": {{Value: "eu", DeviceCount: 1}, {Value: "us", DeviceCount: 1}},
+	} {
+		values, err := store.SearchMetadataValues(ctx, appID, key, "", 10)
+		require.NoError(t, err)
+		require.ElementsMatch(t, want, values, "key %s", key)
+	}
+}
+
+// A number-typed key must round-trip through JSONB without corrupting the
+// stat bookkeeping: 42 stored then re-read as float64 must compare equal to
+// an incoming 42 (no phantom dec/inc), and a real change must move the count.
+func TestApplyIdentifyNumberRoundtrip(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	declareKey(t, store, appID, "seats", ValueTypeNumber)
+
+	clientID := uuid.NewString()
+	_, err := store.ApplyIdentify(ctx, appID, clientID, map[string]any{"seats": int64(42)}, nil)
+	require.NoError(t, err)
+	_, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"seats": float64(42)}, nil)
+	require.NoError(t, err)
+	values, err := store.SearchMetadataValues(ctx, appID, "seats", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "42", DeviceCount: 1}}, values)
+
+	_, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"seats": 42.5}, nil)
+	require.NoError(t, err)
+	values, err = store.SearchMetadataValues(ctx, appID, "seats", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "42.5", DeviceCount: 1}}, values)
+}
+
+func TestUpsertSchemaKeyCap(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+
+	for i := 0; i < MaxSchemaKeys; i++ {
+		_, err := store.UpsertSchemaKey(ctx, appID, KeySpec{Key: fmt.Sprintf("key%d", i), Type: ValueTypeString})
+		require.NoError(t, err)
+	}
+	// The 101st key is rejected...
+	_, err := store.UpsertSchemaKey(ctx, appID, KeySpec{Key: "overflow", Type: ValueTypeString})
+	require.ErrorContains(t, err, "limited to")
+	// ...but re-declaring an existing key at the cap still works.
+	_, err = store.UpsertSchemaKey(ctx, appID, KeySpec{Key: "key0", Type: ValueTypeNumber})
+	require.NoError(t, err)
 }

--- a/internal/database/postgres/migrations/20260722150000_identity.sql
+++ b/internal/database/postgres/migrations/20260722150000_identity.sql
@@ -1,0 +1,84 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Device identity (ee/identity). Maps an expo-eas-client install UUID to
+-- operator-defined metadata (userId, tenant, ...) fed by `identify` log
+-- events on the observe ingestion route, plus GeoIP columns resolved from
+-- the request IP. EE-licensed code, but NOT license-gated: the feature works
+-- on community deployments too.
+
+-- Trigram index support for the metadata value autocomplete. Ships with the
+-- postgres contrib package (present in the official Docker images and on the
+-- managed offerings: RDS, Cloud SQL, Neon, Supabase). Operators on a build
+-- without contrib get a clear migration failure here, not a silent one later.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- The allowlist managed in the dashboard "Identity" section. Ingestion drops
+-- every metadata key that is not declared here with a matching value type,
+-- which is what makes hostile payloads (thousands of keys, megabyte values)
+-- a non-issue by construction rather than by heuristics.
+CREATE TABLE identity_schema (
+    app_id UUID NOT NULL REFERENCES apps (id) ON DELETE CASCADE,
+    key TEXT NOT NULL,
+    value_type TEXT NOT NULL CHECK (value_type IN ('string', 'number', 'boolean')),
+    -- Applies to string values only. A string over the limit is dropped, not
+    -- truncated: a truncated userId would silently corrupt the mapping.
+    max_length INT NOT NULL DEFAULT 256,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (app_id, key)
+);
+
+-- One row per install. eas_client_id is the persistent per-install UUID from
+-- expo-eas-client (sent as the expo.eas_client.id resource attribute).
+-- metadata only ever contains allowlisted keys, so its size is bounded by the
+-- schema, and the GIN index serves equality/containment lookups on any key
+-- (metadata @> '{"userId": "X"}') without per-key indexes.
+CREATE TABLE device_identity (
+    app_id UUID NOT NULL REFERENCES apps (id) ON DELETE CASCADE,
+    eas_client_id UUID NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    -- GeoIP enrichment, city-level accuracy (MaxMind GeoLite2). Nullable:
+    -- resolution is best-effort and optional. COALESCE semantics on update:
+    -- a request that resolves no geo never erases a previously known one.
+    country_code TEXT,
+    city TEXT,
+    lat DOUBLE PRECISION,
+    lng DOUBLE PRECISION,
+    first_seen_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_seen_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (app_id, eas_client_id)
+);
+
+CREATE INDEX idx_device_identity_metadata ON device_identity USING GIN (metadata jsonb_path_ops);
+CREATE INDEX idx_device_identity_country ON device_identity (app_id, country_code);
+CREATE INDEX idx_device_identity_last_seen ON device_identity (app_id, last_seen_at);
+
+-- Distinct-value stats powering searchMetadata (dashboard autocomplete and
+-- segmentation dropdowns). Cardinality is the number of distinct values, not
+-- the number of devices, so lookups stay cheap at any fleet size. Counts are
+-- maintained transactionally with device updates but treated as approximate
+-- ranking signals, not billing-grade numbers.
+CREATE TABLE identity_value_stats (
+    app_id UUID NOT NULL REFERENCES apps (id) ON DELETE CASCADE,
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    device_count BIGINT NOT NULL DEFAULT 0,
+    last_seen_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (app_id, key, value)
+);
+
+CREATE INDEX idx_identity_value_stats_trgm ON identity_value_stats USING GIN (value gin_trgm_ops);
+
+-- Serves the empty-search autocomplete (dropdown open, the most common call)
+-- as an index-only top-N scan. Without it, every call top-N sorts all distinct
+-- values of the key, which is O(user count) for a userId-style key.
+CREATE INDEX idx_identity_value_stats_top ON identity_value_stats (app_id, key, device_count DESC, value ASC);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS identity_value_stats;
+DROP TABLE IF EXISTS device_identity;
+DROP TABLE IF EXISTS identity_schema;
+-- +goose StatementEnd

--- a/internal/database/postgres/pgdb/models.go
+++ b/internal/database/postgres/pgdb/models.go
@@ -84,11 +84,39 @@ type ChannelRollout struct {
 	UpdatedAt       pgtype.Timestamptz `json:"updated_at"`
 }
 
+type DeviceIdentity struct {
+	AppID       pgtype.UUID        `json:"app_id"`
+	EasClientID pgtype.UUID        `json:"eas_client_id"`
+	Metadata    []byte             `json:"metadata"`
+	CountryCode *string            `json:"country_code"`
+	City        *string            `json:"city"`
+	Lat         *float64           `json:"lat"`
+	Lng         *float64           `json:"lng"`
+	FirstSeenAt pgtype.Timestamptz `json:"first_seen_at"`
+	LastSeenAt  pgtype.Timestamptz `json:"last_seen_at"`
+}
+
 type EnterpriseLicense struct {
 	Singleton  bool               `json:"singleton"`
 	LicenseKey string             `json:"license_key"`
 	CreatedAt  pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
+}
+
+type IdentitySchema struct {
+	AppID     pgtype.UUID        `json:"app_id"`
+	Key       string             `json:"key"`
+	ValueType string             `json:"value_type"`
+	MaxLength int32              `json:"max_length"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+}
+
+type IdentityValueStat struct {
+	AppID       pgtype.UUID        `json:"app_id"`
+	Key         string             `json:"key"`
+	Value       string             `json:"value"`
+	DeviceCount int64              `json:"device_count"`
+	LastSeenAt  pgtype.Timestamptz `json:"last_seen_at"`
 }
 
 type Role struct {

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -138,6 +138,23 @@ func (q *Queries) CountGrantsPerUser(ctx context.Context) ([]CountGrantsPerUserR
 	return items, nil
 }
 
+const decrementIdentityValueStat = `-- name: DecrementIdentityValueStat :exec
+UPDATE identity_value_stats
+SET device_count = GREATEST(device_count - 1, 0)
+WHERE app_id = $1 AND key = $2 AND value = $3
+`
+
+type DecrementIdentityValueStatParams struct {
+	AppID pgtype.UUID `json:"app_id"`
+	Key   string      `json:"key"`
+	Value string      `json:"value"`
+}
+
+func (q *Queries) DecrementIdentityValueStat(ctx context.Context, arg DecrementIdentityValueStatParams) error {
+	_, err := q.db.Exec(ctx, decrementIdentityValueStat, arg.AppID, arg.Key, arg.Value)
+	return err
+}
+
 const deleteAppByID = `-- name: DeleteAppByID :execresult
 DELETE FROM apps
 WHERE id = $1
@@ -206,6 +223,38 @@ func (q *Queries) DeleteEnterpriseLicense(ctx context.Context) error {
 	return err
 }
 
+const deleteIdentitySchemaKey = `-- name: DeleteIdentitySchemaKey :execresult
+DELETE FROM identity_schema
+WHERE app_id = $1 AND key = $2
+`
+
+type DeleteIdentitySchemaKeyParams struct {
+	AppID pgtype.UUID `json:"app_id"`
+	Key   string      `json:"key"`
+}
+
+func (q *Queries) DeleteIdentitySchemaKey(ctx context.Context, arg DeleteIdentitySchemaKeyParams) (pgconn.CommandTag, error) {
+	return q.db.Exec(ctx, deleteIdentitySchemaKey, arg.AppID, arg.Key)
+}
+
+const deleteIdentityValueStatsForKey = `-- name: DeleteIdentityValueStatsForKey :exec
+DELETE FROM identity_value_stats
+WHERE app_id = $1 AND key = $2
+`
+
+type DeleteIdentityValueStatsForKeyParams struct {
+	AppID pgtype.UUID `json:"app_id"`
+	Key   string      `json:"key"`
+}
+
+// Wipes the autocomplete entries of a key when it leaves the allowlist, so
+// searchMetadata never suggests values of a key the operator removed. The
+// values already merged into device_identity.metadata are left in place.
+func (q *Queries) DeleteIdentityValueStatsForKey(ctx context.Context, arg DeleteIdentityValueStatsForKeyParams) error {
+	_, err := q.db.Exec(ctx, deleteIdentityValueStatsForKey, arg.AppID, arg.Key)
+	return err
+}
+
 const deleteRole = `-- name: DeleteRole :execresult
 DELETE FROM roles
 WHERE id = $1
@@ -253,6 +302,42 @@ WHERE users.id = $1
 // an account that cannot sign in is no safety net.
 func (q *Queries) DeleteUserByID(ctx context.Context, id pgtype.UUID) (pgconn.CommandTag, error) {
 	return q.db.Exec(ctx, deleteUserByID, id)
+}
+
+const deleteZeroIdentityValueStats = `-- name: DeleteZeroIdentityValueStats :exec
+DELETE FROM identity_value_stats
+WHERE app_id = $1 AND key = $2 AND value = $3 AND device_count <= 0
+`
+
+type DeleteZeroIdentityValueStatsParams struct {
+	AppID pgtype.UUID `json:"app_id"`
+	Key   string      `json:"key"`
+	Value string      `json:"value"`
+}
+
+func (q *Queries) DeleteZeroIdentityValueStats(ctx context.Context, arg DeleteZeroIdentityValueStatsParams) error {
+	_, err := q.db.Exec(ctx, deleteZeroIdentityValueStats, arg.AppID, arg.Key, arg.Value)
+	return err
+}
+
+const ensureDeviceIdentity = `-- name: EnsureDeviceIdentity :exec
+INSERT INTO device_identity (app_id, eas_client_id)
+VALUES ($1, $2)
+ON CONFLICT (app_id, eas_client_id) DO NOTHING
+`
+
+type EnsureDeviceIdentityParams struct {
+	AppID       pgtype.UUID `json:"app_id"`
+	EasClientID pgtype.UUID `json:"eas_client_id"`
+}
+
+// Creates the row if this install was never seen. Split from the update on
+// purpose: FOR UPDATE cannot lock a row that does not exist yet, so two
+// concurrent first identifies of the same install would both merge against
+// an empty map and one would silently win. Insert-then-lock serializes them.
+func (q *Queries) EnsureDeviceIdentity(ctx context.Context, arg EnsureDeviceIdentityParams) error {
+	_, err := q.db.Exec(ctx, ensureDeviceIdentity, arg.AppID, arg.EasClientID)
+	return err
 }
 
 const getActiveRolloutUpdates = `-- name: GetActiveRolloutUpdates :many
@@ -763,6 +848,61 @@ func (q *Queries) GetChannelsByAppID(ctx context.Context, appID pgtype.UUID) ([]
 		return nil, err
 	}
 	return items, nil
+}
+
+const getDeviceIdentity = `-- name: GetDeviceIdentity :one
+SELECT app_id, eas_client_id, metadata, country_code, city, lat, lng, first_seen_at, last_seen_at FROM device_identity
+WHERE app_id = $1 AND eas_client_id = $2
+`
+
+type GetDeviceIdentityParams struct {
+	AppID       pgtype.UUID `json:"app_id"`
+	EasClientID pgtype.UUID `json:"eas_client_id"`
+}
+
+func (q *Queries) GetDeviceIdentity(ctx context.Context, arg GetDeviceIdentityParams) (DeviceIdentity, error) {
+	row := q.db.QueryRow(ctx, getDeviceIdentity, arg.AppID, arg.EasClientID)
+	var i DeviceIdentity
+	err := row.Scan(
+		&i.AppID,
+		&i.EasClientID,
+		&i.Metadata,
+		&i.CountryCode,
+		&i.City,
+		&i.Lat,
+		&i.Lng,
+		&i.FirstSeenAt,
+		&i.LastSeenAt,
+	)
+	return i, err
+}
+
+const getDeviceIdentityForUpdate = `-- name: GetDeviceIdentityForUpdate :one
+SELECT app_id, eas_client_id, metadata, country_code, city, lat, lng, first_seen_at, last_seen_at FROM device_identity
+WHERE app_id = $1 AND eas_client_id = $2
+FOR UPDATE
+`
+
+type GetDeviceIdentityForUpdateParams struct {
+	AppID       pgtype.UUID `json:"app_id"`
+	EasClientID pgtype.UUID `json:"eas_client_id"`
+}
+
+func (q *Queries) GetDeviceIdentityForUpdate(ctx context.Context, arg GetDeviceIdentityForUpdateParams) (DeviceIdentity, error) {
+	row := q.db.QueryRow(ctx, getDeviceIdentityForUpdate, arg.AppID, arg.EasClientID)
+	var i DeviceIdentity
+	err := row.Scan(
+		&i.AppID,
+		&i.EasClientID,
+		&i.Metadata,
+		&i.CountryCode,
+		&i.City,
+		&i.Lat,
+		&i.Lng,
+		&i.FirstSeenAt,
+		&i.LastSeenAt,
+	)
+	return i, err
 }
 
 const getEnterpriseLicense = `-- name: GetEnterpriseLicense :one
@@ -1516,6 +1656,25 @@ func (q *Queries) HasActiveRolloutUpdate(ctx context.Context, arg HasActiveRollo
 	return exists, err
 }
 
+const incrementIdentityValueStat = `-- name: IncrementIdentityValueStat :exec
+INSERT INTO identity_value_stats (app_id, key, value, device_count)
+VALUES ($1, $2, $3, 1)
+ON CONFLICT (app_id, key, value) DO UPDATE SET
+    device_count = identity_value_stats.device_count + 1,
+    last_seen_at = CURRENT_TIMESTAMP
+`
+
+type IncrementIdentityValueStatParams struct {
+	AppID pgtype.UUID `json:"app_id"`
+	Key   string      `json:"key"`
+	Value string      `json:"value"`
+}
+
+func (q *Queries) IncrementIdentityValueStat(ctx context.Context, arg IncrementIdentityValueStatParams) error {
+	_, err := q.db.Exec(ctx, incrementIdentityValueStat, arg.AppID, arg.Key, arg.Value)
+	return err
+}
+
 const insertApiKey = `-- name: InsertApiKey :one
 INSERT INTO api_keys (app_id, name, hint, hashed_key)
 VALUES ($1, $2, $3, $4)
@@ -2215,6 +2374,42 @@ func (q *Queries) ListAuditLogEventsAfter(ctx context.Context, arg ListAuditLogE
 	return items, nil
 }
 
+const listIdentitySchemaKeys = `-- name: ListIdentitySchemaKeys :many
+
+SELECT app_id, key, value_type, max_length, created_at FROM identity_schema
+WHERE app_id = $1
+ORDER BY key ASC
+`
+
+// ============================================================
+// Identity (ee/identity)
+// ============================================================
+func (q *Queries) ListIdentitySchemaKeys(ctx context.Context, appID pgtype.UUID) ([]IdentitySchema, error) {
+	rows, err := q.db.Query(ctx, listIdentitySchemaKeys, appID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []IdentitySchema
+	for rows.Next() {
+		var i IdentitySchema
+		if err := rows.Scan(
+			&i.AppID,
+			&i.Key,
+			&i.ValueType,
+			&i.MaxLength,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRoles = `-- name: ListRoles :many
 SELECT id, name, permissions, created_at, updated_at FROM roles
 ORDER BY name ASC
@@ -2640,6 +2835,54 @@ func (q *Queries) RevokeApiKeyByID(ctx context.Context, arg RevokeApiKeyByIDPara
 	return name, err
 }
 
+const searchIdentityValues = `-- name: SearchIdentityValues :many
+SELECT value, device_count FROM identity_value_stats
+WHERE app_id = $1 AND key = $2
+  AND value ILIKE '%' || $3::TEXT || '%'
+ORDER BY device_count DESC, value ASC
+LIMIT $4::INT
+`
+
+type SearchIdentityValuesParams struct {
+	AppID      pgtype.UUID `json:"app_id"`
+	Key        string      `json:"key"`
+	Search     string      `json:"search"`
+	MaxResults int32       `json:"max_results"`
+}
+
+type SearchIdentityValuesRow struct {
+	Value       string `json:"value"`
+	DeviceCount int64  `json:"device_count"`
+}
+
+// Autocomplete, substring arm: case-insensitive containment served by the
+// trigram index. % and _ in the search act as SQL wildcards; harmless for
+// autocomplete, so they are not escaped.
+func (q *Queries) SearchIdentityValues(ctx context.Context, arg SearchIdentityValuesParams) ([]SearchIdentityValuesRow, error) {
+	rows, err := q.db.Query(ctx, searchIdentityValues,
+		arg.AppID,
+		arg.Key,
+		arg.Search,
+		arg.MaxResults,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SearchIdentityValuesRow
+	for rows.Next() {
+		var i SearchIdentityValuesRow
+		if err := rows.Scan(&i.Value, &i.DeviceCount); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const setBranchProtected = `-- name: SetBranchProtected :execrows
 UPDATE branches
 SET protected = $1
@@ -2720,6 +2963,50 @@ func (q *Queries) StoreUpdateUUID(ctx context.Context, arg StoreUpdateUUIDParams
 		arg.AppID,
 		arg.Name,
 	)
+}
+
+const topIdentityValues = `-- name: TopIdentityValues :many
+SELECT value, device_count FROM identity_value_stats
+WHERE app_id = $1 AND key = $2
+ORDER BY device_count DESC, value ASC
+LIMIT $3::INT
+`
+
+type TopIdentityValuesParams struct {
+	AppID      pgtype.UUID `json:"app_id"`
+	Key        string      `json:"key"`
+	MaxResults int32       `json:"max_results"`
+}
+
+type TopIdentityValuesRow struct {
+	Value       string `json:"value"`
+	DeviceCount int64  `json:"device_count"`
+}
+
+// Autocomplete, empty-search arm: top values of a key by device count.
+// Deliberately a separate query from SearchIdentityValues: an OR'd
+// "search = ” OR value ILIKE ..." arm makes the statement un-indexable under
+// a generic plan (pgx prepares statements), forcing a seq scan of every
+// distinct value. Split, each arm gets its own stable plan: this one is an
+// index-only scan on (app_id, key, device_count DESC, value ASC).
+func (q *Queries) TopIdentityValues(ctx context.Context, arg TopIdentityValuesParams) ([]TopIdentityValuesRow, error) {
+	rows, err := q.db.Query(ctx, topIdentityValues, arg.AppID, arg.Key, arg.MaxResults)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []TopIdentityValuesRow
+	for rows.Next() {
+		var i TopIdentityValuesRow
+		if err := rows.Scan(&i.Value, &i.DeviceCount); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const touchSSOIdentityLastLogin = `-- name: TouchSSOIdentityLastLogin :exec
@@ -2840,6 +3127,53 @@ func (q *Queries) UpdateChannelRolloutPercentage(ctx context.Context, arg Update
 	return result.RowsAffected(), nil
 }
 
+const updateDeviceIdentity = `-- name: UpdateDeviceIdentity :one
+UPDATE device_identity SET
+    metadata = $3,
+    country_code = COALESCE($4, country_code),
+    city = COALESCE($5, city),
+    lat = COALESCE($6, lat),
+    lng = COALESCE($7, lng),
+    last_seen_at = CURRENT_TIMESTAMP
+WHERE app_id = $1 AND eas_client_id = $2
+RETURNING app_id, eas_client_id, metadata, country_code, city, lat, lng, first_seen_at, last_seen_at
+`
+
+type UpdateDeviceIdentityParams struct {
+	AppID       pgtype.UUID `json:"app_id"`
+	EasClientID pgtype.UUID `json:"eas_client_id"`
+	Metadata    []byte      `json:"metadata"`
+	CountryCode *string     `json:"country_code"`
+	City        *string     `json:"city"`
+	Lat         *float64    `json:"lat"`
+	Lng         *float64    `json:"lng"`
+}
+
+func (q *Queries) UpdateDeviceIdentity(ctx context.Context, arg UpdateDeviceIdentityParams) (DeviceIdentity, error) {
+	row := q.db.QueryRow(ctx, updateDeviceIdentity,
+		arg.AppID,
+		arg.EasClientID,
+		arg.Metadata,
+		arg.CountryCode,
+		arg.City,
+		arg.Lat,
+		arg.Lng,
+	)
+	var i DeviceIdentity
+	err := row.Scan(
+		&i.AppID,
+		&i.EasClientID,
+		&i.Metadata,
+		&i.CountryCode,
+		&i.City,
+		&i.Lat,
+		&i.Lng,
+		&i.FirstSeenAt,
+		&i.LastSeenAt,
+	)
+	return i, err
+}
+
 const updateRole = `-- name: UpdateRole :execresult
 UPDATE roles
 SET name = $2, permissions = $3, updated_at = CURRENT_TIMESTAMP
@@ -2936,6 +3270,40 @@ func (q *Queries) UpsertEnterpriseLicense(ctx context.Context, licenseKey string
 		&i.LicenseKey,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const upsertIdentitySchemaKey = `-- name: UpsertIdentitySchemaKey :one
+INSERT INTO identity_schema (app_id, key, value_type, max_length)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (app_id, key) DO UPDATE SET
+    value_type = EXCLUDED.value_type,
+    max_length = EXCLUDED.max_length
+RETURNING app_id, key, value_type, max_length, created_at
+`
+
+type UpsertIdentitySchemaKeyParams struct {
+	AppID     pgtype.UUID `json:"app_id"`
+	Key       string      `json:"key"`
+	ValueType string      `json:"value_type"`
+	MaxLength int32       `json:"max_length"`
+}
+
+func (q *Queries) UpsertIdentitySchemaKey(ctx context.Context, arg UpsertIdentitySchemaKeyParams) (IdentitySchema, error) {
+	row := q.db.QueryRow(ctx, upsertIdentitySchemaKey,
+		arg.AppID,
+		arg.Key,
+		arg.ValueType,
+		arg.MaxLength,
+	)
+	var i IdentitySchema
+	err := row.Scan(
+		&i.AppID,
+		&i.Key,
+		&i.ValueType,
+		&i.MaxLength,
+		&i.CreatedAt,
 	)
 	return i, err
 }

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -975,3 +975,98 @@ WHERE (sqlc.narg('actor_id')::TEXT IS NULL OR actor_id = sqlc.narg('actor_id'))
   AND (sqlc.narg('outcome')::TEXT IS NULL OR outcome = sqlc.narg('outcome'))
   AND (sqlc.narg('occurred_from')::TIMESTAMPTZ IS NULL OR occurred_at >= sqlc.narg('occurred_from'))
   AND (sqlc.narg('occurred_to')::TIMESTAMPTZ IS NULL OR occurred_at <= sqlc.narg('occurred_to'));
+
+-- ============================================================
+-- Identity (ee/identity)
+-- ============================================================
+
+-- name: ListIdentitySchemaKeys :many
+SELECT * FROM identity_schema
+WHERE app_id = $1
+ORDER BY key ASC;
+
+-- name: UpsertIdentitySchemaKey :one
+INSERT INTO identity_schema (app_id, key, value_type, max_length)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (app_id, key) DO UPDATE SET
+    value_type = EXCLUDED.value_type,
+    max_length = EXCLUDED.max_length
+RETURNING *;
+
+-- name: DeleteIdentitySchemaKey :execresult
+DELETE FROM identity_schema
+WHERE app_id = $1 AND key = $2;
+
+-- Wipes the autocomplete entries of a key when it leaves the allowlist, so
+-- searchMetadata never suggests values of a key the operator removed. The
+-- values already merged into device_identity.metadata are left in place.
+-- name: DeleteIdentityValueStatsForKey :exec
+DELETE FROM identity_value_stats
+WHERE app_id = $1 AND key = $2;
+
+-- Creates the row if this install was never seen. Split from the update on
+-- purpose: FOR UPDATE cannot lock a row that does not exist yet, so two
+-- concurrent first identifies of the same install would both merge against
+-- an empty map and one would silently win. Insert-then-lock serializes them.
+-- name: EnsureDeviceIdentity :exec
+INSERT INTO device_identity (app_id, eas_client_id)
+VALUES ($1, $2)
+ON CONFLICT (app_id, eas_client_id) DO NOTHING;
+
+-- name: GetDeviceIdentityForUpdate :one
+SELECT * FROM device_identity
+WHERE app_id = $1 AND eas_client_id = $2
+FOR UPDATE;
+
+-- name: GetDeviceIdentity :one
+SELECT * FROM device_identity
+WHERE app_id = $1 AND eas_client_id = $2;
+
+-- name: UpdateDeviceIdentity :one
+UPDATE device_identity SET
+    metadata = $3,
+    country_code = COALESCE(sqlc.narg('country_code'), country_code),
+    city = COALESCE(sqlc.narg('city'), city),
+    lat = COALESCE(sqlc.narg('lat'), lat),
+    lng = COALESCE(sqlc.narg('lng'), lng),
+    last_seen_at = CURRENT_TIMESTAMP
+WHERE app_id = $1 AND eas_client_id = $2
+RETURNING *;
+
+-- name: IncrementIdentityValueStat :exec
+INSERT INTO identity_value_stats (app_id, key, value, device_count)
+VALUES ($1, $2, $3, 1)
+ON CONFLICT (app_id, key, value) DO UPDATE SET
+    device_count = identity_value_stats.device_count + 1,
+    last_seen_at = CURRENT_TIMESTAMP;
+
+-- name: DecrementIdentityValueStat :exec
+UPDATE identity_value_stats
+SET device_count = GREATEST(device_count - 1, 0)
+WHERE app_id = $1 AND key = $2 AND value = $3;
+
+-- name: DeleteZeroIdentityValueStats :exec
+DELETE FROM identity_value_stats
+WHERE app_id = $1 AND key = $2 AND value = $3 AND device_count <= 0;
+
+-- Autocomplete, empty-search arm: top values of a key by device count.
+-- Deliberately a separate query from SearchIdentityValues: an OR'd
+-- "search = '' OR value ILIKE ..." arm makes the statement un-indexable under
+-- a generic plan (pgx prepares statements), forcing a seq scan of every
+-- distinct value. Split, each arm gets its own stable plan: this one is an
+-- index-only scan on (app_id, key, device_count DESC, value ASC).
+-- name: TopIdentityValues :many
+SELECT value, device_count FROM identity_value_stats
+WHERE app_id = $1 AND key = $2
+ORDER BY device_count DESC, value ASC
+LIMIT sqlc.arg(max_results)::INT;
+
+-- Autocomplete, substring arm: case-insensitive containment served by the
+-- trigram index. % and _ in the search act as SQL wildcards; harmless for
+-- autocomplete, so they are not escaped.
+-- name: SearchIdentityValues :many
+SELECT value, device_count FROM identity_value_stats
+WHERE app_id = $1 AND key = $2
+  AND value ILIKE '%' || sqlc.arg(search)::TEXT || '%'
+ORDER BY device_count DESC, value ASC
+LIMIT sqlc.arg(max_results)::INT;


### PR DESCRIPTION
Stack 1/3 of the device-identity feature (ee/identity). Base: \`main\`.

Postgres control-plane storage that maps an expo-eas-client install UUID to operator-defined metadata:
- Migration \`20260722150000_identity.sql\`: \`identity_schema\` (per-app allowlist, types string|number|boolean + max_length), \`device_identity\` (JSONB metadata + GIN, GeoIP columns), \`identity_value_stats\` (distinct-value counts + trigram) powering searchMetadata.
- \`ee/identity\` domain + Postgres store: allowlist sanitization, transactional insert-then-lock merge with deterministic (key,value) stat-op ordering (no deadlock), split top/substring autocomplete queries with a top-N btree index.
- EE-licensed, NOT license-gated: identity works for community users too.
- Unit + gated integration tests (TEST_DATABASE_URL) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added identity metadata management with allowlisted keys, type validation, length limits, and sanitization.
  * Added device identity tracking with metadata merging, optional geolocation, and last-seen information.
  * Added metadata value statistics and autocomplete/search ranked by device counts.
  * Added schema key creation, updates, deletion, and safeguards against exceeding configured limits.
* **Bug Fixes**
  * Prevented invalid, unsupported, oversized, or non-finite metadata values from being stored.
  * Improved consistency and concurrency safety when updating identity data and statistics.
* **Tests**
  * Added comprehensive validation, storage, search, geolocation, numeric handling, deletion, and concurrency coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->