### PR TITLE
identity: service + GeoLite2

### DIFF
--- a/ee/identity/geoip.go
+++ b/ee/identity/geoip.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package identity
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"strings"
+
+	"github.com/oschwald/geoip2-golang"
+)
+
+// GeoResolver turns a request IP into an optional Geo enrichment. Resolvers
+// must be nil-tolerant on the value they return: no resolution is a normal
+// outcome (private IP, unknown range, no database configured), never an error
+// worth failing an identify over.
+type GeoResolver interface {
+	Resolve(ip string) *Geo
+}
+
+// GeoLite2Resolver resolves against a local MaxMind GeoLite2/GeoIP2 City
+// database (mmdb file). The operator downloads the database with their own
+// MaxMind license key; without a configured file the feature is simply off.
+// City-level accuracy: lat/lng is a city centroid, not a device position.
+type GeoLite2Resolver struct {
+	db *geoip2.Reader
+}
+
+func NewGeoLite2Resolver(path string) (*GeoLite2Resolver, error) {
+	db, err := geoip2.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening GeoLite2 database %q: %w", path, err)
+	}
+	// Open succeeds on ANY valid mmdb (ASN, ISP...), after which every City()
+	// lookup fails silently and the operator would see geo mysteriously never
+	// resolve. Fail loud at boot instead.
+	if dbType := db.Metadata().DatabaseType; !strings.Contains(dbType, "City") && !strings.Contains(dbType, "Country") {
+		_ = db.Close()
+		return nil, fmt.Errorf("GeoLite2 database %q has type %q; a City or Country database is required", path, dbType)
+	}
+	log.Printf("🌍 [IDENTITY] GeoLite2 database loaded from %s", path)
+	return &GeoLite2Resolver{db: db}, nil
+}
+
+func (r *GeoLite2Resolver) Close() {
+	if r != nil && r.db != nil {
+		_ = r.db.Close()
+	}
+}
+
+func (r *GeoLite2Resolver) Resolve(ipStr string) *Geo {
+	ip := net.ParseIP(ipStr)
+	if ip == nil || ip.IsPrivate() || ip.IsLoopback() || ip.IsUnspecified() {
+		return nil
+	}
+	if r == nil || r.db == nil {
+		return nil
+	}
+	record, err := r.db.City(ip)
+	if err != nil {
+		return nil
+	}
+
+	geo := &Geo{}
+	resolved := false
+	if code := record.Country.IsoCode; code != "" {
+		geo.CountryCode = &code
+		resolved = true
+	}
+	if city := record.City.Names["en"]; city != "" {
+		geo.City = &city
+		resolved = true
+	}
+	// 0,0 (Null Island) is what the database reports when it has no location;
+	// treat it as absent rather than pinning devices in the Gulf of Guinea.
+	if record.Location.Latitude != 0 || record.Location.Longitude != 0 {
+		lat, lng := record.Location.Latitude, record.Location.Longitude
+		geo.Lat = &lat
+		geo.Lng = &lng
+		resolved = true
+	}
+	if !resolved {
+		return nil
+	}
+	return geo
+}

--- a/ee/identity/metrics.go
+++ b/ee/identity/metrics.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package identity
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Identity is expected to be quiet in steady state (per-session, mostly
+// no-op re-identifies); these metrics exist to see the two failure modes
+// coming: latency creep on the hot stat rows during install storms (the
+// signal to move stats to a batched aggregator), and a chronic dropped-keys
+// count (a client sending keys the operator never declared).
+var (
+	identityApplyDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "identity_apply_duration_seconds",
+			Help:    "Duration of identity operations against the store, by operation and outcome",
+			Buckets: []float64{0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5},
+		},
+		// outcome keeps fast-failing hostile requests from skewing the
+		// latency percentiles of legitimate operations down.
+		[]string{"op", "outcome"},
+	)
+
+	identityApplyVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "identity_apply_total",
+			Help: "Identity operations applied, by appId, operation and outcome",
+		},
+		[]string{"appId", "op", "outcome"},
+	)
+
+	identityDroppedKeysVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "identity_dropped_keys_total",
+			Help: "Metadata keys rejected by the allowlist, by appId",
+		},
+		[]string{"appId"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(identityApplyDuration, identityApplyVec, identityDroppedKeysVec)
+}
+
+func observeApply(appID string, op Op, err error, droppedKeys int, elapsed time.Duration) {
+	outcome := "ok"
+	if err != nil {
+		outcome = "error"
+		// The appId only becomes trustworthy once the store accepted it (the
+		// device FK guarantees a real app). On errors it may be any string a
+		// hostile client sprayed on the unauthenticated wire, and every unique
+		// label value allocates a permanent child series in the registry, so
+		// error counts are aggregated under a sentinel instead.
+		appID = "unknown"
+	}
+	identityApplyDuration.WithLabelValues(string(op), outcome).Observe(elapsed.Seconds())
+	identityApplyVec.WithLabelValues(appID, string(op), outcome).Inc()
+	if droppedKeys > 0 && err == nil {
+		identityDroppedKeysVec.WithLabelValues(appID).Add(float64(droppedKeys))
+	}
+}

--- a/ee/identity/service.go
+++ b/ee/identity/service.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package identity
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Op is one identity operation as carried on the wire (the log event name).
+// The vocabulary mirrors PostHog/Mixpanel/Amplitude on purpose: $set merges,
+// $set_once only fills absent keys, $unset removes. There is deliberately no
+// reset(): the eas_client_id cannot rotate, so logout is expressed as $unset.
+type Op string
+
+const (
+	OpSet     Op = "$set"
+	OpSetOnce Op = "$set_once"
+	OpUnset   Op = "$unset"
+)
+
+// IsIdentityOp reports whether a log event name is one of the identity
+// operations; the ingest route uses it to route identity events away from the
+// telemetry path.
+func IsIdentityOp(eventName string) bool {
+	switch Op(eventName) {
+	case OpSet, OpSetOnce, OpUnset:
+		return true
+	}
+	return false
+}
+
+// IdentityMutator is what the service needs from the store; narrow on purpose
+// so tests can fake it and future stores stay honest about the contract.
+type IdentityMutator interface {
+	ApplySet(ctx context.Context, appID string, easClientID string, raw map[string]any, geo *Geo) (ApplyResult, error)
+	ApplySetOnce(ctx context.Context, appID string, easClientID string, raw map[string]any, geo *Geo) (ApplyResult, error)
+	ApplyUnset(ctx context.Context, appID string, easClientID string, keys []string, geo *Geo) (ApplyResult, error)
+}
+
+// Service applies identity operations coming off the wire: resolve the
+// request IP into a geo enrichment, dispatch to the store, and account for
+// what happened in Prometheus. The ingest route owns transport concerns
+// (decoding, response codes); the service owns semantics.
+type Service struct {
+	store IdentityMutator
+	geo   GeoResolver
+}
+
+// NewService builds the identity service. geo may be nil: identity works
+// without a GeoLite2 database, devices simply stay unlocated.
+func NewService(store IdentityMutator, geo GeoResolver) *Service {
+	return &Service{store: store, geo: geo}
+}
+
+// Request is one identity operation extracted from a log event.
+type Request struct {
+	AppID       string
+	EASClientID string
+	Op          Op
+	// Attributes carries the key/value payload of $set and $set_once.
+	Attributes map[string]any
+	// UnsetKeys carries the key names of $unset.
+	UnsetKeys []string
+	// RemoteIP is the already-resolved client IP of the HTTP request that
+	// delivered the batch (proxy handling happens upstream).
+	RemoteIP string
+}
+
+func (s *Service) Apply(ctx context.Context, req Request) (ApplyResult, error) {
+	start := time.Now()
+
+	var geo *Geo
+	if s.geo != nil && req.RemoteIP != "" {
+		geo = s.geo.Resolve(req.RemoteIP)
+	}
+
+	var result ApplyResult
+	var err error
+	switch req.Op {
+	case OpSet:
+		result, err = s.store.ApplySet(ctx, req.AppID, req.EASClientID, req.Attributes, geo)
+	case OpSetOnce:
+		result, err = s.store.ApplySetOnce(ctx, req.AppID, req.EASClientID, req.Attributes, geo)
+	case OpUnset:
+		result, err = s.store.ApplyUnset(ctx, req.AppID, req.EASClientID, req.UnsetKeys, geo)
+	default:
+		// The op sentinel keeps the label set bounded: req.Op is wire input
+		// here, not one of our constants.
+		err = fmt.Errorf("unknown identity op %q", req.Op)
+		observeApply(req.AppID, Op("unknown"), err, 0, time.Since(start))
+		return ApplyResult{}, err
+	}
+
+	observeApply(req.AppID, req.Op, err, len(result.DroppedKeys), time.Since(start))
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	return result, nil
+}

--- a/ee/identity/service_test.go
+++ b/ee/identity/service_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package identity
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeMutator records the exact call the service dispatched, geo included.
+type fakeMutator struct {
+	calledOp Op
+	raw      map[string]any
+	keys     []string
+	geo      *Geo
+}
+
+func (f *fakeMutator) ApplySet(_ context.Context, _ string, _ string, raw map[string]any, geo *Geo) (ApplyResult, error) {
+	f.calledOp, f.raw, f.geo = OpSet, raw, geo
+	return ApplyResult{}, nil
+}
+
+func (f *fakeMutator) ApplySetOnce(_ context.Context, _ string, _ string, raw map[string]any, geo *Geo) (ApplyResult, error) {
+	f.calledOp, f.raw, f.geo = OpSetOnce, raw, geo
+	return ApplyResult{}, nil
+}
+
+func (f *fakeMutator) ApplyUnset(_ context.Context, _ string, _ string, keys []string, geo *Geo) (ApplyResult, error) {
+	f.calledOp, f.keys, f.geo = OpUnset, keys, geo
+	return ApplyResult{}, nil
+}
+
+type fakeResolver struct {
+	geo    *Geo
+	lastIP string
+}
+
+func (f *fakeResolver) Resolve(ip string) *Geo {
+	f.lastIP = ip
+	return f.geo
+}
+
+func TestIsIdentityOp(t *testing.T) {
+	require.True(t, IsIdentityOp("$set"))
+	require.True(t, IsIdentityOp("$set_once"))
+	require.True(t, IsIdentityOp("$unset"))
+	require.False(t, IsIdentityOp("identify"))
+	require.False(t, IsIdentityOp("exception"))
+	require.False(t, IsIdentityOp(""))
+}
+
+func TestServiceDispatchAndGeo(t *testing.T) {
+	appID, clientID := uuid.NewString(), uuid.NewString()
+	geo := &Geo{CountryCode: strPtr("FR")}
+
+	t.Run("set carries attributes and resolved geo", func(t *testing.T) {
+		mutator := &fakeMutator{}
+		resolver := &fakeResolver{geo: geo}
+		service := NewService(mutator, resolver)
+		_, err := service.Apply(context.Background(), Request{
+			AppID: appID, EASClientID: clientID, Op: OpSet,
+			Attributes: map[string]any{"userId": "u1"},
+			RemoteIP:   "203.0.113.7",
+		})
+		require.NoError(t, err)
+		require.Equal(t, OpSet, mutator.calledOp)
+		require.Equal(t, map[string]any{"userId": "u1"}, mutator.raw)
+		require.Equal(t, geo, mutator.geo)
+		require.Equal(t, "203.0.113.7", resolver.lastIP)
+	})
+
+	t.Run("set_once and unset dispatch to their store paths", func(t *testing.T) {
+		mutator := &fakeMutator{}
+		service := NewService(mutator, nil)
+		_, err := service.Apply(context.Background(), Request{AppID: appID, EASClientID: clientID, Op: OpSetOnce, Attributes: map[string]any{"a": "b"}})
+		require.NoError(t, err)
+		require.Equal(t, OpSetOnce, mutator.calledOp)
+
+		_, err = service.Apply(context.Background(), Request{AppID: appID, EASClientID: clientID, Op: OpUnset, UnsetKeys: []string{"userId"}})
+		require.NoError(t, err)
+		require.Equal(t, OpUnset, mutator.calledOp)
+		require.Equal(t, []string{"userId"}, mutator.keys)
+	})
+
+	t.Run("nil resolver and empty ip mean nil geo", func(t *testing.T) {
+		mutator := &fakeMutator{}
+		service := NewService(mutator, nil)
+		_, err := service.Apply(context.Background(), Request{AppID: appID, EASClientID: clientID, Op: OpSet})
+		require.NoError(t, err)
+		require.Nil(t, mutator.geo)
+
+		resolver := &fakeResolver{geo: geo}
+		service = NewService(mutator, resolver)
+		_, err = service.Apply(context.Background(), Request{AppID: appID, EASClientID: clientID, Op: OpSet})
+		require.NoError(t, err)
+		require.Empty(t, resolver.lastIP, "resolver must not be called without an IP")
+	})
+
+	t.Run("unknown op is an error", func(t *testing.T) {
+		service := NewService(&fakeMutator{}, nil)
+		_, err := service.Apply(context.Background(), Request{AppID: appID, EASClientID: clientID, Op: Op("identify")})
+		require.ErrorContains(t, err, "unknown identity op")
+	})
+}
+
+func TestGeoLite2ResolverGuards(t *testing.T) {
+	// Constructor surfaces a clear error on a missing database.
+	_, err := NewGeoLite2Resolver("/nonexistent/GeoLite2-City.mmdb")
+	require.Error(t, err)
+
+	// The IP guards run before any database access, so an empty resolver is
+	// safe: garbage, private, loopback and unspecified IPs resolve to nil.
+	resolver := &GeoLite2Resolver{}
+	for _, ip := range []string{"", "not-an-ip", "10.1.2.3", "192.168.1.1", "127.0.0.1", "0.0.0.0", "::1", "fd00::1"} {
+		require.Nil(t, resolver.Resolve(ip), "ip %q", ip)
+	}
+	// Public IP with no database still resolves to nil instead of panicking.
+	require.Nil(t, resolver.Resolve("203.0.113.7"))
+}

--- a/ee/identity/store_postgres.go
+++ b/ee/identity/store_postgres.go
@@ -164,13 +164,41 @@ type statOp struct {
 	decrement bool
 }
 
-// ApplyIdentify runs one identify against the store: sanitize the raw wire
-// metadata against the allowlist, merge it into the device row (per-key merge,
-// incoming keys win), refresh geo when provided, and keep the per-value
-// device counts in sync. Everything happens in one transaction with the
-// device row locked, so concurrent identifies of the same install serialize
-// and the counts never drift from the merges that produced them.
-func (s *PostgresIdentityStore) ApplyIdentify(ctx context.Context, appID string, easClientID string, raw map[string]any, geo *Geo) (ApplyResult, error) {
+type mutationKind int
+
+const (
+	mutationSet mutationKind = iota
+	mutationSetOnce
+	mutationUnset
+)
+
+// ApplySet runs one $set against the store: sanitize the raw wire metadata
+// against the allowlist, merge it into the device row (per-key merge, incoming
+// keys win), refresh geo when provided, and keep the per-value device counts
+// in sync. Everything happens in one transaction with the device row locked,
+// so concurrent identifies of the same install serialize and the counts never
+// drift from the merges that produced them.
+func (s *PostgresIdentityStore) ApplySet(ctx context.Context, appID string, easClientID string, raw map[string]any, geo *Geo) (ApplyResult, error) {
+	return s.mutate(ctx, appID, easClientID, mutationSet, raw, nil, geo)
+}
+
+// ApplySetOnce is $set_once: a sanitized key is written only when the device
+// does not hold it yet; keys already present are silently left untouched
+// (same contract as PostHog/Mixpanel/Amplitude).
+func (s *PostgresIdentityStore) ApplySetOnce(ctx context.Context, appID string, easClientID string, raw map[string]any, geo *Geo) (ApplyResult, error) {
+	return s.mutate(ctx, appID, easClientID, mutationSetOnce, raw, nil, geo)
+}
+
+// ApplyUnset removes keys from the device and moves the stat counts down.
+// Keys the device does not hold are ignored, which also bounds the work to
+// the (schema-capped) size of the device's metadata no matter how many keys
+// a hostile payload lists. Unset works even for keys since removed from the
+// allowlist: it is the cleanup path.
+func (s *PostgresIdentityStore) ApplyUnset(ctx context.Context, appID string, easClientID string, keys []string, geo *Geo) (ApplyResult, error) {
+	return s.mutate(ctx, appID, easClientID, mutationUnset, nil, keys, geo)
+}
+
+func (s *PostgresIdentityStore) mutate(ctx context.Context, appID string, easClientID string, kind mutationKind, raw map[string]any, unsetKeys []string, geo *Geo) (ApplyResult, error) {
 	appUUID, err := toPgUUID(appID)
 	if err != nil {
 		return ApplyResult{}, err
@@ -182,13 +210,18 @@ func (s *PostgresIdentityStore) ApplyIdentify(ctx context.Context, appID string,
 
 	var result ApplyResult
 	err = s.engine.WithTx(ctx, func(q *pgdb.Queries) error {
-		// The schema read shares the transaction so a concurrent allowlist
-		// change cannot produce a merge mixing two versions of the schema.
-		schemaRows, err := q.ListIdentitySchemaKeys(ctx, appUUID)
-		if err != nil {
-			return fmt.Errorf("listing identity schema: %w", err)
+		var sanitized map[string]any
+		var dropped []string
+		if kind != mutationUnset {
+			// The schema read shares the transaction so a concurrent allowlist
+			// change cannot produce a merge mixing two versions of the schema.
+			// Unset skips it entirely: it bypasses the allowlist by design.
+			schemaRows, err := q.ListIdentitySchemaKeys(ctx, appUUID)
+			if err != nil {
+				return fmt.Errorf("listing identity schema: %w", err)
+			}
+			sanitized, dropped = schemaFromRows(schemaRows).Sanitize(raw)
 		}
-		sanitized, dropped := schemaFromRows(schemaRows).Sanitize(raw)
 
 		if err := q.EnsureDeviceIdentity(ctx, pgdb.EnsureDeviceIdentityParams{AppID: appUUID, EasClientID: clientUUID}); err != nil {
 			return fmt.Errorf("ensuring device row: %w", err)
@@ -209,17 +242,36 @@ func (s *PostgresIdentityStore) ApplyIdentify(ctx context.Context, appID string,
 			merged[key] = value
 		}
 		var ops []statOp
-		for key, value := range sanitized {
-			merged[key] = value
-			newRendered := RenderValue(value)
-			if oldValue, existed := previous[key]; existed {
-				oldRendered := RenderValue(oldValue)
-				if oldRendered == newRendered {
+		switch kind {
+		case mutationSet, mutationSetOnce:
+			for key, value := range sanitized {
+				oldValue, existed := previous[key]
+				if kind == mutationSetOnce && existed {
 					continue
 				}
-				ops = append(ops, statOp{key: key, value: oldRendered, decrement: true})
+				merged[key] = value
+				newRendered := RenderValue(value)
+				if existed {
+					oldRendered := RenderValue(oldValue)
+					if oldRendered == newRendered {
+						continue
+					}
+					ops = append(ops, statOp{key: key, value: oldRendered, decrement: true})
+				}
+				ops = append(ops, statOp{key: key, value: newRendered})
 			}
-			ops = append(ops, statOp{key: key, value: newRendered})
+		case mutationUnset:
+			for _, key := range unsetKeys {
+				oldValue, existed := previous[key]
+				if !existed {
+					continue
+				}
+				// Also remove from previous so a duplicated key in the payload
+				// cannot decrement the same stat row twice.
+				delete(previous, key)
+				delete(merged, key)
+				ops = append(ops, statOp{key: key, value: RenderValue(oldValue), decrement: true})
+			}
 		}
 		mergedJSON, err := json.Marshal(merged)
 		if err != nil {

--- a/ee/identity/store_postgres_test.go
+++ b/ee/identity/store_postgres_test.go
@@ -108,7 +108,7 @@ func TestSchemaCRUD(t *testing.T) {
 	require.False(t, deleted)
 }
 
-func TestApplyIdentifyMergesAndCounts(t *testing.T) {
+func TestApplySetMergesAndCounts(t *testing.T) {
 	store, pool := setupIdentityStore(t)
 	appID := seedApp(t, pool)
 	ctx := context.Background()
@@ -116,7 +116,7 @@ func TestApplyIdentifyMergesAndCounts(t *testing.T) {
 	declareKey(t, store, appID, "tenant", ValueTypeString)
 
 	clientID := uuid.NewString()
-	result, err := store.ApplyIdentify(ctx, appID, clientID, map[string]any{
+	result, err := store.ApplySet(ctx, appID, clientID, map[string]any{
 		"userId": "user_1",
 		"junk":   "dropped by the allowlist",
 	}, nil)
@@ -125,20 +125,20 @@ func TestApplyIdentifyMergesAndCounts(t *testing.T) {
 	require.Equal(t, []string{"junk"}, result.DroppedKeys)
 
 	// Second identify adds a key and keeps the first one (per-key merge).
-	result, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"tenant": "acme"}, nil)
+	result, err = store.ApplySet(ctx, appID, clientID, map[string]any{"tenant": "acme"}, nil)
 	require.NoError(t, err)
 	require.Equal(t, map[string]any{"userId": "user_1", "tenant": "acme"}, result.Device.Metadata)
 
 	// Changing a value moves the device count from the old value to the new
 	// one and prunes the emptied row.
-	_, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"tenant": "globex"}, nil)
+	_, err = store.ApplySet(ctx, appID, clientID, map[string]any{"tenant": "globex"}, nil)
 	require.NoError(t, err)
 	values, err := store.SearchMetadataValues(ctx, appID, "tenant", "", 10)
 	require.NoError(t, err)
 	require.Equal(t, []ValueCount{{Value: "globex", DeviceCount: 1}}, values)
 
 	// Re-identifying the same value must not inflate the count.
-	_, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"tenant": "globex"}, nil)
+	_, err = store.ApplySet(ctx, appID, clientID, map[string]any{"tenant": "globex"}, nil)
 	require.NoError(t, err)
 	values, err = store.SearchMetadataValues(ctx, appID, "tenant", "", 10)
 	require.NoError(t, err)
@@ -153,27 +153,27 @@ func TestApplyIdentifyMergesAndCounts(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, missing)
 
-	_, err = store.ApplyIdentify(ctx, appID, "not-a-uuid", map[string]any{}, nil)
+	_, err = store.ApplySet(ctx, appID, "not-a-uuid", map[string]any{}, nil)
 	require.Error(t, err)
 }
 
 func strPtr(s string) *string     { return &s }
 func floatPtr(f float64) *float64 { return &f }
 
-func TestApplyIdentifyGeoCoalesce(t *testing.T) {
+func TestApplySetGeoCoalesce(t *testing.T) {
 	store, pool := setupIdentityStore(t)
 	appID := seedApp(t, pool)
 	ctx := context.Background()
 	clientID := uuid.NewString()
 
 	fullGeo := &Geo{CountryCode: strPtr("FR"), City: strPtr("Paris"), Lat: floatPtr(48.85), Lng: floatPtr(2.35)}
-	result, err := store.ApplyIdentify(ctx, appID, clientID, nil, fullGeo)
+	result, err := store.ApplySet(ctx, appID, clientID, nil, fullGeo)
 	require.NoError(t, err)
 	require.NotNil(t, result.Device.CountryCode)
 	require.Equal(t, "FR", *result.Device.CountryCode)
 
 	// An identify that resolves no geo keeps the previously known location.
-	result, err = store.ApplyIdentify(ctx, appID, clientID, nil, nil)
+	result, err = store.ApplySet(ctx, appID, clientID, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result.Device.CountryCode)
 	require.Equal(t, "FR", *result.Device.CountryCode)
@@ -182,7 +182,7 @@ func TestApplyIdentifyGeoCoalesce(t *testing.T) {
 
 	// A PARTIAL resolution (country-only is the common GeoLite2 case) updates
 	// what it knows and never blanks the rest with '' or 0/0.
-	result, err = store.ApplyIdentify(ctx, appID, clientID, nil, &Geo{CountryCode: strPtr("BE")})
+	result, err = store.ApplySet(ctx, appID, clientID, nil, &Geo{CountryCode: strPtr("BE")})
 	require.NoError(t, err)
 	require.Equal(t, "BE", *result.Device.CountryCode)
 	require.NotNil(t, result.Device.City)
@@ -200,7 +200,7 @@ func TestSearchMetadataValuesRankingAndFilter(t *testing.T) {
 	seed := map[string]int{"acme": 3, "acme-eu": 2, "globex": 1}
 	for tenant, devices := range seed {
 		for i := 0; i < devices; i++ {
-			_, err := store.ApplyIdentify(ctx, appID, uuid.NewString(), map[string]any{"tenant": tenant}, nil)
+			_, err := store.ApplySet(ctx, appID, uuid.NewString(), map[string]any{"tenant": tenant}, nil)
 			require.NoError(t, err)
 		}
 	}
@@ -233,7 +233,7 @@ func TestDeleteSchemaKeyWipesItsStats(t *testing.T) {
 	declareKey(t, store, appID, "tenant", ValueTypeString)
 	declareKey(t, store, appID, "plan", ValueTypeString)
 
-	_, err := store.ApplyIdentify(ctx, appID, uuid.NewString(), map[string]any{"tenant": "acme", "plan": "pro"}, nil)
+	_, err := store.ApplySet(ctx, appID, uuid.NewString(), map[string]any{"tenant": "acme", "plan": "pro"}, nil)
 	require.NoError(t, err)
 
 	deleted, err := store.DeleteSchemaKey(ctx, appID, "tenant")
@@ -249,7 +249,7 @@ func TestDeleteSchemaKeyWipesItsStats(t *testing.T) {
 	require.Equal(t, []ValueCount{{Value: "pro", DeviceCount: 1}}, values)
 
 	// And its values are no longer accepted on the next identify.
-	result, err := store.ApplyIdentify(ctx, appID, uuid.NewString(), map[string]any{"tenant": "acme"}, nil)
+	result, err := store.ApplySet(ctx, appID, uuid.NewString(), map[string]any{"tenant": "acme"}, nil)
 	require.NoError(t, err)
 	require.Empty(t, result.Device.Metadata)
 	require.Equal(t, []string{"tenant"}, result.DroppedKeys)
@@ -258,7 +258,7 @@ func TestDeleteSchemaKeyWipesItsStats(t *testing.T) {
 // Concurrent first identifies of the same install must both land: the
 // insert-then-lock sequence serializes the merges, so neither metadata write
 // nor stat increment is lost.
-func TestApplyIdentifyConcurrentFirstWrite(t *testing.T) {
+func TestApplySetConcurrentFirstWrite(t *testing.T) {
 	store, pool := setupIdentityStore(t)
 	appID := seedApp(t, pool)
 	ctx := context.Background()
@@ -271,11 +271,11 @@ func TestApplyIdentifyConcurrentFirstWrite(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		_, errs[0] = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"userId": "user_1"}, nil)
+		_, errs[0] = store.ApplySet(ctx, appID, clientID, map[string]any{"userId": "user_1"}, nil)
 	}()
 	go func() {
 		defer wg.Done()
-		_, errs[1] = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"tenant": "acme"}, nil)
+		_, errs[1] = store.ApplySet(ctx, appID, clientID, map[string]any{"tenant": "acme"}, nil)
 	}()
 	wg.Wait()
 	require.NoError(t, errs[0])
@@ -300,7 +300,7 @@ func TestApplyIdentifyConcurrentFirstWrite(t *testing.T) {
 // values) must not deadlock: the store orders its stat-row locks by
 // (key, value) precisely for this. Before that ordering, this test deadlocked
 // within a handful of iterations (40P01 after the 1s deadlock_timeout).
-func TestApplyIdentifyConcurrentSharedStatRowsNoDeadlock(t *testing.T) {
+func TestApplySetConcurrentSharedStatRowsNoDeadlock(t *testing.T) {
 	store, pool := setupIdentityStore(t)
 	appID := seedApp(t, pool)
 	ctx := context.Background()
@@ -325,7 +325,7 @@ func TestApplyIdentifyConcurrentSharedStatRowsNoDeadlock(t *testing.T) {
 			if i%2 == 1 {
 				p = alternate
 			}
-			if _, err := store.ApplyIdentify(ctx, appID, deviceA, p, nil); err != nil {
+			if _, err := store.ApplySet(ctx, appID, deviceA, p, nil); err != nil {
 				errsA[i] = err
 				return
 			}
@@ -338,7 +338,7 @@ func TestApplyIdentifyConcurrentSharedStatRowsNoDeadlock(t *testing.T) {
 			if i%2 == 1 {
 				p = payload
 			}
-			if _, err := store.ApplyIdentify(ctx, appID, deviceB, p, nil); err != nil {
+			if _, err := store.ApplySet(ctx, appID, deviceB, p, nil); err != nil {
 				errsB[i] = err
 				return
 			}
@@ -366,26 +366,105 @@ func TestApplyIdentifyConcurrentSharedStatRowsNoDeadlock(t *testing.T) {
 // A number-typed key must round-trip through JSONB without corrupting the
 // stat bookkeeping: 42 stored then re-read as float64 must compare equal to
 // an incoming 42 (no phantom dec/inc), and a real change must move the count.
-func TestApplyIdentifyNumberRoundtrip(t *testing.T) {
+func TestApplySetNumberRoundtrip(t *testing.T) {
 	store, pool := setupIdentityStore(t)
 	appID := seedApp(t, pool)
 	ctx := context.Background()
 	declareKey(t, store, appID, "seats", ValueTypeNumber)
 
 	clientID := uuid.NewString()
-	_, err := store.ApplyIdentify(ctx, appID, clientID, map[string]any{"seats": int64(42)}, nil)
+	_, err := store.ApplySet(ctx, appID, clientID, map[string]any{"seats": int64(42)}, nil)
 	require.NoError(t, err)
-	_, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"seats": float64(42)}, nil)
+	_, err = store.ApplySet(ctx, appID, clientID, map[string]any{"seats": float64(42)}, nil)
 	require.NoError(t, err)
 	values, err := store.SearchMetadataValues(ctx, appID, "seats", "", 10)
 	require.NoError(t, err)
 	require.Equal(t, []ValueCount{{Value: "42", DeviceCount: 1}}, values)
 
-	_, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"seats": 42.5}, nil)
+	_, err = store.ApplySet(ctx, appID, clientID, map[string]any{"seats": 42.5}, nil)
 	require.NoError(t, err)
 	values, err = store.SearchMetadataValues(ctx, appID, "seats", "", 10)
 	require.NoError(t, err)
 	require.Equal(t, []ValueCount{{Value: "42.5", DeviceCount: 1}}, values)
+}
+
+func TestApplySetOnce(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	declareKey(t, store, appID, "initialReferrer", ValueTypeString)
+	declareKey(t, store, appID, "plan", ValueTypeString)
+
+	clientID := uuid.NewString()
+	result, err := store.ApplySetOnce(ctx, appID, clientID, map[string]any{"initialReferrer": "organic"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"initialReferrer": "organic"}, result.Device.Metadata)
+
+	// A second set_once on a held key is silently ignored; absent keys apply.
+	result, err = store.ApplySetOnce(ctx, appID, clientID, map[string]any{"initialReferrer": "paid", "plan": "pro"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"initialReferrer": "organic", "plan": "pro"}, result.Device.Metadata)
+
+	// The ignored write must not have touched the stats either.
+	values, err := store.SearchMetadataValues(ctx, appID, "initialReferrer", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "organic", DeviceCount: 1}}, values)
+
+	// $set still overwrites what $set_once pinned.
+	result, err = store.ApplySet(ctx, appID, clientID, map[string]any{"initialReferrer": "paid"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, "paid", result.Device.Metadata["initialReferrer"])
+}
+
+func TestApplyUnset(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	declareKey(t, store, appID, "userId", ValueTypeString)
+	declareKey(t, store, appID, "tenant", ValueTypeString)
+
+	clientID := uuid.NewString()
+	_, err := store.ApplySet(ctx, appID, clientID, map[string]any{"userId": "user_1", "tenant": "acme"}, nil)
+	require.NoError(t, err)
+	// A second device holds the same userId value so the count sits at 2:
+	// without the payload dedupe, the duplicated key below would decrement
+	// twice, hit zero, and wrongly prune this survivor's count.
+	survivor := uuid.NewString()
+	_, err = store.ApplySet(ctx, appID, survivor, map[string]any{"userId": "user_1"}, nil)
+	require.NoError(t, err)
+
+	// Unset removes the key, decrements its stat once, and ignores
+	// duplicated and unknown keys in the payload.
+	result, err := store.ApplyUnset(ctx, appID, clientID, []string{"userId", "userId", "neverSeen"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"tenant": "acme"}, result.Device.Metadata)
+	values, err := store.SearchMetadataValues(ctx, appID, "userId", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "user_1", DeviceCount: 1}}, values)
+
+	// Unsetting the survivor takes the count to zero and prunes the row.
+	_, err = store.ApplyUnset(ctx, appID, survivor, []string{"userId"}, nil)
+	require.NoError(t, err)
+	values, err = store.SearchMetadataValues(ctx, appID, "userId", "", 10)
+	require.NoError(t, err)
+	require.Empty(t, values)
+	values, err = store.SearchMetadataValues(ctx, appID, "tenant", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "acme", DeviceCount: 1}}, values)
+
+	// Unset still works for a key removed from the allowlist: cleanup path.
+	deleted, err := store.DeleteSchemaKey(ctx, appID, "tenant")
+	require.NoError(t, err)
+	require.True(t, deleted)
+	result, err = store.ApplyUnset(ctx, appID, clientID, []string{"tenant"}, nil)
+	require.NoError(t, err)
+	require.Empty(t, result.Device.Metadata)
+
+	// Unsetting on a never-seen device just creates the empty row, no error.
+	fresh := uuid.NewString()
+	result, err = store.ApplyUnset(ctx, appID, fresh, []string{"userId"}, nil)
+	require.NoError(t, err)
+	require.Empty(t, result.Device.Metadata)
 }
 
 func TestUpsertSchemaKeyCap(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/jarcoal/httpmock v1.3.1
 	github.com/joho/godotenv v1.5.1
+	github.com/oschwald/geoip2-golang v1.13.0
 	github.com/pressly/goose/v3 v3.26.0
 	github.com/prometheus/client_golang v1.20.5
 	github.com/redis/go-redis/v9 v9.18.0
@@ -72,6 +73,7 @@ require (
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/oschwald/maxminddb-golang v1.13.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,10 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/oschwald/geoip2-golang v1.13.0 h1:Q44/Ldc703pasJeP5V9+aFSZFmBN7DKHbNsSFzQATJI=
+github.com/oschwald/geoip2-golang v1.13.0/go.mod h1:P9zG+54KPEFOliZ29i7SeYZ/GM6tfEL+rgSn03hYuUo=
+github.com/oschwald/maxminddb-golang v1.13.0 h1:R8xBorY71s84yO06NgTmQvqvTvlS/bnYZrrWX1MElnU=
+github.com/oschwald/maxminddb-golang v1.13.0/go.mod h1:BU0z8BfFVhi1LQaonTwwGQlsHUEu9pWNdMfmq4ztm0o=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=


### PR DESCRIPTION
Stack 2/3 of the device-identity feature. Base: \`identity/01-schema-store\`.

The identity operations and geo enrichment on top of the store:
- \`$set\` / \`$set_once\` / \`$unset\` (PostHog/Mixpanel/Amplitude vocabulary) via a shared \`mutate\` core; \`$unset\` dedupes payload keys and works on de-allowlisted keys as cleanup.
- \`GeoLite2Resolver\` (MaxMind mmdb, operator-provided): guards private/loopback/unspecified IPs, treats 0,0 as absent, per-field pointers so a country-only hit never blanks a known city.
- Identity \`Service\`: op dispatch + geo enrichment + Prometheus (apply duration/outcome, dropped keys), with the appId label bounded to a sentinel on errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)