### PR TITLE
observe: ingest route

### DIFF
--- a/ee/identity/record.go
+++ b/ee/identity/record.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package identity
+
+// Identity consumes log records already decoded by the transport (ee/observe
+// owns the OTLP wire format); this file owns the identity-side conventions:
+// which record attributes form the operation payload.
+
+// The two record attributes the client SDK reserves on every log record; they
+// are envelope, not payload, and are stripped before sanitization. Stripping
+// is identity policy and lives here on purpose: keyPattern allows dots, so an
+// operator could declare a metadata key literally named "event.name", and the
+// future ClickHouse flattener will keep these as real columns rather than
+// strip them. recordEventNameKey mirrors observe.EventNameKey by necessity
+// (the observe → identity dependency forbids importing it back).
+const (
+	recordEventNameKey = "event.name"
+	recordSessionIDKey = "session.id"
+)
+
+// unsetKeysAttributeKey is the record attribute carrying the key names of a
+// $unset: `logEvent('$unset', { attributes: { keys: ['userId'] } })`. An
+// explicit array attribute because null values never leave the stock SDK
+// (dropped client-side), so "set to null" cannot express removal.
+const unsetKeysAttributeKey = "keys"
+
+// RequestFromRecord builds an identity Request from one decoded log record.
+// The second return is false when the record carries nothing applicable
+// (a $unset without keys, a $set with an empty payload): skipping those saves
+// a store transaction that would be a no-op. attributes ownership transfers
+// to the request (the map is mutated to strip the envelope keys).
+func RequestFromRecord(appID string, easClientID string, op Op, attributes map[string]any, remoteIP string) (Request, bool) {
+	req := Request{AppID: appID, EASClientID: easClientID, Op: op, RemoteIP: remoteIP}
+	switch op {
+	case OpUnset:
+		rawKeys, _ := attributes[unsetKeysAttributeKey].([]any)
+		for _, rawKey := range rawKeys {
+			if key, ok := rawKey.(string); ok && key != "" {
+				req.UnsetKeys = append(req.UnsetKeys, key)
+			}
+		}
+		if len(req.UnsetKeys) == 0 {
+			return Request{}, false
+		}
+	case OpSet, OpSetOnce:
+		delete(attributes, recordEventNameKey)
+		delete(attributes, recordSessionIDKey)
+		if len(attributes) == 0 {
+			return Request{}, false
+		}
+		req.Attributes = attributes
+	default:
+		return Request{}, false
+	}
+	return req, true
+}
+
+// CoalesceRequests folds ADJACENT same-op requests of the same device into
+// one store transaction: the SDK ships its whole backlog in a single batch,
+// so several $set of one device commonly arrive together. Only adjacent ops
+// merge; folding across a different op in between would reorder the timeline
+// ($set(a) $unset(a) $set(a) must not collapse).
+func CoalesceRequests(requests []Request) []Request {
+	if len(requests) < 2 {
+		return requests
+	}
+	coalesced := make([]Request, 0, len(requests))
+	lastByDevice := make(map[string]int)
+	for _, req := range requests {
+		if idx, seen := lastByDevice[req.EASClientID]; seen && coalesced[idx].Op == req.Op {
+			previous := &coalesced[idx]
+			switch req.Op {
+			case OpUnset:
+				previous.UnsetKeys = append(previous.UnsetKeys, req.UnsetKeys...)
+				continue
+			case OpSet:
+				for key, value := range req.Attributes {
+					previous.Attributes[key] = value
+				}
+				continue
+			case OpSetOnce:
+				// First value wins within the fold, matching the store.
+				for key, value := range req.Attributes {
+					if _, held := previous.Attributes[key]; !held {
+						previous.Attributes[key] = value
+					}
+				}
+				continue
+			}
+		}
+		coalesced = append(coalesced, req)
+		lastByDevice[req.EASClientID] = len(coalesced) - 1
+	}
+	return coalesced
+}

--- a/ee/identity/record_test.go
+++ b/ee/identity/record_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package identity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestFromRecord(t *testing.T) {
+	t.Run("set strips the envelope and keeps the payload", func(t *testing.T) {
+		req, ok := RequestFromRecord("app", "client", OpSet, map[string]any{
+			"event.name": "$set",
+			"session.id": "aaaa",
+			"userId":     "u1",
+		}, "203.0.113.7")
+		require.True(t, ok)
+		require.Equal(t, OpSet, req.Op)
+		require.Equal(t, map[string]any{"userId": "u1"}, req.Attributes)
+		require.Equal(t, "203.0.113.7", req.RemoteIP)
+	})
+
+	t.Run("set with only envelope is skipped", func(t *testing.T) {
+		_, ok := RequestFromRecord("app", "client", OpSet, map[string]any{
+			"event.name": "$set",
+			"session.id": "aaaa",
+		}, "")
+		require.False(t, ok)
+	})
+
+	t.Run("unset reads its keys array and tolerates junk entries", func(t *testing.T) {
+		req, ok := RequestFromRecord("app", "client", OpUnset, map[string]any{
+			"event.name": "$unset",
+			"keys":       []any{"userId", "", 42, "tenant"},
+		}, "")
+		require.True(t, ok)
+		require.Equal(t, []string{"userId", "tenant"}, req.UnsetKeys)
+	})
+
+	t.Run("unset without usable keys is skipped", func(t *testing.T) {
+		_, ok := RequestFromRecord("app", "client", OpUnset, map[string]any{"event.name": "$unset"}, "")
+		require.False(t, ok)
+		_, ok = RequestFromRecord("app", "client", OpUnset, map[string]any{"keys": "userId"}, "")
+		require.False(t, ok)
+	})
+
+	t.Run("unknown op is skipped", func(t *testing.T) {
+		_, ok := RequestFromRecord("app", "client", Op("identify"), map[string]any{"userId": "u1"}, "")
+		require.False(t, ok)
+	})
+}
+
+func TestCoalesceRequests(t *testing.T) {
+	set := func(device string, kv map[string]any) Request {
+		return Request{AppID: "app", EASClientID: device, Op: OpSet, Attributes: kv}
+	}
+
+	t.Run("adjacent sets of one device fold, later keys win", func(t *testing.T) {
+		out := CoalesceRequests([]Request{
+			set("d1", map[string]any{"a": "1", "b": "1"}),
+			set("d1", map[string]any{"b": "2"}),
+			set("d2", map[string]any{"a": "x"}),
+		})
+		require.Len(t, out, 2)
+		require.Equal(t, map[string]any{"a": "1", "b": "2"}, out[0].Attributes)
+		require.Equal(t, "d2", out[1].EASClientID)
+	})
+
+	t.Run("a different op in between blocks the fold", func(t *testing.T) {
+		out := CoalesceRequests([]Request{
+			set("d1", map[string]any{"a": "1"}),
+			{AppID: "app", EASClientID: "d1", Op: OpUnset, UnsetKeys: []string{"a"}},
+			set("d1", map[string]any{"a": "2"}),
+		})
+		require.Len(t, out, 3, "$set $unset $set must not collapse")
+	})
+
+	t.Run("set_once folds with first value winning", func(t *testing.T) {
+		out := CoalesceRequests([]Request{
+			{AppID: "app", EASClientID: "d1", Op: OpSetOnce, Attributes: map[string]any{"ref": "organic"}},
+			{AppID: "app", EASClientID: "d1", Op: OpSetOnce, Attributes: map[string]any{"ref": "paid", "v": "1"}},
+		})
+		require.Len(t, out, 1)
+		require.Equal(t, map[string]any{"ref": "organic", "v": "1"}, out[0].Attributes)
+	})
+
+	t.Run("adjacent unsets append keys", func(t *testing.T) {
+		out := CoalesceRequests([]Request{
+			{AppID: "app", EASClientID: "d1", Op: OpUnset, UnsetKeys: []string{"a"}},
+			{AppID: "app", EASClientID: "d1", Op: OpUnset, UnsetKeys: []string{"b"}},
+		})
+		require.Len(t, out, 1)
+		require.Equal(t, []string{"a", "b"}, out[0].UnsetKeys)
+	})
+
+	t.Run("interleaved devices still fold per device", func(t *testing.T) {
+		out := CoalesceRequests([]Request{
+			set("d1", map[string]any{"a": "1"}),
+			set("d2", map[string]any{"a": "x"}),
+			set("d1", map[string]any{"b": "2"}),
+		})
+		// d1's two sets fold even though d2 sits between them: "adjacent" is
+		// per device, order across devices carries no meaning.
+		require.Len(t, out, 2)
+		require.Equal(t, map[string]any{"a": "1", "b": "2"}, out[0].Attributes)
+	})
+}

--- a/ee/observe/ingest.go
+++ b/ee/observe/ingest.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package observe
+
+import (
+	"errors"
+	"expo-open-ota/ee/identity"
+	"expo-open-ota/internal/helpers"
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+)
+
+// observeResult labels the batches_total counter; see metrics.go.
+const (
+	resultAccepted    = "accepted"
+	resultBadRequest  = "bad_request"
+	resultTooLarge    = "too_large"
+	resultUnavailable = "unavailable"
+)
+
+// maxLogsBodyBytes caps a /v1/logs body. The SDK sends its whole pending
+// backlog uncompressed in one POST with no client-side cap; a realistic batch
+// is hundreds of KB, 16MB covers a device coming back from a long offline
+// stretch. Beyond it we answer 413: the SDK treats it as a permanent failure
+// and drops the batch, which is the point: a 5xx would make the device
+// re-send the same oversized poison pill forever.
+const maxLogsBodyBytes = 16 << 20
+
+// IngestHandler owns the expo-observe ingestion routes. The response contract
+// is dictated by the SDK's classification and every arm of it either destroys
+// or preserves data on the device:
+//
+//	2xx              batch deleted on the device
+//	429/502/503/504  batch kept, retried later
+//	anything else    batch deleted (permanent failure)
+//
+// Two rules follow. Never answer 500 (a panic destroys a batch: the recover
+// arm answers 503), and only answer 503 for genuinely transient conditions
+// (a healthy retry, not a poison-pill loop).
+type IngestHandler struct {
+	// identityService applies $set/$set_once/$unset records. nil in stateless
+	// mode (no control plane): identity ops are then acknowledged and dropped,
+	// like every other record, so devices never accumulate a backlog.
+	identityService *identity.Service
+}
+
+func NewIngestHandler(identityService *identity.Service) *IngestHandler {
+	return &IngestHandler{identityService: identityService}
+}
+
+// HandleLogs ingests POST /observe/{APP_ID}/{projectId}/v1/logs. Rate
+// limiting and app-existence run in middleware ahead of this handler. Today
+// the only consumer is identity; telemetry records are acknowledged and
+// dropped. When the ClickHouse path lands, its dispatch slots in right after
+// the identity split, behind the enterprise license gate (identity stays
+// free).
+func (h *IngestHandler) HandleLogs(w http.ResponseWriter, r *http.Request) {
+	// A panic must not turn into gorilla's 500: 500 destroys the batch on the
+	// device, 503 preserves it for a retry.
+	defer func() {
+		if rec := recover(); rec != nil {
+			log.Printf("observe: recovered panic in logs ingestion: %v", rec)
+			observeBatch(resultUnavailable)
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+	}()
+
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxLogsBodyBytes))
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			observeBatch(resultTooLarge)
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			return
+		}
+		// The body could not be read off the wire: transient, preserve.
+		observeBatch(resultUnavailable)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
+	batch, err := DecodeLogs(body)
+	if err != nil {
+		// Structurally unreadable JSON: a broken client will not repair
+		// itself, 400 (permanent) rather than an eternal retry loop.
+		observeBatch(resultBadRequest)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if h.identityService == nil {
+		observeBatch(resultAccepted)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	appID := mux.Vars(r)["APP_ID"]
+	remoteIP := ""
+	if clientIP := helpers.ClientIP(r); clientIP.IsValid() {
+		remoteIP = clientIP.String()
+	}
+
+	requests := identityRequestsFromBatch(batch, appID, remoteIP)
+	for _, req := range identity.CoalesceRequests(requests) {
+		if _, err := h.identityService.Apply(r.Context(), req); err != nil {
+			// Store errors are transient (pool exhausted, database down):
+			// 503 keeps the batch on the device for a retry. Re-applying the
+			// already-committed prefix on that retry is idempotent ($set
+			// merges, $unset ignores absent keys), so no double effects.
+			log.Printf("observe: identity apply failed: %v", err)
+			observeBatch(resultUnavailable)
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+	}
+
+	observeBatch(resultAccepted)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// identityRequestsFromBatch turns a decoded logs batch into the identity
+// operations it carries, dropping (and counting) records that cannot be
+// attributed or are telemetry, not identity. Pure apart from the drop
+// counters, so it is unit-tested directly without an HTTP round-trip.
+func identityRequestsFromBatch(batch LogBatch, appID, remoteIP string) []identity.Request {
+	var requests []identity.Request
+	for _, resource := range batch.Resources {
+		clientID, _ := resource.Attributes[EASClientIDKey].(string)
+		// A missing or forged client id cannot be attributed to an install:
+		// skip those records instead of failing the batch (a non-2xx would
+		// also destroy or block every legitimate record around them).
+		if _, err := uuid.Parse(clientID); err != nil {
+			observeRecordsDropped(reasonForgedClientID, len(resource.Records))
+			continue
+		}
+		for _, record := range resource.Records {
+			eventName, _ := record.Attributes[EventNameKey].(string)
+			if !identity.IsIdentityOp(eventName) {
+				observeRecordsDropped(reasonTelemetry, 1) // ClickHouse path, later.
+				continue
+			}
+			if req, ok := identity.RequestFromRecord(appID, clientID, identity.Op(eventName), record.Attributes, remoteIP); ok {
+				requests = append(requests, req)
+			}
+		}
+	}
+	return requests
+}
+
+// HandleMetrics reserves POST /observe/{APP_ID}/{projectId}/v1/metrics.
+// Metrics are acknowledged and dropped until the ClickHouse path lands: for
+// the SDK, 204 and 404 destroy the batch identically, but the registered
+// route keeps operator logs quiet and the URL shape final. Rate limiting runs
+// in middleware ahead of this handler.
+func (h *IngestHandler) HandleMetrics(w http.ResponseWriter, r *http.Request) {
+	// Drain within the same cap so keep-alive connections stay reusable.
+	_, _ = io.Copy(io.Discard, http.MaxBytesReader(w, r.Body, maxLogsBodyBytes))
+	observeBatch(resultAccepted)
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/ee/observe/ingest_test.go
+++ b/ee/observe/ingest_test.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package observe
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"expo-open-ota/ee/identity"
+	"expo-open-ota/internal/database"
+	"expo-open-ota/internal/database/postgres"
+	"expo-open-ota/internal/database/postgres/pgdb"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+// serveIngest routes a request through the handler ONLY (no middleware), so
+// handler-contract tests are not perturbed by the rate limiter or the app
+// resolver. The middleware chain has its own tests.
+func serveIngest(handler *IngestHandler, method, path string, body []byte) *httptest.ResponseRecorder {
+	router := mux.NewRouter()
+	router.HandleFunc("/observe/{APP_ID}/{PROJECT_ID}/v1/logs", handler.HandleLogs).Methods(http.MethodPost)
+	router.HandleFunc("/observe/{APP_ID}/{PROJECT_ID}/v1/metrics", handler.HandleMetrics).Methods(http.MethodPost)
+	req := httptest.NewRequest(method, path, bytes.NewReader(body))
+	req.RemoteAddr = "203.0.113.9:40000"
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	return recorder
+}
+
+type recordingMutator struct {
+	sets   []map[string]any
+	unsets [][]string
+	fail   bool
+}
+
+func (m *recordingMutator) ApplySet(_ context.Context, _ string, _ string, raw map[string]any, _ *identity.Geo) (identity.ApplyResult, error) {
+	if m.fail {
+		return identity.ApplyResult{}, fmt.Errorf("database is down")
+	}
+	m.sets = append(m.sets, raw)
+	return identity.ApplyResult{}, nil
+}
+
+func (m *recordingMutator) ApplySetOnce(_ context.Context, _ string, _ string, raw map[string]any, _ *identity.Geo) (identity.ApplyResult, error) {
+	return identity.ApplyResult{}, nil
+}
+
+func (m *recordingMutator) ApplyUnset(_ context.Context, _ string, _ string, keys []string, _ *identity.Geo) (identity.ApplyResult, error) {
+	if m.fail {
+		return identity.ApplyResult{}, fmt.Errorf("database is down")
+	}
+	m.unsets = append(m.unsets, keys)
+	return identity.ApplyResult{}, nil
+}
+
+const logsPath = "/observe/app-1/ignored-project/v1/logs"
+
+func TestHandleLogsResponseContract(t *testing.T) {
+	t.Run("nil service acknowledges and drops", func(t *testing.T) {
+		recorder := serveIngest(NewIngestHandler(nil), http.MethodPost, logsPath, []byte(androidLogsFixture))
+		require.Equal(t, http.StatusNoContent, recorder.Code)
+	})
+
+	t.Run("unreadable body is a permanent 400", func(t *testing.T) {
+		handler := NewIngestHandler(identity.NewService(&recordingMutator{}, nil))
+		recorder := serveIngest(handler, http.MethodPost, logsPath, []byte("not json"))
+		require.Equal(t, http.StatusBadRequest, recorder.Code)
+	})
+
+	t.Run("oversized body is a permanent 413", func(t *testing.T) {
+		handler := NewIngestHandler(identity.NewService(&recordingMutator{}, nil))
+		big := bytes.Repeat([]byte("x"), maxLogsBodyBytes+1)
+		recorder := serveIngest(handler, http.MethodPost, logsPath, big)
+		require.Equal(t, http.StatusRequestEntityTooLarge, recorder.Code)
+	})
+
+	t.Run("store failure is a retryable 503, never 500", func(t *testing.T) {
+		handler := NewIngestHandler(identity.NewService(&recordingMutator{fail: true}, nil))
+		recorder := serveIngest(handler, http.MethodPost, logsPath, []byte(androidLogsFixture))
+		require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	})
+
+	t.Run("telemetry-only batch is acknowledged untouched", func(t *testing.T) {
+		mutator := &recordingMutator{}
+		handler := NewIngestHandler(identity.NewService(mutator, nil))
+		body := strings.ReplaceAll(androidLogsFixture, "$set", "exception")
+		recorder := serveIngest(handler, http.MethodPost, logsPath, []byte(body))
+		require.Equal(t, http.StatusNoContent, recorder.Code)
+		require.Empty(t, mutator.sets)
+	})
+
+	t.Run("forged client id skips records without failing the batch", func(t *testing.T) {
+		mutator := &recordingMutator{}
+		handler := NewIngestHandler(identity.NewService(mutator, nil))
+		body := strings.ReplaceAll(androidLogsFixture, "8b9c1fe0-93b3-4b3a-8c1d-2f4a5e6b7c8d", "not-a-uuid")
+		recorder := serveIngest(handler, http.MethodPost, logsPath, []byte(body))
+		require.Equal(t, http.StatusNoContent, recorder.Code)
+		require.Empty(t, mutator.sets)
+	})
+
+	t.Run("identity ops reach the service", func(t *testing.T) {
+		mutator := &recordingMutator{}
+		handler := NewIngestHandler(identity.NewService(mutator, nil))
+		recorder := serveIngest(handler, http.MethodPost, logsPath, []byte(androidLogsFixture))
+		require.Equal(t, http.StatusNoContent, recorder.Code)
+		require.Len(t, mutator.sets, 1)
+		require.Equal(t, "user_42", mutator.sets[0]["userId"])
+		// The envelope attributes were stripped before the store.
+		require.NotContains(t, mutator.sets[0], "event.name")
+		require.NotContains(t, mutator.sets[0], "session.id")
+
+		recorder = serveIngest(handler, http.MethodPost, logsPath, []byte(iosLogsFixture))
+		require.Equal(t, http.StatusNoContent, recorder.Code)
+		require.Equal(t, [][]string{{"userId", "tenant"}}, mutator.unsets)
+	})
+
+	t.Run("metrics stub acknowledges and drops", func(t *testing.T) {
+		recorder := serveIngest(NewIngestHandler(nil), http.MethodPost, "/observe/app-1/p/v1/metrics", []byte(`{"resourceMetrics":[]}`))
+		require.Equal(t, http.StatusNoContent, recorder.Code)
+	})
+}
+
+// End-to-end against a real Postgres: an SDK-shaped batch lands as a device
+// row. Gated like the identity store tests.
+func TestIngestEndToEnd(t *testing.T) {
+	dbURL := os.Getenv("TEST_DATABASE_URL")
+	if dbURL == "" {
+		if os.Getenv("CI") != "" {
+			t.Fatal("TEST_DATABASE_URL must be set in CI")
+		}
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+	t.Setenv("ADMIN_EMAIL", "seed-admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "Sup3rSecret!")
+	postgres.RunDBMigrations(dbURL)
+	pool, err := pgxpool.New(context.Background(), dbURL)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	appID := uuid.NewString()
+	_, err = pool.Exec(context.Background(), "INSERT INTO apps (id, name) VALUES ($1, $2)", appID, "observe-e2e")
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = pool.Exec(context.Background(), "DELETE FROM apps WHERE id = $1", appID) })
+
+	identityStore := identity.NewPostgresIdentityStore(&database.Engine{Queries: pgdb.New(pool), DB: pool})
+	for _, spec := range []identity.KeySpec{
+		{Key: "userId", Type: identity.ValueTypeString},
+		{Key: "seats", Type: identity.ValueTypeNumber},
+		{Key: "isInternal", Type: identity.ValueTypeBoolean},
+	} {
+		_, err := identityStore.UpsertSchemaKey(context.Background(), appID, spec)
+		require.NoError(t, err)
+	}
+
+	handler := NewIngestHandler(identity.NewService(identityStore, nil))
+	path := "/observe/" + appID + "/whatever-project/v1/logs"
+	recorder := serveIngest(handler, http.MethodPost, path, []byte(androidLogsFixture))
+	require.Equal(t, http.StatusNoContent, recorder.Code)
+
+	device, err := identityStore.GetDevice(context.Background(), appID, "8b9c1fe0-93b3-4b3a-8c1d-2f4a5e6b7c8d")
+	require.NoError(t, err)
+	require.NotNil(t, device)
+	require.Equal(t, "user_42", device.Metadata["userId"])
+	require.Equal(t, float64(12), device.Metadata["seats"])
+	require.Equal(t, true, device.Metadata["isInternal"])
+}
+
+func TestIdentityRequestsFromBatch(t *testing.T) {
+	batch, err := DecodeLogs([]byte(androidLogsFixture))
+	require.NoError(t, err)
+	requests := identityRequestsFromBatch(batch, "app-1", "203.0.113.7")
+	require.Len(t, requests, 1)
+	require.Equal(t, identity.OpSet, requests[0].Op)
+	require.Equal(t, "app-1", requests[0].AppID)
+	require.Equal(t, "203.0.113.7", requests[0].RemoteIP)
+	require.Equal(t, "user_42", requests[0].Attributes["userId"])
+
+	t.Run("forged client id yields no requests", func(t *testing.T) {
+		body := strings.ReplaceAll(androidLogsFixture, "8b9c1fe0-93b3-4b3a-8c1d-2f4a5e6b7c8d", "not-a-uuid")
+		b, err := DecodeLogs([]byte(body))
+		require.NoError(t, err)
+		require.Empty(t, identityRequestsFromBatch(b, "app-1", ""))
+	})
+
+	t.Run("telemetry records yield no requests", func(t *testing.T) {
+		body := strings.ReplaceAll(androidLogsFixture, "$set", "exception")
+		b, err := DecodeLogs([]byte(body))
+		require.NoError(t, err)
+		require.Empty(t, identityRequestsFromBatch(b, "app-1", ""))
+	})
+}

--- a/ee/observe/metrics.go
+++ b/ee/observe/metrics.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package observe
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// The ingestion route is a public, unauthenticated endpoint; these counters
+// are how an operator sees rejection and abuse rates. A 429 spike is a source
+// being throttled; a bad_request/too_large spike is a broken or hostile
+// client; a telemetry drop count is the size of the analytics backlog waiting
+// for the ClickHouse path. No appId label: the id is wire input on this route,
+// so labeling by it would be an unbounded-cardinality hole.
+var (
+	observeBatchesVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "observe_batches_total",
+			Help: "expo-observe ingestion batches, by result",
+		},
+		[]string{"result"},
+	)
+
+	observeRecordsDroppedVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "observe_records_dropped_total",
+			Help: "Log records received but not stored, by reason",
+		},
+		[]string{"reason"},
+	)
+)
+
+const (
+	reasonForgedClientID = "forged_client_id"
+	reasonTelemetry      = "telemetry_no_sink"
+)
+
+func init() {
+	prometheus.MustRegister(observeBatchesVec, observeRecordsDroppedVec)
+}
+
+func observeBatch(result string) {
+	observeBatchesVec.WithLabelValues(result).Inc()
+}
+
+func observeRecordsDropped(reason string, n int) {
+	if n > 0 {
+		observeRecordsDroppedVec.WithLabelValues(reason).Add(float64(n))
+	}
+}

--- a/ee/observe/middleware.go
+++ b/ee/observe/middleware.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package observe
+
+import (
+	"expo-open-ota/config"
+	"expo-open-ota/internal/cache"
+	"expo-open-ota/internal/services"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// The observe subrouter runs CachedAppResolverMiddleware before the handler.
+// (Request rate limiting is intentionally not implemented yet: per-IP would
+// punish the shared-NAT / carrier-CGNAT case that dominates mobile, and the
+// right shape is operator-configurable, so it is deferred. Hard limits belong
+// at the edge in the meantime; the store's own per-device bounds still apply.)
+
+// appExistenceTTLSeconds bounds how long a known/unknown app id is trusted
+// from cache. Short enough that a freshly created or deleted app converges
+// quickly, long enough that a device fleet backgrounding in unison collapses
+// to one database read per app per window instead of one per request.
+const appExistenceTTLSeconds = 60
+
+const (
+	appKnownCacheValue   = "1"
+	appUnknownCacheValue = "0"
+)
+
+// CachedAppResolverMiddleware validates {APP_ID} against the registry like the
+// generic AppResolverMiddleware, but memoizes the lookup so telemetry (which
+// fires on every app-background of every device) does not issue an uncached
+// primary-key query per request. Both outcomes are cached: a valid id skips
+// the query for the window, an invalid id is short-circuited to 404 without
+// re-hitting the database under a flood of the same bad id.
+func CachedAppResolverMiddleware(appRepo services.AppRepository) func(http.Handler) http.Handler {
+	c := cache.GetCache()
+	ttl := appExistenceTTLSeconds
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			appID := mux.Vars(r)["APP_ID"]
+			if !isValidAppID(appID) {
+				// 404, not 400: for the SDK both are permanent (batch dropped),
+				// and 404 matches the manifest/asset edge for unknown ids.
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+
+			cacheKey := "observe:app_exists:" + appID
+			switch c.Get(cacheKey) {
+			case appKnownCacheValue:
+				next.ServeHTTP(w, r)
+				return
+			case appUnknownCacheValue:
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+
+			if _, err := appRepo.GetAppByID(r.Context(), appID); err != nil {
+				_ = c.Set(cacheKey, appUnknownCacheValue, &ttl)
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			_ = c.Set(cacheKey, appKnownCacheValue, &ttl)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// isValidAppID uses the same syntactic guard as the generic
+// AppResolverMiddleware (internal/middleware delegates to this too): the
+// observe {APP_ID} is the same internal app id and must obey the same rules.
+// We call config directly rather than import internal/middleware, which would
+// pull the whole handler graph into ee/observe.
+func isValidAppID(id string) bool {
+	return config.ValidateAppId(id, "appId") == nil
+}

--- a/ee/observe/middleware_test.go
+++ b/ee/observe/middleware_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package observe
+
+import (
+	"bytes"
+	"context"
+	"expo-open-ota/config"
+	"expo-open-ota/internal/cache"
+	"expo-open-ota/internal/services"
+	"expo-open-ota/internal/store"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+func resetObserveCache(t *testing.T) {
+	t.Helper()
+	require.NoError(t, cache.GetCache().Clear())
+}
+
+// countingAppRepo counts GetAppByID calls so the cache's effect is observable.
+type countingAppRepo struct {
+	calls   int64
+	unknown bool
+}
+
+func (r *countingAppRepo) GetAppByID(_ context.Context, _ string) (config.AppConfig, error) {
+	atomic.AddInt64(&r.calls, 1)
+	if r.unknown {
+		return config.AppConfig{}, fmt.Errorf("app not found")
+	}
+	return config.AppConfig{}, nil
+}
+func (r *countingAppRepo) InsertApp(context.Context, store.InsertAppParameters) (string, error) {
+	return "", nil
+}
+func (r *countingAppRepo) DeleteAppByID(context.Context, string) error             { return nil }
+func (r *countingAppRepo) GetApps(context.Context) ([]config.AppDescriptor, error) { return nil, nil }
+func (r *countingAppRepo) UpdateAppNameByID(context.Context, string, string) error { return nil }
+
+// Just here to verify correct compilation of the mocked appRepo
+var _ services.AppRepository = (*countingAppRepo)(nil)
+
+func chain(handler *IngestHandler, repo services.AppRepository) http.Handler {
+	router := mux.NewRouter()
+	sub := router.PathPrefix("/observe/{APP_ID}").Subrouter()
+	sub.Use(CachedAppResolverMiddleware(repo))
+	sub.HandleFunc("/{PROJECT_ID}/v1/logs", handler.HandleLogs).Methods(http.MethodPost)
+	return router
+}
+
+func post(h http.Handler, path, remote string) *httptest.ResponseRecorder {
+	// A valid empty batch: these tests exercise the middleware chain, not the
+	// decoder, so the handler must reach its 204 rather than 400 on the body.
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader([]byte(`{}`)))
+	req.RemoteAddr = remote
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestCachedAppResolverMemoizesLookup(t *testing.T) {
+	resetObserveCache(t)
+	repo := &countingAppRepo{}
+	h := chain(NewIngestHandler(nil), repo)
+
+	for i := 0; i < 5; i++ {
+		rec := post(h, "/observe/known-app/proj/v1/logs", "203.0.113.20:1")
+		require.Equal(t, http.StatusNoContent, rec.Code)
+	}
+	// The five requests share one database read.
+	require.Equal(t, int64(1), atomic.LoadInt64(&repo.calls))
+}
+
+func TestCachedAppResolverCachesUnknown(t *testing.T) {
+	resetObserveCache(t)
+	repo := &countingAppRepo{unknown: true}
+	h := chain(NewIngestHandler(nil), repo)
+
+	for i := 0; i < 5; i++ {
+		rec := post(h, "/observe/ghost-app/proj/v1/logs", "203.0.113.21:1")
+		require.Equal(t, http.StatusNotFound, rec.Code)
+	}
+	// A flood of the same unknown id does not re-hit the database each time.
+	require.Equal(t, int64(1), atomic.LoadInt64(&repo.calls))
+}
+
+func TestCachedAppResolverRejectsMalformedID(t *testing.T) {
+	resetObserveCache(t)
+	repo := &countingAppRepo{}
+	h := chain(NewIngestHandler(nil), repo)
+	// A control character in the id fails the syntactic guard before any read.
+	rec := post(h, "/observe/%00bad/proj/v1/logs", "203.0.113.22:1")
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Equal(t, int64(0), atomic.LoadInt64(&repo.calls))
+}

--- a/ee/observe/otlp.go
+++ b/ee/observe/otlp.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+// Package observe receives expo-observe telemetry: the OTLP/JSON ingestion
+// routes, decoding, and dispatch. It sees EVERY log record a device ships;
+// identity operations ($set, $set_once, $unset) are routed to ee/identity,
+// and the remaining telemetry records will feed the ClickHouse path when it
+// lands. Identity dispatch is NOT license-gated (the identity feature is free);
+// the future telemetry path is where the enterprise gate will sit.
+package observe
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// Minimal, tolerant decoder for the OTLP/JSON bodies the expo-observe SDK
+// POSTs. Deliberately hand-rolled over the otlp protobuf bindings: we only
+// need resource attributes and per-record attributes, and the two platforms
+// diverge from strict OTLP anyway (iOS sends intValue as a raw JSON number
+// where the spec says string). Unknown fields are ignored by encoding/json,
+// which is exactly the tolerance we want: rejecting a batch destroys it on
+// the device. The decoded types are neutral on purpose: the ClickHouse
+// flattener will extend them (timestamps, severity, body) without another
+// decoder.
+
+// LogBatch is one decoded /v1/logs body.
+type LogBatch struct {
+	Resources []ResourceLogs
+}
+
+// ResourceLogs is one device session's worth of records: the resource
+// attributes (device, app, update...) and the log records they scope.
+type ResourceLogs struct {
+	Attributes map[string]any
+	Records    []LogRecord
+}
+
+// LogRecord is one log record's attributes. Telemetry fields (timestamp,
+// severity, body) are not decoded yet: nothing consumes them before the
+// ClickHouse path exists.
+type LogRecord struct {
+	Attributes map[string]any
+}
+
+// EASClientIDKey is the resource attribute carrying the persistent
+// per-install UUID from expo-eas-client.
+const EASClientIDKey = "expo.eas_client.id"
+
+// EventNameKey is the record attribute carrying the log event name; it is
+// what identity operations are recognized by. Deliberately also defined in
+// ee/identity (recordEventNameKey): observe reads it here to classify
+// identity-vs-telemetry, identity strips it there as envelope. The dependency
+// direction (observe → identity) and the future flattener wanting it as a real
+// column both forbid collapsing the two into one owner today.
+const EventNameKey = "event.name"
+
+// DecodeLogs parses an OTLP/JSON logs body. An error means the body is not
+// JSON we can read at all; a readable body with zero records is normal.
+func DecodeLogs(body []byte) (LogBatch, error) {
+	var decoded otlpLogsBody
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return LogBatch{}, fmt.Errorf("unreadable OTLP logs body: %w", err)
+	}
+	batch := LogBatch{Resources: make([]ResourceLogs, 0, len(decoded.ResourceLogs))}
+	for _, resource := range decoded.ResourceLogs {
+		entry := ResourceLogs{Attributes: kvToMap(resource.Resource.Attributes)}
+		for _, scope := range resource.ScopeLogs {
+			for _, record := range scope.LogRecords {
+				entry.Records = append(entry.Records, LogRecord{Attributes: kvToMap(record.Attributes)})
+			}
+		}
+		batch.Resources = append(batch.Resources, entry)
+	}
+	return batch, nil
+}
+
+type otlpLogsBody struct {
+	ResourceLogs []otlpResourceLogs `json:"resourceLogs"`
+}
+
+type otlpResourceLogs struct {
+	Resource  otlpResource    `json:"resource"`
+	ScopeLogs []otlpScopeLogs `json:"scopeLogs"`
+}
+
+type otlpResource struct {
+	Attributes []otlpKV `json:"attributes"`
+}
+
+type otlpScopeLogs struct {
+	LogRecords []otlpLogRecord `json:"logRecords"`
+}
+
+type otlpLogRecord struct {
+	Attributes []otlpKV `json:"attributes"`
+}
+
+type otlpKV struct {
+	Key   string       `json:"key"`
+	Value otlpAnyValue `json:"value"`
+}
+
+type otlpAnyValue struct {
+	StringValue *string          `json:"stringValue"`
+	IntValue    json.RawMessage  `json:"intValue"`
+	DoubleValue *float64         `json:"doubleValue"`
+	BoolValue   *bool            `json:"boolValue"`
+	ArrayValue  *otlpArrayValue  `json:"arrayValue"`
+	KvlistValue *otlpKvlistValue `json:"kvlistValue"`
+}
+
+type otlpArrayValue struct {
+	Values []otlpAnyValue `json:"values"`
+}
+
+type otlpKvlistValue struct {
+	Values []otlpKV `json:"values"`
+}
+
+// toGo unwraps the single-key AnyValue union into plain Go values. intValue
+// accepts both wire forms: Android emits the OTLP-conformant string ("42"),
+// iOS deliberately emits a raw JSON number (42). Unrepresentable values decode
+// to nil; downstream consumers (identity's Sanitize, the future flattener)
+// drop them.
+func (v otlpAnyValue) toGo() any {
+	switch {
+	case v.StringValue != nil:
+		return *v.StringValue
+	case len(v.IntValue) > 0:
+		var num json.Number
+		if err := json.Unmarshal(v.IntValue, &num); err == nil {
+			if i, err := num.Int64(); err == nil {
+				return i
+			}
+		}
+		var str string
+		if err := json.Unmarshal(v.IntValue, &str); err == nil {
+			if i, err := strconv.ParseInt(str, 10, 64); err == nil {
+				return i
+			}
+		}
+		return nil
+	case v.DoubleValue != nil:
+		return *v.DoubleValue
+	case v.BoolValue != nil:
+		return *v.BoolValue
+	case v.ArrayValue != nil:
+		values := make([]any, 0, len(v.ArrayValue.Values))
+		for _, item := range v.ArrayValue.Values {
+			values = append(values, item.toGo())
+		}
+		return values
+	case v.KvlistValue != nil:
+		return kvToMap(v.KvlistValue.Values)
+	}
+	return nil
+}
+
+func kvToMap(kvs []otlpKV) map[string]any {
+	m := make(map[string]any, len(kvs))
+	for _, kv := range kvs {
+		if kv.Key == "" {
+			continue
+		}
+		m[kv.Key] = kv.Value.toGo()
+	}
+	return m
+}

--- a/ee/observe/otlp_test.go
+++ b/ee/observe/otlp_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package observe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Android wire shape: pretty-printed, intValue as OTLP-conformant string.
+const androidLogsFixture = `{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          { "key": "expo.eas_client.id", "value": { "stringValue": "8b9c1fe0-93b3-4b3a-8c1d-2f4a5e6b7c8d" } },
+          { "key": "os.type", "value": { "stringValue": "linux" } },
+          { "key": "service.name", "value": { "stringValue": "fr.skeat.myapp" } }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": { "name": "expo-observe", "version": "56.0.16" },
+          "logRecords": [
+            {
+              "timeUnixNano": 1767960489000000000,
+              "severityNumber": 9,
+              "severityText": "INFO",
+              "body": { "stringValue": "" },
+              "attributes": [
+                { "key": "session.id", "value": { "stringValue": "aaaa-1111" } },
+                { "key": "event.name", "value": { "stringValue": "$set" } },
+                { "key": "userId", "value": { "stringValue": "user_42" } },
+                { "key": "seats", "value": { "intValue": "12" } },
+                { "key": "isInternal", "value": { "boolValue": true } }
+              ]
+            }
+          ]
+        }
+      ],
+      "schemaUrl": "https://opentelemetry.io/schemas/1.27.0"
+    }
+  ]
+}`
+
+// iOS wire shape: compact, intValue as a raw JSON number (deliberate OTLP
+// deviation of the Swift client).
+const iosLogsFixture = `{"resourceLogs":[{"resource":{"attributes":[{"key":"expo.eas_client.id","value":{"stringValue":"7A6B5C4D-3E2F-1A0B-9C8D-7E6F5A4B3C2D"}}]},"scopeLogs":[{"scope":{"name":"expo-observe","version":"56.0.16"},"logRecords":[{"timeUnixNano":1767960489000000000,"severityNumber":9,"severityText":"INFO","body":{"stringValue":"user logged in"},"attributes":[{"key":"event.name","value":{"stringValue":"$unset"}},{"key":"keys","value":{"arrayValue":{"values":[{"stringValue":"userId"},{"stringValue":"tenant"}]}}},{"key":"seats","value":{"intValue":42}}]}]}],"schemaUrl":"https://opentelemetry.io/schemas/1.27.0"}]}`
+
+func TestDecodeLogsAndroidShape(t *testing.T) {
+	batch, err := DecodeLogs([]byte(androidLogsFixture))
+	require.NoError(t, err)
+	require.Len(t, batch.Resources, 1)
+
+	resource := batch.Resources[0]
+	require.Equal(t, "8b9c1fe0-93b3-4b3a-8c1d-2f4a5e6b7c8d", resource.Attributes[EASClientIDKey])
+	require.Len(t, resource.Records, 1)
+
+	attrs := resource.Records[0].Attributes
+	require.Equal(t, "$set", attrs[EventNameKey])
+	require.Equal(t, "user_42", attrs["userId"])
+	// Android string-form intValue decodes to a number.
+	require.Equal(t, int64(12), attrs["seats"])
+	require.Equal(t, true, attrs["isInternal"])
+}
+
+func TestDecodeLogsIOSShape(t *testing.T) {
+	batch, err := DecodeLogs([]byte(iosLogsFixture))
+	require.NoError(t, err)
+	require.Len(t, batch.Resources, 1)
+
+	attrs := batch.Resources[0].Records[0].Attributes
+	require.Equal(t, "$unset", attrs[EventNameKey])
+	// iOS raw-number intValue decodes to the same Go value as Android's.
+	require.Equal(t, int64(42), attrs["seats"])
+	// Nested arrayValue unwraps to []any of plain values.
+	require.Equal(t, []any{"userId", "tenant"}, attrs["keys"])
+}
+
+func TestDecodeLogsTolerance(t *testing.T) {
+	// Unknown fields and empty bodies are tolerated: rejecting destroys the
+	// batch on the device.
+	batch, err := DecodeLogs([]byte(`{"resourceLogs":[],"partialSuccess":{"whatever":1}}`))
+	require.NoError(t, err)
+	require.Empty(t, batch.Resources)
+
+	batch, err = DecodeLogs([]byte(`{}`))
+	require.NoError(t, err)
+	require.Empty(t, batch.Resources)
+
+	// Structural garbage is a hard error (the 400 arm).
+	_, err = DecodeLogs([]byte(`not json at all`))
+	require.Error(t, err)
+
+	// Unrepresentable values decode to nil instead of failing the batch.
+	batch, err = DecodeLogs([]byte(`{"resourceLogs":[{"resource":{"attributes":[{"key":"x","value":{"intValue":"not-a-number"}}]},"scopeLogs":[]}]}`))
+	require.NoError(t, err)
+	require.Nil(t, batch.Resources[0].Attributes["x"])
+
+	// kvlistValue unwraps to a nested map.
+	batch, err = DecodeLogs([]byte(`{"resourceLogs":[{"resource":{"attributes":[{"key":"nested","value":{"kvlistValue":{"values":[{"key":"a","value":{"doubleValue":1.5}}]}}}]},"scopeLogs":[]}]}`))
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"a": 1.5}, batch.Resources[0].Attributes["nested"])
+}

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	golang.org/x/crypto v0.54.0
 	golang.org/x/oauth2 v0.35.0
 	golang.org/x/sync v0.22.0
+	golang.org/x/time v0.5.0
 	google.golang.org/api v0.178.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -91,7 +92,6 @@ require (
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
-	golang.org/x/time v0.5.0 // indirect
 	google.golang.org/genproto v0.0.0-20240401170217-c3f982113cda // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect

--- a/internal/middleware/logging_middleware.go
+++ b/internal/middleware/logging_middleware.go
@@ -26,6 +26,12 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
+		// Telemetry ingestion fires on every app-background of every device;
+		// logging each batch would drown the request log.
+		if strings.HasSuffix(r.URL.Path, "/v1/logs") || strings.HasSuffix(r.URL.Path, "/v1/metrics") {
+			next.ServeHTTP(w, r)
+			return
+		}
 		start := time.Now()
 
 		safeHeaders := redactHeaders(r.Header)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -2,6 +2,7 @@ package infrastructure
 
 import (
 	"expo-open-ota/config"
+	"expo-open-ota/ee/observe"
 	"expo-open-ota/ee/rbac"
 	dashutils "expo-open-ota/internal/dashboard"
 	"expo-open-ota/internal/metrics"
@@ -64,6 +65,21 @@ func NewRouter(container *AppContainer) *mux.Router {
 	appSubrouter.HandleFunc("/markUpdateAsUploaded/{BRANCH}", container.UploadHandler.MarkUpdateAsUploadedHandler).Methods(http.MethodPost)
 	appSubrouter.HandleFunc("/rollback/{BRANCH}", container.RollbackHandler.HandleRollback).Methods(http.MethodPost)
 	appSubrouter.HandleFunc("/republish/{BRANCH}", container.RepublishHandler.HandleRepublish).Methods(http.MethodPost)
+
+	// expo-observe ingestion (ee/observe), all under one /observe prefix. The
+	// operator sets extra.eas.observe.endpointUrl to
+	// https://<host>/observe/{APP_ID}; the SDK appends /{projectId}/v1/logs
+	// with the app's REAL EAS project id (used by EAS builds, never equal to
+	// our APP_ID), so the PROJECT_ID segment is deliberately ignored, exactly
+	// as the SDK itself never validates it. Exact paths, no trailing-slash
+	// variant: a gorilla 301 would turn the POST into a bodyless GET.
+	observeSubrouter := r.PathPrefix("/observe/{APP_ID}").Subrouter()
+	// The app check is memoized so telemetry (which fires on every
+	// app-background of every device) does not issue an uncached primary-key
+	// query per request.
+	observeSubrouter.Use(observe.CachedAppResolverMiddleware(container.AppRepo))
+	observeSubrouter.HandleFunc("/{PROJECT_ID}/v1/logs", container.ObserveIngestHandler.HandleLogs).Methods(http.MethodPost)
+	observeSubrouter.HandleFunc("/{PROJECT_ID}/v1/metrics", container.ObserveIngestHandler.HandleMetrics).Methods(http.MethodPost)
 
 	r.HandleFunc("/manifest", container.ExpoProtocolHandler.HandleManifest).Methods(http.MethodGet)
 	r.HandleFunc("/assets", container.ExpoProtocolHandler.HandleAssets).Methods(http.MethodGet)

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -5,7 +5,9 @@ import (
 	"expo-open-ota/config"
 	"expo-open-ota/ee/apikeyrestrictions"
 	"expo-open-ota/ee/audit"
+	"expo-open-ota/ee/identity"
 	"expo-open-ota/ee/licensing"
+	"expo-open-ota/ee/observe"
 	"expo-open-ota/ee/rbac"
 	"expo-open-ota/ee/sso"
 	"expo-open-ota/internal/bucket"
@@ -44,6 +46,7 @@ type AppContainer struct {
 	UsersHandler             *dashhandlers.UsersHandler
 	AuditHandler             *audit.AuditHandler
 	UserRepo                 services.UserRepository
+	ObserveIngestHandler     *observe.IngestHandler
 }
 
 // logLegacyAppIdFallback states, once at boot, which app receives manifest and
@@ -87,6 +90,10 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	// The audit trail (ee/audit) as well: nil keeps its recorder a no-op, so
 	// stateless deployments never collect an event.
 	var auditRepo audit.AuditRepository
+	// Device identity (ee/identity) lives in the database; nil makes the
+	// observe ingestion acknowledge-and-drop, so stateless deployments never
+	// block a device's telemetry queue. EE-licensed code, NOT license-gated.
+	var identityService *identity.Service
 
 	cleanup := func() {}
 	dbUrl := config.GetDBURL()
@@ -123,6 +130,24 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		channelRepo = store.NewPostgresChannelStore(dbEngine)
 		updateRepo = store.NewPostgresUpdateStore(dbEngine)
 		rolloutRepo = store.NewPostgresRolloutStore(dbEngine)
+
+		// GeoIP enrichment is optional: without a configured GeoLite2 City
+		// database, devices simply stay unlocated. A configured-but-broken
+		// path fails the boot loudly instead of resolving nothing forever.
+		var geoResolver identity.GeoResolver
+		if mmdbPath := config.GetEnv("GEOIP_MMDB_PATH"); mmdbPath != "" {
+			resolver, err := identity.NewGeoLite2Resolver(mmdbPath)
+			if err != nil {
+				log.Fatalf("🚨 [IDENTITY] %v", err)
+			}
+			geoResolver = resolver
+			dbCleanup := cleanup
+			cleanup = func() {
+				resolver.Close()
+				dbCleanup()
+			}
+		}
+		identityService = identity.NewService(identity.NewPostgresIdentityStore(dbEngine), geoResolver)
 	} else {
 		log.Println("⚙️  [STATELESS] Initializing Stateless Mode (Flat-Env Mode)...")
 		if err := config.LoadAppsFromFlatEnv(); err != nil {
@@ -223,5 +248,6 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		UploadHandler:            handlers.NewUploadHandler(cliAuthService, deploymentService),
 		UsersHandler:             dashhandlers.NewUsersHandler(userService),
 		UserRepo:                 userRepo,
+		ObserveIngestHandler:     observe.NewIngestHandler(identityService),
 	}, cleanup
 }


### PR DESCRIPTION
Stack 3/3 of the device-identity feature. Base: \`identity/02-service-geoip\`.

The expo-observe ingestion route that feeds identity:
- New \`ee/observe\` package (owns OTLP transport; will ingest ALL telemetry logs for the future ClickHouse path): tolerant OTLP/JSON decoder (dual iOS/Android intValue), ingest handler with the SDK response contract (204/400/413/503, never 500), route metrics.
- \`ee/identity\` record mapping: \`RequestFromRecord\` (\$unset \`keys\` array convention) + \`CoalesceRequests\` (adjacent same-op fold per device).
- Route \`POST /observe/{APP_ID}/{PROJECT_ID}/v1/logs\` (+ /v1/metrics stub); PROJECT_ID ignored. Cached app-existence middleware so telemetry does not hit the DB per request.
- Wiring in \`wire.go\` (nil service in stateless = ack-and-drop), \`GEOIP_MMDB_PATH\` env.
- Request rate limiting intentionally deferred (per-IP punishes mobile CGNAT; the right shape is operator-configurable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)