### PR TITLE
feat: enhance upload request validation and testing

### DIFF
--- a/apps/eoas/src/commands/__tests__/publish.test.ts
+++ b/apps/eoas/src/commands/__tests__/publish.test.ts
@@ -1,0 +1,296 @@
+/* eslint-disable node/no-sync */
+// End-to-end publish flow against a hostile update server. The oclif command
+// runs for real on a temporary project, with the project/auth/network seams
+// mocked, so these pin the property that matters: when the server forges an
+// upload request, the CLI uploads NOTHING, not even the entries that were fine.
+import spawnAsync from '@expo/spawn-async';
+import fs from 'fs-extra';
+// node-fetch's Response, not the DOM one: that is what fetchWithRetries resolves to.
+import type { Response } from 'node-fetch';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchWithRetries } from '../../lib/fetch';
+import Log from '../../lib/log';
+import Publish from '../publish';
+
+vi.mock('@expo/spawn-async', () => ({ default: vi.fn() }));
+vi.mock('../../lib/fetch', () => ({ fetchWithRetries: vi.fn() }));
+vi.mock('../../lib/auth', () => ({
+  retrieveCredentials: () => ({ token: 'test-token' }),
+  validateCredentials: () => true,
+  getAuthHeaders: () => ({ Authorization: 'Bearer test-token' }),
+}));
+vi.mock('../../lib/vcs', () => ({
+  resolveVcsClient: () => ({
+    getCommitHashAsync: async () => 'abc1234',
+    canGetLastCommitMessage: () => false,
+    ensureRepoExistsAsync: async () => {},
+  }),
+}));
+vi.mock('../../lib/package', () => ({ isExpoInstalled: () => true }));
+vi.mock('../../lib/runtimeVersion', () => ({
+  resolveRuntimeVersionAsync: async () => ({ runtimeVersion: '1.0.0' }),
+}));
+vi.mock('../../lib/workflow', () => ({ resolveWorkflowAsync: async () => 'generic' }));
+vi.mock('../../lib/expoConfig', async importOriginal => {
+  const original = await importOriginal<typeof import('../../lib/expoConfig')>();
+  return {
+    ...original,
+    getPrivateExpoConfigAsync: async () => ({}),
+    getPublicExpoConfigAsync: async () => ({ name: 'test-app' }),
+    requireExpoAppId: () => 'app-1',
+    resolveServerUrl: async () => 'https://ota.example.com',
+  };
+});
+
+const eoasRoot = path.resolve(__dirname, '../../..');
+const SERVER = 'https://ota.example.com';
+
+let projectDir: string;
+let secretDir: string;
+let previousCwd: string;
+
+function distFile(...segments: string[]): string {
+  return path.join(projectDir, 'dist', ...segments);
+}
+
+// The export the CLI believes it produced. spawnAsync is mocked, so this mock
+// writes what `expo export` would have written.
+function writeExport(): void {
+  fs.ensureDirSync(distFile('bundles'));
+  fs.writeJsonSync(distFile('metadata.json'), {
+    version: 0,
+    bundler: 'metro',
+    fileMetadata: { ios: { bundle: 'bundles/ios-abc.hbc', assets: [] } },
+  });
+  fs.writeFileSync(distFile('bundles', 'ios-abc.hbc'), 'BUNDLE BYTES');
+}
+
+function uploadRequest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    requestUploadUrl: 'https://storage.example.com/upload/metadata.json',
+    fileName: 'metadata.json',
+    filePath: 'metadata.json',
+    ...overrides,
+  };
+}
+
+function respondWith(uploadRequests: Record<string, unknown>[]): void {
+  vi.mocked(fetchWithRetries).mockImplementation(async (url: string) => {
+    if (url.startsWith(`${SERVER}/app-1/requestUploadUrl`)) {
+      // updateId is a JSON number on the wire: services.RequestUploadURLResponse
+      // marshals an int64.
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ updateId: 1753800000000, uploadRequests }),
+      } as Response;
+    }
+    return { ok: true, status: 200, text: async () => '', json: async () => ({}) } as Response;
+  });
+}
+
+function putCalls(): { url: string; options: any }[] {
+  return vi
+    .mocked(fetchWithRetries)
+    .mock.calls.filter(([, options]) => (options as any)?.method === 'PUT')
+    .map(([url, options]) => ({ url: String(url), options }));
+}
+
+// What the command printed through Log.error, so a test can tell a rejection by
+// one of the guards apart from an incidental failure that exits the same way.
+function loggedErrors(): string {
+  return vi
+    .mocked(Log.error)
+    .mock.calls.flat()
+    .map(arg => (arg instanceof Error ? arg.message : String(arg)))
+    .join('\n');
+}
+
+function runPublish(): Promise<unknown> {
+  return Publish.run(
+    ['--branch', 'main', '--platform', 'ios', '--nonInteractive', '--disableRepositoryCheck'],
+    eoasRoot
+  );
+}
+
+beforeEach(() => {
+  previousCwd = process.cwd();
+  projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eoas-project-'));
+  secretDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eoas-secrets-'));
+  fs.writeFileSync(path.join(secretDir, 'id_rsa'), 'PRIVATE KEY');
+  process.chdir(projectDir);
+  vi.mocked(spawnAsync).mockImplementation((async () => {
+    writeExport();
+    return { stdout: 'exported', stderr: '' };
+  }) as any);
+  vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    throw new Error(`process.exit(${code})`);
+  }) as any);
+  vi.spyOn(Log, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  process.chdir(previousCwd);
+  fs.removeSync(projectDir);
+  fs.removeSync(secretDir);
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe('publish against a hostile server response', () => {
+  it('uploads nothing when one entry escapes the export directory', async () => {
+    // Two levels up: the export root is projectDir/dist, so a single '..' would
+    // land on a non-existent file inside projectDir and the test would pass on
+    // an ENOENT rather than on the guard. This path really resolves onto the
+    // secret, so removing the guard makes the file readable and the test fail.
+    const traversal = path.join('..', '..', path.basename(secretDir), 'id_rsa');
+    expect(fs.existsSync(path.resolve(projectDir, 'dist', traversal))).toBe(true);
+    respondWith([
+      uploadRequest(),
+      uploadRequest({
+        requestUploadUrl: 'https://attacker.tld/collect',
+        fileName: 'id_rsa',
+        filePath: traversal,
+      }),
+    ]);
+
+    await expect(runPublish()).rejects.toThrow(/process\.exit\(1\)/);
+
+    expect(loggedErrors()).toMatch(/requested a path outside the export directory/);
+    expect(putCalls()).toHaveLength(0);
+  });
+
+  it('uploads nothing when the server names a local file that was not exported', async () => {
+    // Written by the export step: the command wipes and recreates dist first.
+    vi.mocked(spawnAsync).mockImplementation((async () => {
+      writeExport();
+      fs.writeFileSync(distFile('.env'), 'EXPO_TOKEN=secret');
+      return { stdout: 'exported', stderr: '' };
+    }) as any);
+    respondWith([
+      uploadRequest({
+        requestUploadUrl: 'https://attacker.tld/collect',
+        fileName: '.env',
+        filePath: '.env',
+      }),
+    ]);
+
+    await expect(runPublish()).rejects.toThrow(/process\.exit\(1\)/);
+    expect(loggedErrors()).toMatch(/not part of this export/);
+    expect(putCalls()).toHaveLength(0);
+  });
+
+  it('uploads nothing when an upload URL downgrades to plain HTTP', async () => {
+    respondWith([uploadRequest({ requestUploadUrl: 'http://attacker.tld/collect' })]);
+
+    await expect(runPublish()).rejects.toThrow(/process\.exit\(1\)/);
+    expect(loggedErrors()).toMatch(/only be sent over HTTPS/);
+    expect(putCalls()).toHaveLength(0);
+  });
+
+  it('never follows a redirect away from the validated upload URL', async () => {
+    // The URL is only ever checked as a string, so the PUT itself must refuse to
+    // be redirected to an origin nothing validated.
+    respondWith([
+      uploadRequest(),
+      uploadRequest({
+        requestUploadUrl: 'https://storage.example.com/upload/ios-abc.hbc',
+        fileName: 'ios-abc.hbc',
+        filePath: 'bundles/ios-abc.hbc',
+      }),
+    ]);
+
+    await runPublish();
+
+    expect(putCalls()).toHaveLength(2);
+    for (const call of putCalls()) {
+      expect(call.options.redirect).toBe('error');
+    }
+  });
+});
+
+describe('publish forwards the storage backend requirements', () => {
+  it('carries the Azure Blob header through validation onto the PUT', async () => {
+    // Azure Put Blob rejects a request without x-ms-blob-type, and the server
+    // ships the requirement in the response (internal/bucket/bucket.go). The
+    // schema must let it through and publish must forward it verbatim.
+    respondWith([
+      uploadRequest({
+        requestUploadUrl: 'https://acct.blob.core.windows.net/updates/metadata.json?sig=abc',
+        headers: { 'x-ms-blob-type': 'BlockBlob' },
+      }),
+    ]);
+
+    await runPublish();
+
+    const [call] = putCalls();
+    expect(call.options.headers['x-ms-blob-type']).toBe('BlockBlob');
+    expect(call.options.headers['Content-Type']).toBe('application/json');
+  });
+});
+
+describe('publish credential handling', () => {
+  it('attaches the token only to the configured server, never to storage', async () => {
+    respondWith([
+      uploadRequest({ requestUploadUrl: `${SERVER}/app-1/uploadLocalFile?file=metadata.json` }),
+      uploadRequest({
+        requestUploadUrl: 'https://storage.example.com/upload/ios-abc.hbc',
+        fileName: 'ios-abc.hbc',
+        filePath: 'bundles/ios-abc.hbc',
+      }),
+    ]);
+
+    await runPublish();
+
+    const byUrl = new Map(putCalls().map(call => [call.url, call.options]));
+    const localBucket = byUrl.get(`${SERVER}/app-1/uploadLocalFile?file=metadata.json`);
+    expect(localBucket.headers.Authorization).toBe('Bearer test-token');
+    // The credential-bearing PUT must refuse redirects too, or the token follows
+    // the Location header.
+    expect(localBucket.redirect).toBe('error');
+    expect(byUrl.get('https://storage.example.com/upload/ios-abc.hbc').headers.Authorization).toBe(
+      undefined
+    );
+  });
+});
+
+describe('publish against an honest server response', () => {
+  it('uploads exactly the files it exported and marks the update as uploaded', async () => {
+    respondWith([
+      uploadRequest(),
+      uploadRequest({
+        requestUploadUrl: 'https://storage.example.com/upload/expoConfig.json',
+        fileName: 'expoConfig.json',
+        filePath: 'expoConfig.json',
+      }),
+      uploadRequest({
+        requestUploadUrl: 'https://storage.example.com/upload/ios-abc.hbc',
+        fileName: 'ios-abc.hbc',
+        filePath: 'bundles/ios-abc.hbc',
+      }),
+    ]);
+
+    await runPublish();
+
+    // Uploads run concurrently, so compare the set, not the order.
+    expect(
+      putCalls()
+        .map(call => call.url)
+        .sort()
+    ).toEqual([
+      'https://storage.example.com/upload/expoConfig.json',
+      'https://storage.example.com/upload/ios-abc.hbc',
+      'https://storage.example.com/upload/metadata.json',
+    ]);
+    const marked = vi
+      .mocked(fetchWithRetries)
+      .mock.calls.map(([url]) => String(url))
+      .filter(url => url.includes('/markUpdateAsUploaded/'));
+    expect(marked).toHaveLength(1);
+    // The numeric updateId reached the query string as a string.
+    expect(new URL(marked[0]).searchParams.get('updateId')).toBe('1753800000000');
+  });
+});

--- a/apps/eoas/src/commands/publish.ts
+++ b/apps/eoas/src/commands/publish.ts
@@ -12,6 +12,7 @@ import {
   activeRolloutConflictMessage,
   computeFilesRequests,
   requestUploadUrls,
+  resolveUploadRequests,
 } from '../lib/assets';
 import { getAuthHeaders, retrieveCredentials, validateCredentials } from '../lib/auth';
 import {
@@ -332,46 +333,57 @@ export default class Publish extends Command {
           };
         })
       );
-      const allItems = uploadUrls.flatMap(({ uploadRequests }) => uploadRequests);
+      // Every path and URL the server handed back is checked here, before a
+      // single file is opened. A server that forges a filePath would otherwise
+      // make the CLI read arbitrary files off this machine and PUT them wherever
+      // it likes. Validated per response: each platform gets its own upload URLs
+      // for the same files.
+      const resolvedUploads = (
+        await Promise.all(
+          uploadUrls.map(({ uploadRequests }) =>
+            resolveUploadRequests({
+              uploadRequests,
+              exportDir: path.join(projectDir, outputDir),
+              manifest: files,
+            })
+          )
+        )
+      ).flat();
       await Promise.all(
-        allItems.map(async itm => {
+        resolvedUploads.map(async ({ item: itm, absolutePath, manifestEntry }) => {
           const isLocalBucketFileUpload = itm.requestUploadUrl.startsWith(
             `${serverUrl}/${appId}/uploadLocalFile`
           );
-          const formData = new FormData();
-          let file: fs.ReadStream;
-          try {
-            file = fs.createReadStream(path.join(projectDir, outputDir, itm.filePath));
-          } catch {
-            throw new Error(`Failed to read file ${itm.filePath}`);
-          }
-          formData.append(itm.fileName, file);
           if (isLocalBucketFileUpload) {
-            const response = await fetchWithRetries(itm.requestUploadUrl, {
-              method: 'PUT',
-              headers: {
-                ...formData.getHeaders(),
-                ...getAuthHeaders(credentials),
-              },
-              body: formData,
-            });
-            if (!response.ok) {
-              Log.error('Failed to upload file', await response.text());
-              throw new Error('Failed to upload file');
+            const formData = new FormData();
+            const file = fs.createReadStream(absolutePath);
+            formData.append(itm.fileName, file);
+            try {
+              const response = await fetchWithRetries(itm.requestUploadUrl, {
+                method: 'PUT',
+                headers: {
+                  ...formData.getHeaders(),
+                  ...getAuthHeaders(credentials),
+                },
+                body: formData,
+                // The URL was validated as a string; following a redirect would
+                // send these bytes to an origin nothing ever checked.
+                redirect: 'error',
+              });
+              if (!response.ok) {
+                Log.error('Failed to upload file', await response.text());
+                throw new Error('Failed to upload file');
+              }
+            } finally {
+              file.close();
             }
-            file.close();
             return;
           }
-          const findFile = files.find(f => f.path === itm.filePath || f.name === itm.fileName);
-          if (!findFile) {
-            Log.error(`File ${itm.filePath} not found`);
-            throw new Error(`File ${itm.filePath} not found`);
-          }
-          let contentType = mime.getType(findFile.ext);
+          let contentType = mime.getType(manifestEntry.ext);
           if (!contentType) {
             contentType = 'application/octet-stream';
           }
-          const buffer = await fs.readFile(path.join(projectDir, outputDir, itm.filePath));
+          const buffer = await fs.readFile(absolutePath);
           const response = await fetchWithRetries(itm.requestUploadUrl, {
             method: 'PUT',
             headers: {
@@ -380,12 +392,17 @@ export default class Publish extends Command {
               ...(itm.headers ?? {}),
             },
             body: buffer,
+            // Only the URL string was validated. node-fetch follows up to 20
+            // redirects by default with no protocol or host check, so a server
+            // handing back a valid https URL that 302s to http://internal-host
+            // would exfiltrate the bundle in cleartext to an origin of its
+            // choosing. Nothing legitimate redirects an upload PUT.
+            redirect: 'error',
           });
           if (!response.ok) {
             Log.error('❌ File upload failed', await response.text());
             process.exit(1);
           }
-          file.close();
         })
       );
       uploadFilesSpinner.succeed('✅ Files uploaded successfully');

--- a/apps/eoas/src/lib/__tests__/assets.test.ts
+++ b/apps/eoas/src/lib/__tests__/assets.test.ts
@@ -1,3 +1,5 @@
+// node-fetch's Response, not the DOM one: that is what fetchWithRetries resolves to.
+import type { Response } from 'node-fetch';
 import { describe, expect, it, vi } from 'vitest';
 
 import { activeRolloutConflictMessage, requestUploadUrls } from '../assets';
@@ -55,6 +57,92 @@ describe('requestUploadUrls publish group wire contract', () => {
     respondWith({ updateId: '1', uploadRequests: [] });
     const result = await requestUploadUrls({ ...baseParams(), publishGroup: 'group-a' });
     expect(result.publishGroup).toBeUndefined();
+  });
+});
+
+describe('requestUploadUrls response schema', () => {
+  const validItem = {
+    requestUploadUrl: 'https://storage.example.com/upload/bundle.js',
+    fileName: 'bundle.js',
+    filePath: 'bundle.js',
+  };
+
+  it('accepts a well-formed response and its optional headers', async () => {
+    respondWith({
+      updateId: '1',
+      uploadRequests: [{ ...validItem, headers: { 'x-ms-blob-type': 'BlockBlob' } }],
+    });
+    const result = await requestUploadUrls(baseParams());
+    expect(result.uploadRequests[0].headers).toEqual({ 'x-ms-blob-type': 'BlockBlob' });
+  });
+
+  it('accepts the numeric updateId the Go server actually marshals', async () => {
+    // services.RequestUploadURLResponse.UpdateID is an int64, so the wire value
+    // is a JSON number. Normalized to a string for the markUpdateAsUploaded query.
+    respondWith({ updateId: 1753800000000, uploadRequests: [validItem] });
+    const result = await requestUploadUrls(baseParams());
+    expect(result.updateId).toBe('1753800000000');
+  });
+
+  it('still accepts a string updateId', async () => {
+    respondWith({ updateId: '1753800000000', uploadRequests: [validItem] });
+    const result = await requestUploadUrls(baseParams());
+    expect(result.updateId).toBe('1753800000000');
+  });
+
+  it('accepts an empty header value', async () => {
+    // Joi.string() rejects '' by default, which would abort a publish over a
+    // header the CLI only ever forwards.
+    respondWith({ updateId: '1', uploadRequests: [{ ...validItem, headers: { 'x-a': '' } }] });
+    await expect(requestUploadUrls(baseParams())).resolves.toBeDefined();
+  });
+
+  it('tolerates unknown fields so a newer server does not break the CLI', async () => {
+    // Both levels: a new top-level field and a new field inside an entry.
+    respondWith({
+      updateId: '1',
+      uploadRequests: [{ ...validItem, expiresAt: '2026-01-01' }],
+      somethingNew: true,
+    });
+    await expect(requestUploadUrls(baseParams())).resolves.toBeDefined();
+  });
+
+  it.each([
+    ['a missing updateId', { uploadRequests: [] }],
+    ['a missing uploadRequests', { updateId: '1' }],
+    ['an updateId that is neither string nor number', { updateId: {}, uploadRequests: [] }],
+    ['uploadRequests that is not an array', { updateId: '1', uploadRequests: {} }],
+    ['an entry that is not an object', { updateId: '1', uploadRequests: ['bundle.js'] }],
+    [
+      'a non-string filePath',
+      { updateId: '1', uploadRequests: [{ ...validItem, filePath: ['bundle.js'] }] },
+    ],
+    [
+      'a missing requestUploadUrl',
+      { updateId: '1', uploadRequests: [{ fileName: 'bundle.js', filePath: 'bundle.js' }] },
+    ],
+    [
+      'a non-http upload URL',
+      { updateId: '1', uploadRequests: [{ ...validItem, requestUploadUrl: 'file:///etc/passwd' }] },
+    ],
+    [
+      'headers that are not strings',
+      { updateId: '1', uploadRequests: [{ ...validItem, headers: { 'x-a': { nested: 1 } } }] },
+    ],
+    [
+      'a header value smuggling a CRLF',
+      {
+        updateId: '1',
+        uploadRequests: [{ ...validItem, headers: { 'x-a': 'v\r\nAuthorization: Bearer x' } }],
+      },
+    ],
+    [
+      'a header name that is not a token',
+      { updateId: '1', uploadRequests: [{ ...validItem, headers: { 'x a': 'v' } }] },
+    ],
+  ])('rejects %s', async (_label, payload) => {
+    respondWith(payload);
+    await expect(requestUploadUrls(baseParams())).rejects.toThrow(/invalid upload response/);
   });
 });
 

--- a/apps/eoas/src/lib/__tests__/uploadRequests.test.ts
+++ b/apps/eoas/src/lib/__tests__/uploadRequests.test.ts
@@ -1,0 +1,298 @@
+/* eslint-disable node/no-sync */
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { AssetToUpload, RequestUploadUrlItem, resolveUploadRequests } from '../assets';
+
+// These cover what a hostile or compromised update server can put in its
+// requestUploadUrl answer. Everything here must be rejected before the CLI opens
+// a single file: the payoff for the attacker is reading arbitrary files off a
+// developer or CI machine and having them PUT to a URL it controls.
+
+let exportDir: string;
+let outsideDir: string;
+
+const manifest: AssetToUpload[] = [
+  { path: 'metadata.json', name: 'metadata.json', ext: 'json' },
+  { path: 'bundles/ios-abc.hbc', name: 'ios-abc.hbc', ext: 'hbc' },
+];
+
+function item(overrides: Partial<RequestUploadUrlItem> = {}): RequestUploadUrlItem {
+  return {
+    requestUploadUrl: 'https://storage.example.com/upload/metadata.json',
+    fileName: 'metadata.json',
+    filePath: 'metadata.json',
+    ...overrides,
+  };
+}
+
+function resolve(uploadRequests: RequestUploadUrlItem[]): Promise<unknown> {
+  return resolveUploadRequests({ uploadRequests, exportDir, manifest });
+}
+
+beforeEach(() => {
+  exportDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eoas-export-'));
+  outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eoas-secrets-'));
+  fs.writeFileSync(path.join(exportDir, 'metadata.json'), '{}');
+  fs.ensureDirSync(path.join(exportDir, 'bundles'));
+  fs.writeFileSync(path.join(exportDir, 'bundles', 'ios-abc.hbc'), 'bundle');
+  // Present in the export directory but never exported by the CLI.
+  fs.writeFileSync(path.join(exportDir, '.env'), 'EXPO_TOKEN=secret');
+  fs.writeFileSync(path.join(outsideDir, 'id_rsa'), 'private key');
+});
+
+afterEach(() => {
+  fs.removeSync(exportDir);
+  fs.removeSync(outsideDir);
+});
+
+describe('resolveUploadRequests on a well-behaved server response', () => {
+  it('resolves each request to a canonical path inside the export directory', async () => {
+    const resolved = await resolveUploadRequests({
+      uploadRequests: [
+        item(),
+        item({
+          filePath: 'bundles/ios-abc.hbc',
+          fileName: 'ios-abc.hbc',
+          requestUploadUrl: 'https://storage.example.com/upload/ios-abc.hbc',
+        }),
+      ],
+      exportDir,
+      manifest,
+    });
+    expect(resolved.map(r => r.absolutePath)).toEqual([
+      path.join(fs.realpathSync(exportDir), 'metadata.json'),
+      path.join(fs.realpathSync(exportDir), 'bundles', 'ios-abc.hbc'),
+    ]);
+    expect(resolved[1].manifestEntry.ext).toBe('hbc');
+  });
+
+  it('accepts an empty response', async () => {
+    await expect(resolve([])).resolves.toEqual([]);
+  });
+});
+
+describe('resolveUploadRequests against forged file paths', () => {
+  it('rejects traversal out of the export directory', async () => {
+    const filePath = path.join('..', path.basename(outsideDir), 'id_rsa');
+    await expect(resolve([item({ filePath, fileName: 'id_rsa' })])).rejects.toThrow(
+      /requested a path outside the export directory/
+    );
+  });
+
+  it('rejects traversal that loops back into the export directory', async () => {
+    // Lands on a real, readable file, so only the '..' rejection stops it.
+    await expect(
+      resolve([item({ filePath: 'bundles/../metadata.json', fileName: 'metadata.json' })])
+    ).rejects.toThrow(/requested a path outside the export directory/);
+  });
+
+  it('rejects absolute paths', async () => {
+    await expect(
+      resolve([item({ filePath: path.join(outsideDir, 'id_rsa'), fileName: 'id_rsa' })])
+    ).rejects.toThrow(/absolute path/);
+  });
+
+  it('rejects windows-style absolute paths', async () => {
+    await expect(
+      resolve([item({ filePath: 'C:\\Users\\ci\\.npmrc', fileName: '.npmrc' })])
+    ).rejects.toThrow(/absolute path/);
+  });
+
+  it('rejects backslash traversal', async () => {
+    await expect(
+      resolve([item({ filePath: '..\\..\\.npmrc', fileName: '.npmrc' })])
+    ).rejects.toThrow(/requested a path outside the export directory/);
+  });
+
+  it('matches the manifest by path, never by file name', async () => {
+    // 'ios-abc.hbc' is the *name* of a manifest entry whose path is
+    // 'bundles/ios-abc.hbc'. Matching on the name would resolve it at the
+    // export root, which is not where the CLI exported it.
+    await expect(
+      resolve([item({ filePath: 'ios-abc.hbc', fileName: 'ios-abc.hbc' })])
+    ).rejects.toThrow(/not part of this export/);
+  });
+
+  it('rejects a file that exists in the export directory but was never exported', async () => {
+    await expect(resolve([item({ filePath: '.env', fileName: '.env' })])).rejects.toThrow(
+      /not part of this export/
+    );
+  });
+
+  it('rejects a path with a NUL byte', async () => {
+    await expect(resolve([item({ filePath: 'metadata.json\0.png' })])).rejects.toThrow(
+      /empty or malformed/
+    );
+  });
+
+  it('rejects an empty path', async () => {
+    await expect(resolve([item({ filePath: '' })])).rejects.toThrow(/empty or malformed/);
+  });
+
+  it('rejects a file name that does not match the file path', async () => {
+    await expect(resolve([item({ fileName: '../../evil.json' })])).rejects.toThrow(
+      /mismatched name/
+    );
+  });
+
+  it('rejects the same file requested twice in one response', async () => {
+    await expect(resolve([item(), item()])).rejects.toThrow(/more than once/);
+  });
+
+  it('allows the same file across two responses, as --platform all produces', async () => {
+    // publish.ts asks for upload URLs once per runtime version, and each answer
+    // names the very same local files. Deduplication is per response only.
+    await expect(resolve([item()])).resolves.toHaveLength(1);
+    await expect(
+      resolve([item({ requestUploadUrl: 'https://storage.example.com/android/metadata.json' })])
+    ).resolves.toHaveLength(1);
+  });
+
+  it('rejects a manifest entry that is missing on disk', async () => {
+    fs.removeSync(path.join(exportDir, 'metadata.json'));
+    await expect(resolve([item()])).rejects.toThrow(/not found in the export directory/);
+  });
+});
+
+describe('resolveUploadRequests against symlinks', () => {
+  it('rejects a symlinked file pointing outside the export directory', async () => {
+    fs.removeSync(path.join(exportDir, 'metadata.json'));
+    fs.symlinkSync(path.join(outsideDir, 'id_rsa'), path.join(exportDir, 'metadata.json'));
+    await expect(resolve([item()])).rejects.toThrow(/symlink/);
+  });
+
+  it('rejects a file reached through a symlinked parent directory', async () => {
+    fs.removeSync(path.join(exportDir, 'bundles'));
+    fs.symlinkSync(outsideDir, path.join(exportDir, 'bundles'));
+    fs.writeFileSync(path.join(outsideDir, 'ios-abc.hbc'), 'stolen');
+    await expect(
+      resolve([item({ filePath: 'bundles/ios-abc.hbc', fileName: 'ios-abc.hbc' })])
+    ).rejects.toThrow(/symlink/);
+  });
+
+  it('rejects a symlink that stays inside the export directory', async () => {
+    fs.removeSync(path.join(exportDir, 'metadata.json'));
+    fs.symlinkSync(path.join(exportDir, '.env'), path.join(exportDir, 'metadata.json'));
+    await expect(resolve([item()])).rejects.toThrow(/symlink/);
+  });
+
+  it('rejects a directory in place of a file', async () => {
+    fs.removeSync(path.join(exportDir, 'metadata.json'));
+    fs.ensureDirSync(path.join(exportDir, 'metadata.json'));
+    await expect(resolve([item()])).rejects.toThrow(/not a regular file/);
+  });
+});
+
+describe('resolveUploadRequests transport requirements', () => {
+  it('rejects a plain HTTP upload URL on a remote host', async () => {
+    await expect(
+      resolve([item({ requestUploadUrl: 'http://attacker.tld/collect' })])
+    ).rejects.toThrow(/only be sent over HTTPS/);
+  });
+
+  it('allows plain HTTP on loopback addresses', async () => {
+    for (const requestUploadUrl of [
+      'http://localhost:3000/app/uploadLocalFile',
+      'http://127.0.0.1:3000/app/uploadLocalFile',
+      'http://[::1]:3000/app/uploadLocalFile',
+      // Node's URL normalizes these to 127.0.0.1 before the host is inspected.
+      'http://127.1/app/uploadLocalFile',
+      'http://2130706433/app/uploadLocalFile',
+    ]) {
+      await expect(resolve([item({ requestUploadUrl })])).resolves.toHaveLength(1);
+    }
+  });
+
+  it('does not let a remote host masquerade as loopback', async () => {
+    for (const requestUploadUrl of [
+      // *.localhost is deliberately not exempt: a resolver may answer it from DNS.
+      'http://evil.localhost/collect',
+      'http://attacker.tld.localhost/collect',
+      // The 127.x pattern is anchored at both ends.
+      'http://127.0.0.1.evil.tld/collect',
+      'http://evil127.0.0.1.tld/collect',
+    ]) {
+      await expect(resolve([item({ requestUploadUrl })])).rejects.toThrow(
+        /only be sent over HTTPS/
+      );
+    }
+  });
+
+  it.each(['1', 'true', 'TRUE', 'True'])('honours the opt-in spelled %s', async spelling => {
+    process.env.EOAS_ALLOW_INSECURE_UPLOAD_URLS = spelling;
+    try {
+      await expect(
+        resolve([item({ requestUploadUrl: 'http://minio:9000/updates/metadata.json' })])
+      ).resolves.toHaveLength(1);
+    } finally {
+      delete process.env.EOAS_ALLOW_INSECURE_UPLOAD_URLS;
+    }
+  });
+
+  it.each(['0', 'false', 'yes', ''])('ignores the opt-in spelled %s', async spelling => {
+    process.env.EOAS_ALLOW_INSECURE_UPLOAD_URLS = spelling;
+    try {
+      await expect(
+        resolve([item({ requestUploadUrl: 'http://minio:9000/updates/metadata.json' })])
+      ).rejects.toThrow(/only be sent over HTTPS/);
+    } finally {
+      delete process.env.EOAS_ALLOW_INSECURE_UPLOAD_URLS;
+    }
+  });
+
+  it('allows plain HTTP when the operator opted in, and never lifts a path check', async () => {
+    // MinIO or an S3-compatible endpoint on AWS_BASE_ENDPOINT, or a local bucket
+    // on an internal BASE_URL, both legitimately serve http.
+    process.env.EOAS_ALLOW_INSECURE_UPLOAD_URLS = '1';
+    try {
+      await expect(
+        resolve([item({ requestUploadUrl: 'http://minio:9000/updates/metadata.json' })])
+      ).resolves.toHaveLength(1);
+      await expect(
+        resolve([
+          item({
+            requestUploadUrl: 'http://minio:9000/updates/.env',
+            filePath: '.env',
+            fileName: '.env',
+          }),
+        ])
+      ).rejects.toThrow(/not part of this export/);
+    } finally {
+      delete process.env.EOAS_ALLOW_INSECURE_UPLOAD_URLS;
+    }
+  });
+
+  it('rejects non-http schemes even when the opt-in is set', async () => {
+    process.env.EOAS_ALLOW_INSECURE_UPLOAD_URLS = '1';
+    try {
+      await expect(resolve([item({ requestUploadUrl: 'file:///etc/passwd' })])).rejects.toThrow(
+        /only be sent over HTTPS/
+      );
+    } finally {
+      delete process.env.EOAS_ALLOW_INSECURE_UPLOAD_URLS;
+    }
+  });
+
+  it('rejects non-http schemes', async () => {
+    await expect(resolve([item({ requestUploadUrl: 'file:///etc/passwd' })])).rejects.toThrow(
+      /only be sent over HTTPS/
+    );
+  });
+
+  it('rejects an unparseable upload URL', async () => {
+    await expect(resolve([item({ requestUploadUrl: 'not a url' })])).rejects.toThrow(
+      /unusable upload URL/
+    );
+  });
+
+  it('rejects the whole response when a single entry is bad', async () => {
+    // That no upload happens either is proven at the command level, in
+    // src/commands/__tests__/publish.test.ts.
+    await expect(resolve([item(), item({ filePath: '.env', fileName: '.env' })])).rejects.toThrow(
+      /not part of this export/
+    );
+  });
+});

--- a/apps/eoas/src/lib/assets.ts
+++ b/apps/eoas/src/lib/assets.ts
@@ -33,7 +33,7 @@ type Metadata = {
   };
 };
 
-interface AssetToUpload {
+export interface AssetToUpload {
   path: string;
   name: string;
   ext: string;
@@ -101,6 +101,195 @@ export interface RequestUploadUrlItem {
   headers?: Record<string, string>;
 }
 
+export interface RequestUploadUrlsResponse {
+  uploadRequests: RequestUploadUrlItem[];
+  updateId: string;
+  rolloutPercentage?: number;
+  publishGroup?: string;
+}
+
+// The server dictates which local files the CLI opens and where their bytes are
+// sent, so its answer is untrusted input: a hostile or compromised server that
+// gets a forged filePath past us reads any file it wants off the developer or CI
+// machine. Every field is typed here, and the paths are checked against the
+// export manifest in resolveUploadRequests before anything is opened.
+const uploadRequestHeadersJoi = Joi.object()
+  .pattern(
+    // RFC 7230 header field-name, and a value that cannot smuggle a CRLF.
+    /^[A-Za-z0-9!#$%&'*+\-.^_`|~]+$/,
+    Joi.string()
+      .allow('')
+      .pattern(/^[^\r\n]*$/)
+  )
+  .optional();
+
+const uploadRequestJoi = Joi.object({
+  requestUploadUrl: Joi.string()
+    .uri({ scheme: ['http', 'https'] })
+    .required(),
+  fileName: Joi.string().required(),
+  filePath: Joi.string().required(),
+  headers: uploadRequestHeadersJoi,
+  // Unknown keys are tolerated so a newer server can add fields without
+  // breaking older CLIs; nothing reads them.
+}).unknown(true);
+
+export const RequestUploadUrlsResponseJoi = Joi.object({
+  // The server marshals updateId from an int64, so it arrives as a JSON number;
+  // older or third-party servers may send it as a string. Normalized to a string
+  // below, which is what the markUpdateAsUploaded query parameter needs.
+  updateId: Joi.alternatives().try(Joi.string(), Joi.number()).required(),
+  uploadRequests: Joi.array().items(uploadRequestJoi).required(),
+  rolloutPercentage: Joi.number().optional(),
+  publishGroup: Joi.string().optional(),
+})
+  .required()
+  .unknown(true);
+
+function isLoopbackHost(hostname: string): boolean {
+  const host = hostname.replace(/^\[/, '').replace(/\]$/, '').toLowerCase();
+  // Deliberately does not accept *.localhost: resolvers are free to answer it
+  // from DNS, which would let a remote host claim the plain-HTTP exemption.
+  return host === 'localhost' || host === '::1' || /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host);
+}
+
+// Escape hatch for the deployments that legitimately serve upload URLs over
+// plain HTTP on a non-loopback host: a MinIO or S3-compatible endpoint set
+// through AWS_BASE_ENDPOINT, or a local bucket whose BASE_URL is an internal
+// hostname. It only lifts the transport requirement, never a path check.
+const INSECURE_UPLOAD_URLS_ENV = 'EOAS_ALLOW_INSECURE_UPLOAD_URLS';
+
+function insecureUploadUrlsAllowed(): boolean {
+  const value = process.env[INSECURE_UPLOAD_URLS_ENV];
+  return value === '1' || value?.toLowerCase() === 'true';
+}
+
+function assertSafeUploadUrl(requestUploadUrl: string): void {
+  let url: URL;
+  try {
+    url = new URL(requestUploadUrl);
+  } catch {
+    throw new Error(`The server returned an unusable upload URL: ${requestUploadUrl}`);
+  }
+  if (url.protocol === 'https:') {
+    return;
+  }
+  if (url.protocol === 'http:' && isLoopbackHost(url.hostname)) {
+    return;
+  }
+  if (url.protocol === 'http:' && insecureUploadUrlsAllowed()) {
+    Log.warn(
+      `Uploading to ${url.origin} over plain HTTP because ${INSECURE_UPLOAD_URLS_ENV} is set. Your update artifacts travel unencrypted.`
+    );
+    return;
+  }
+  throw new Error(
+    `Refusing to upload to ${url.origin}: update artifacts may only be sent over HTTPS (plain HTTP is allowed for loopback addresses only). Set ${INSECURE_UPLOAD_URLS_ENV}=1 if your storage endpoint is intentionally served over HTTP.`
+  );
+}
+
+function assertRelativePathShape(filePath: string): void {
+  if (!filePath || filePath.includes('\0')) {
+    throw new Error('The server returned an empty or malformed file path.');
+  }
+  // win32.isAbsolute also covers the posix cases, drive letters and UNC paths.
+  if (path.isAbsolute(filePath) || path.win32.isAbsolute(filePath)) {
+    throw new Error(`Refusing to upload the absolute path "${filePath}" requested by the server.`);
+  }
+  if (filePath.split(/[/\\]/).some(segment => segment === '..')) {
+    throw new Error(
+      `Refusing to upload "${filePath}": the server requested a path outside the export directory.`
+    );
+  }
+}
+
+export interface ResolvedUploadRequest {
+  item: RequestUploadUrlItem;
+  // Canonical, containment-checked absolute path. The only path the caller may open.
+  absolutePath: string;
+  manifestEntry: AssetToUpload;
+}
+
+/**
+ * Maps every upload request of ONE server response onto a file the CLI itself
+ * exported, and throws on anything it cannot account for. This runs to
+ * completion before the first byte is read: a single bad entry aborts the whole
+ * publish rather than uploading the files that happened to be fine.
+ *
+ * Call it once per response: `eoas publish --platform all` requests upload URLs
+ * per runtime version, and every response legitimately names the same files.
+ */
+export async function resolveUploadRequests({
+  uploadRequests,
+  exportDir,
+  manifest,
+}: {
+  uploadRequests: RequestUploadUrlItem[];
+  exportDir: string;
+  manifest: AssetToUpload[];
+}): Promise<ResolvedUploadRequest[]> {
+  const manifestByPath = new Map(manifest.map(entry => [entry.path, entry]));
+  // Canonical root, so a symlinked export directory (or /tmp on macOS) does not
+  // make every containment check fail below.
+  let exportRoot: string;
+  try {
+    exportRoot = await fs.realpath(exportDir);
+  } catch {
+    throw new Error(`Export directory ${exportDir} could not be resolved.`);
+  }
+
+  const seen = new Set<string>();
+  const resolved: ResolvedUploadRequest[] = [];
+  for (const item of uploadRequests) {
+    assertSafeUploadUrl(item.requestUploadUrl);
+    assertRelativePathShape(item.filePath);
+
+    const manifestEntry = manifestByPath.get(item.filePath);
+    if (!manifestEntry) {
+      throw new Error(
+        `Refusing to upload "${item.filePath}": the server asked for a file that is not part of this export.`
+      );
+    }
+    if (item.fileName !== path.basename(item.filePath)) {
+      throw new Error(
+        `Refusing to upload "${item.filePath}": the server returned the mismatched name "${item.fileName}".`
+      );
+    }
+    if (seen.has(item.filePath)) {
+      throw new Error(`The server requested "${item.filePath}" more than once.`);
+    }
+    seen.add(item.filePath);
+
+    const absolutePath = path.resolve(exportRoot, item.filePath);
+    // Unreachable on POSIX: a path with no '..' segment and no leading separator
+    // cannot resolve out of the root. Kept for the Windows drive-relative case
+    // ("C:file" when the export root sits on another drive) and as a backstop if
+    // the checks above are ever relaxed.
+    if (absolutePath !== exportRoot && !absolutePath.startsWith(exportRoot + path.sep)) {
+      throw new Error(
+        `Refusing to upload "${item.filePath}": it resolves outside the export directory.`
+      );
+    }
+    let realPath: string;
+    try {
+      realPath = await fs.realpath(absolutePath);
+    } catch {
+      throw new Error(`File ${item.filePath} not found in the export directory.`);
+    }
+    // The root is already canonical, so any difference here means a symlink was
+    // traversed, either as the file itself or as one of its parent directories.
+    if (realPath !== absolutePath) {
+      throw new Error(`Refusing to upload "${item.filePath}": it is or goes through a symlink.`);
+    }
+    if (!(await fs.lstat(absolutePath)).isFile()) {
+      throw new Error(`Refusing to upload "${item.filePath}": it is not a regular file.`);
+    }
+
+    resolved.push({ item, absolutePath, manifestEntry });
+  }
+  return resolved;
+}
+
 export function activeRolloutConflictMessage(branch: string): string {
   return `A progressive rollout is already active for branch "${branch}" on this runtime version. End or revert it from the dashboard before publishing a new update.`;
 }
@@ -130,12 +319,7 @@ export async function requestUploadUrls({
   // servers echo it back; a missing echo means the rows were not grouped.
   publishGroup?: string;
   branch: string;
-}): Promise<{
-  uploadRequests: RequestUploadUrlItem[];
-  updateId: string;
-  rolloutPercentage?: number;
-  publishGroup?: string;
-}> {
+}): Promise<RequestUploadUrlsResponse> {
   const uploadUrl = new URL(requestUploadUrl);
   uploadUrl.searchParams.set('runtimeVersion', runtimeVersion);
   uploadUrl.searchParams.set('platform', platform);
@@ -168,13 +352,20 @@ export async function requestUploadUrls({
     throw new Error(`Failed to request upload URL: ${text}`);
   }
   const json = await response.json();
+  // Joi's sanitized value, not the raw payload: it is the object the schema
+  // actually vouched for, with inherited keys such as __proto__ dropped.
+  const { error, value } = RequestUploadUrlsResponseJoi.validate(json);
+  if (error) {
+    throw new Error(`The server returned an invalid upload response: ${error.message}`);
+  }
+  const validated: RequestUploadUrlsResponse = { ...value, updateId: String(value.updateId) };
   // An old server silently ignores unknown query params, so a missing echo means
   // the rollout was not applied even though the flag was set. Abort before any
   // file is uploaded: continuing would finalize a full 100% publish.
-  if (rolloutPercentage !== undefined && json.rolloutPercentage === undefined) {
+  if (rolloutPercentage !== undefined && validated.rolloutPercentage === undefined) {
     throw new Error(
       'The server ignored --rollout-percentage and would publish to 100% of devices. Update the server to a version that supports progressive rollouts, or publish without --rollout-percentage.'
     );
   }
-  return json;
+  return validated;
 }


### PR DESCRIPTION
- Implemented `resolveUploadRequests` function to validate upload requests against the export manifest, ensuring security against forged file paths and unauthorized access.
- Added Joi validation schema for `RequestUploadUrlsResponse` to enforce structure and data integrity.
- Introduced comprehensive tests for `resolveUploadRequests` to cover various edge cases, including path traversal, symlink handling, and HTTP/HTTPS requirements.
- Created end-to-end tests for the `Publish` command to ensure no files are uploaded when the server response is compromised or invalid.
- Updated existing tests to accommodate new validation logic and ensure robust error handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened publishing safeguards against malicious or invalid upload instructions.
  * Prevented path traversal, unauthorized file uploads, symlink abuse, duplicate uploads, and insecure redirects.
  * Enforced secure upload URLs by default, while supporting approved local development scenarios.
  * Improved validation of upload responses, headers, credentials, and update identifiers.
  * Ensured failed uploads stop publishing immediately with clearer server error details.

* **Tests**
  * Added comprehensive coverage for secure and successful publishing workflows, including file uploads and update completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->